### PR TITLE
(autohotkey.portable) Consider new filenames for v2

### DIFF
--- a/automatic/autohotkey.portable/tools/chocolateyInstall.ps1
+++ b/automatic/autohotkey.portable/tools/chocolateyInstall.ps1
@@ -18,9 +18,13 @@ Remove-Item "$toolsPath/AutoHotkeyA32.exe" -ea 0
 if ((Get-OSArchitectureWidth 64) -and ($Env:chocolateyForceX86 -ne 'true')) {
     Write-Verbose "Removing UNICODE-32 version"
     Remove-Item "$toolsPath/AutoHotkeyU32.exe" -ea 0
-    Move-Item "$toolsPath/AutoHotkeyU64.exe" "$toolsPath/AutoHotkey.exe" -Force
+    Move-Item "$toolsPath/AutoHotkeyU64.exe" "$toolsPath/AutoHotkey.exe" -Force -ea 0
+    Remove-Item "$toolsPath/AutoHotkey32.exe" -ea 0
+    Move-Item "$toolsPath/AutoHotkey64.exe" "$toolsPath/AutoHotkey.exe" -Force -ea 0
 } else {
     Write-Verbose "Removing UNICODE-64 version"
     Remove-Item "$toolsPath/AutoHotkeyU64.exe" -ea 0
-    Move-Item "$toolsPath/AutoHotkeyU32.exe" "$toolsPath/AutoHotkey.exe" -Force
+    Move-Item "$toolsPath/AutoHotkeyU32.exe" "$toolsPath/AutoHotkey.exe" -Force -ea 0
+    Remove-Item "$toolsPath/AutoHotkey64.exe" -ea 0
+    Move-Item "$toolsPath/AutoHotkey32.exe" "$toolsPath/AutoHotkey.exe" -Force -ea 0
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
In AutoHotkey v2.0-a135-b66a8739, the executable files "AutoHotkeyU32.exe" and "AutoHotkeyU64.exe" have been renamed to "AutoHotkey32.exe" and "AutoHotkey64.exe". This commit ensures a flawless installation and usage.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

fixes #1663 
