### PR TITLE
(wps-office-free) Upstream site changes required update detection changes

### DIFF
--- a/automatic/wps-office-free/update_helper.ps1
+++ b/automatic/wps-office-free/update_helper.ps1
@@ -17,18 +17,41 @@ return $PackageUrl
 
 }
 
+function Get-ResultInformation() {
+param(
+	[string]$url32,
+	[string]$file,
+	[string]$algorithm = 'sha512',
+	[switch]$info
+)
+
+  $dest = "$env:TEMP\$file"
+  Invoke-WebRequest -UseBasicParsing -Uri $url32 -OutFile $dest
+  $version = Get-Item $dest | Foreach { $_.VersionInfo.ProductVersion -replace '^(\d+(\.[\d]+){1,3}).*', '$1' }
+
+  Remove-Item -Force $dest
+  if ($info){
+    return $version
+  } else {
+    $result = @{
+    URL32          = $url32
+    Version        = $version
+    Checksum32     = (Get-FileHash $dest -Algorithm $algorithm | Foreach Hash)
+    ChecksumType32 = $algorithm
+    }
+    return $result
+  }
+}
+
 function Get-JavaSiteUpdates {
 # $wait number can be adjusted per the package needs
- param(
+param(
 	[string]$package,
-  [string]$Title,
-  [string]$padVersionUnder = '10.2.1',
-  [string]$wait = 4
+	[string]$Title,
+	[string]$padVersionUnder = '10.2.1',
+	[string]$wait = 4
  )
- 
-$OS_caption = ( Get-CimInstance win32_operatingsystem -Property Caption )
-$check = @{$true=$true;$false=$false}[ ( $OS_caption -match 'Server' ) ]
-$regex = '([\d]{0,2}[\.][\d]{0,2}[\.][\d]{0,2}[\.][\d]{0,5})'
+
 $url = Get-PackageName $package
 $ie = New-Object -comobject InternetExplorer.Application
 $ie.Navigate2($url) 
@@ -36,36 +59,20 @@ $ie.Visible = $false
 while($ie.ReadyState -ne $wait) {
  start-sleep -Seconds 20
 }
-	if ( $check ) {
-		$url32 = $ie.Document.IHTMLDocument3_getElementsByTagName("a") | % { $_.href } | where { $_ -match $regex } | select -First 1
-	} else {
-		$url32 = $ie.Document.getElementsByTagName("a") | % { $_.href } | where { $_ -match $regex } | select -First 1
-	}
-  
-    foreach ( $_ in $ie.Document.getElementsByTagName("a") ) {
-     $url = $_.href;
-         if ( $url -match $regex) {
-            $yes = $url | select -last 1
-            $version = $Matches[0]
-            $the_match = $yes -match( $rev_regex );
-            $revision = $Matches[0];
-            break;
-        }
-    }
-$ie.quit()
-if ($package -match 'wps') {
-$version = $version
-} else {
-$version = $version + $revision
-}
+# Server detection not needed anymore currently 10/27/2021
+$url = $ie.Document.getElementsByTagName("a") | % { $_.href } | select -First 2 | Select -Last 1
 
+# New Version from Get-ResultInformation due to downloading file
+$version = ((Get-ResultInformation $url -file "${package}.exe" -info) -replace(",","."))
+
+$ie.quit()
 
 	@{    
 		PackageName = $package
 		Title       = $Title
 		fileType    = 'exe'
 		Version		= Get-FixVersion $version -OnlyFixBelowVersion $padVersionUnder
-		URL32		= $yes
+		URL32		= $url
     }
 
 }


### PR DESCRIPTION
Updated the helper to find the url and version better due to upstream site changes
@gep13 @majkinetor @AdmiringWorm @pascalberger @pauby 
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
Due to website changes upstream for this package. The current update files are not working correctly.
Quoting from the current gist dated **_UTC: 2021-10-28 00:07_**
`au_GetLatest failed
Cannot validate argument on parameter 'Version'. Cannot bind argument to parameter 'version' because it is an empty string.`

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package has not been migrated from another location -->
## Original Location
- [Original Repository](add_link_to_original_repository_location)
- [Open Issues](link_to_the_generic_location_of_open_issues) *Add the different issues underneath, and tick those that are fixed in this PR*
  - [ ] Issue 1 link
  - [ ] Issue 2 Link
- [ ] *Include the link to the opened PR that removes the package from the original location*
- [ ] The [migration guidelines](https://github.com/chocolatey-community/chocolatey-packages/wiki/Package-migration-process) have been followed
