### PR TITLE
(git) Add parameters

### DIFF
--- a/automatic/git.install/README.md
+++ b/automatic/git.install/README.md
@@ -17,10 +17,22 @@ Git for Windows focuses on offering a lightweight, native set of tools that brin
 - `/WindowsTerminal` - Makes `vim` use the regular Windows terminal instead of MinTTY terminal.
 - `/NoShellIntegration` - Disables open GUI and open shell integration ( _"Git GUI Here"_ and _"Git Bash Here"_ entries in context menus).
 - `/NoGuiHereIntegration` - Disables open GUI shell integration ( _"Git GUI Here"_ entry in context menus).
-- `/NoShellHereIntegration` - Disables open git bash shell integration ( _"Git Bash Here"_ entry in context menus)
+- `/NoShellHereIntegration` - Disables open git bash shell integration ( _"Git Bash Here"_ entry in context menus).
 - `/NoCredentialManager` - Disable _Git Credential Manager_ by adding `$Env:GCM_VALIDATE='false'` user environment variable.
 - `/NoGitLfs` - Disable Git LFS installation.
 - `/SChannel` - Configure Git to use the Windows native SSL/TLS implementation (SChannel) instead of OpenSSL. This aligns Git HTTPS behavior with other Windows applications and system components and increases manageability in enterprise environments.
+- `/NoOpenSSH` - Git will not install its own OpenSSH (and related) binaries but use them as found on the PATH.
+- `/WindowsTerminalProfile` - Add a Git Bash Profile to Windows Terminal.
+- `/Symlinks` - Enable symbolic links (requires the SeCreateSymbolicLink permission). Existing repositories are unaffected by this setting.
+- `/DefaultBranchName:default_branch_name` - Define the default branch name.
+- `/Editor:Nano|VIM|Notepad++|VisualStudioCode|VisualStudioCodeInsiders|SublimeText|Atom|VSCodium|Notepad|Wordpad|Custom editor path` - Default editor used by Git. The selected editor needs to be available on the machine (unless it is part of git for windows) for this to work.
+
+### Experimental parameters
+
+Warning: the following parameters are experimental in the git installer and could stop working at any point.
+
+- `/PseudoConsoleSupport` - Enable experimental support for pseudo consoles. Allows running native console programs like Node or Python in a Git Bash window without using winpty, but it still has known bugs.
+- `/FSMonitor` - Enable experimental built-in file system monitor. Automatically run a built-in file system watcher, to speed up common operations such as `git status`, `git add`, `git commit`, etc in worktrees containing many files.
 
 Example: `choco install git.install --params "/GitAndUnixToolsOnPath /NoGitLfs /SChannel /NoAutoCrlf"`
 

--- a/automatic/git.install/git.install.nuspec
+++ b/automatic/git.install/git.install.nuspec
@@ -25,10 +25,17 @@ Git for Windows focuses on offering a lightweight, native set of tools that brin
 - `/WindowsTerminal` - Makes `vim` use the regular Windows terminal instead of MinTTY terminal.
 - `/NoShellIntegration` - Disables open GUI and open shell integration ( _"Git GUI Here"_ and _"Git Bash Here"_ entries in context menus).
 - `/NoGuiHereIntegration` - Disables open GUI shell integration ( _"Git GUI Here"_ entry in context menus).
-- `/NoShellHereIntegration` - Disables open git bash shell integration ( _"Git Bash Here"_ entry in context menus)
+- `/NoShellHereIntegration` - Disables open git bash shell integration ( _"Git Bash Here"_ entry in context menus).
 - `/NoCredentialManager` - Disable _Git Credential Manager_ by adding `$Env:GCM_VALIDATE='false'` user environment variable.
 - `/NoGitLfs` - Disable Git LFS installation.
 - `/SChannel` - Configure Git to use the Windows native SSL/TLS implementation (SChannel) instead of OpenSSL. This aligns Git HTTPS behavior with other Windows applications and system components and increases manageability in enterprise environments.
+- `/NoOpenSSH` - Git will not install its own OpenSSH (and related) binaries but use them as found on the PATH.
+- `/WindowsTerminalProfile` - Add a Git Bash Profile to Windows Terminal.
+- `/Symlinks` - Enable symbolic links (requires the SeCreateSymbolicLink permission). Existing repositories are unaffected by this setting.
+- `/DefaultBranchName:default_branch_name` - Define the default branch name.
+- `/Editor:Nano|VIM|Notepad++|VisualStudioCode|VisualStudioCodeInsiders|SublimeText|Atom|VSCodium|Notepad|Wordpad|Custom editor path` - Default editor used by Git. The selected editor needs to be available on the machine (unless it is part of git for windows) for this to work.
+- `/PseudoConsoleSupport` - Enable experimental support for pseudo consoles. Allows running native console programs like Node or Python in a Git Bash window without using winpty, but it still has known bugs.
+- `/FSMonitor` - Enable experimental built-in file system monitor. Automatically run a built-in file system watcher, to speed up common operations such as `git status`, `git add`, `git commit`, etc in worktrees containing many files.
 
 Example: `choco install git.install --params "/GitAndUnixToolsOnPath /NoGitLfs /SChannel /NoAutoCrlf"`
 
@@ -49,7 +56,6 @@ Example: `choco install git.install --params "/GitAndUnixToolsOnPath /NoGitLfs /
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@10a8d98b2f320b565fa5349a4352e79666db71ff/icons/git.svg</iconUrl>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="chocolatey" version="0.10.7" />      
     </dependencies>
   </metadata>
   <files>

--- a/automatic/git.install/tools/chocolateyInstall.ps1
+++ b/automatic/git.install/tools/chocolateyInstall.ps1
@@ -4,19 +4,21 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 . $toolsPath\helpers.ps1
 
 $pp = Get-PackageParameters
-Set-InstallerRegistrySettings $pp
 
 Stop-GitSSHAgent
 
 $fileName32 = 'Git-2.34.0-32-bit.exe'
 $fileName64 = 'Git-2.34.0-64-bit.exe'
+$silentArgs = "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/NOCANCEL", "/SP-", "/LOG", (Get-InstallComponents $pp)
+$silentArgs += Get-InstallOptions $pp
+
 $packageArgs = @{
     PackageName    = 'git.install'
     FileType       = 'exe'
     SoftwareName   = 'Git version *'
     File           = Get-Item $toolsPath\$fileName32
     File64         = Get-Item $toolsPath\$fileName64
-    SilentArgs     = "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/NOCANCEL", "/SP-", "/LOG", (Get-InstallComponents $pp)
+    SilentArgs     = $silentArgs
 }
 Install-ChocolateyInstallPackage @packageArgs
 Get-ChildItem $toolsPath\$fileName32, $toolsPath\$fileName64 | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" '' } }

--- a/automatic/git.install/tools/helpers.ps1
+++ b/automatic/git.install/tools/helpers.ps1
@@ -1,11 +1,30 @@
 ﻿function Get-InstallOptions( [HashTable]$pp )
 {
+    # Options are defined in this [file](https://github.com/git-for-windows/build-extra/blob/main/installer/install.iss)
+    # You can see [here](https://github.com/git-for-windows/build-extra/blob/4490974c504f1bbc07327b885ea3607ad019f736/installer/install.iss#L1140) how they are interpreted, it is all parameters passed in the ReplayChoice method without spaces.
     $options = @()
     if ($pp.GitOnlyOnPath)             { $options += "/o:PathOption=Cmd" }
     elseif ($pp.GitAndUnixToolsOnPath) { $options += "/o:PathOption=CmdTools" }
     if ($pp.WindowsTerminal)           { $options += "/o:BashTerminalOption=ConHost" }
     if ($pp.NoAutoCrlf)                { $options += "/o:CRLFOption=CRLFCommitAsIs" }
     if ($pp.SChannel)                  { $options += "/o:CURLOption=WinSSL" }
+    if ($pp.NoOpenSSH)                 { $options += "/o:SSHOption=ExternalOpenSSH" }
+    if ($pp.Symlinks)                  { $options += "/o:EnableSymlinks=Enabled" }
+    if ($pp.DefaultBranchName)         { $options += "/o:DefaultBranchOption=" + $pp.DefaultBranchName }
+    if ($pp.PseudoConsoleSupport)      { $options += "/o:EnablePseudoConsoleSupport=Enabled" }
+    if ($pp.FSMonitor)                 { $options += "/o:EnableFSMonitor=Enabled" }
+
+    if($pp.Editor)
+    {
+      if ($pp.Editor -in @('Atom', 'Nano', 'Notepad', 'Notepad++', 'SublimeText', 'VIM', 'VisualStudioCode', 'VisualStudioCodeInsiders', 'VSCodium', 'Wordpad'))
+      {
+        $options += "/o:EditorOption=" + $pp.Editor
+      }
+      else {
+        $options += "/o:EditorOption=CustomEditor"
+        $options += "/o:CustomEditorPath=" + $pp.Editor
+      }
+    }
     return $options
 }
 
@@ -19,6 +38,8 @@ function Get-InstallComponents( [HashTable]$pp )
         Write-Host "Using Git LFS"
         $res += 'gitlfs'
     }
+
+    if ($pp.WindowsTerminalProfile ) { $res += "windowsterminal" }
 
     # Make our install work properly when running under SYSTEM account (Chef Client Service, Puppet Service, etc)
     $isSystem = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).IsSystem

--- a/automatic/git.install/tools/helpers.ps1
+++ b/automatic/git.install/tools/helpers.ps1
@@ -1,27 +1,12 @@
-﻿function Get-InstallKey()
+﻿function Get-InstallOptions( [HashTable]$pp )
 {
-    $keyName = 'Git_is1'
-    $installKey = if ((Get-OSArchitectureWidth 64) -and $env:chocolateyForceX86 -eq 'true') {
-             "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$keyName"
-    } else { "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$keyName" }
-
-    $userInstallKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$keyName"
-    if (Test-Path $userInstallKey) { $installKey = $userInstallKey }
-
-    mkdir $installKey -ea 0 | Out-Null
-    $installKey
-}
-
-function Set-InstallerRegistrySettings( [HashTable]$pp )
-{
-    $installkey = Get-InstallKey
-    $ino = "Inno Setup CodeFile:"
-
-    if ($pp.GitOnlyOnPath)         { New-ItemProperty $InstallKey -Name "$ino Path Option"          -Value "Cmd"            -Force }
-    if ($pp.GitAndUnixToolsOnPath) { New-ItemProperty $InstallKey -Name "$ino Path Option"          -Value "CmdTools"       -Force }
-    if ($pp.WindowsTerminal)       { New-ItemProperty $InstallKey -Name "$ino Bash Terminal Option" -Value "ConHost"        -Force }
-    if ($pp.NoAutoCrlf)            { New-ItemProperty $InstallKey -Name "$ino CRLF Option"          -Value "CRLFCommitAsIs" -Force }
-    if ($pp.SChannel)              { New-ItemProperty $InstallKey -Name "$ino CURL Option"          -Value "WinSSL"         -Force }
+    $options = @()
+    if ($pp.GitOnlyOnPath)             { $options += "/o:PathOption=Cmd" }
+    elseif ($pp.GitAndUnixToolsOnPath) { $options += "/o:PathOption=CmdTools" }
+    if ($pp.WindowsTerminal)           { $options += "/o:BashTerminalOption=ConHost" }
+    if ($pp.NoAutoCrlf)                { $options += "/o:CRLFOption=CRLFCommitAsIs" }
+    if ($pp.SChannel)                  { $options += "/o:CURLOption=WinSSL" }
+    return $options
 }
 
 function Get-InstallComponents( [HashTable]$pp )
@@ -35,7 +20,7 @@ function Get-InstallComponents( [HashTable]$pp )
         $res += 'gitlfs'
     }
 
-    # Make our install work properly when running under SYSTEM account (Chef Cliet Service, Puppet Service, etc)
+    # Make our install work properly when running under SYSTEM account (Chef Client Service, Puppet Service, etc)
     $isSystem = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).IsSystem
     if ( !$isSystem ) { $res += "icons\quicklaunch" }
 


### PR DESCRIPTION
## Description
Replace the usage of registry keys to set the options to the `/o:<key>=<value>` parameters as indicated in [this comment](https://github.com/git-for-windows/git/issues/2912#issuecomment-734281023).
Add new parameters requested in https://github.com/chocolatey-community/chocolatey-packages/issues/1702 (Use Windows' default console window is already the option `WindowsTerminal` of the package), https://github.com/chocolatey-community/chocolatey-packages/issues/1692 and https://github.com/chocolatey-community/chocolatey-packages/issues/1452.

## Motivation and Context
This change avoids messing with the registry and provides requested parameters.
As a user of chocolatey and this package, I needed some of these options.

## How Has this Been Tested?
I have tested the new parameters of the package in a brand new w11 VM.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

