### PR TITLE
(thunderbird) Throws error if Thunderbird was running when installation was started

### DIFF
--- a/automatic/thunderbird/tools/chocolateyInstall.ps1
+++ b/automatic/thunderbird/tools/chocolateyInstall.ps1
@@ -19,9 +19,11 @@ if ($alreadyInstalled -and ($env:ChocolateyForce -ne $true)) {
 
 $tbProcess = Get-Process thunderbird -ea 0
 if ($tbProcess) {
-  Write-Host "Stopping running thunderbird process"
+  Write-Host 'Stopping running thunderbird process'
   Stop-Process $tbProcess
-  $tbProcess = $tbProcess.Path
+  # We make an assumption that the first unique item found
+  # will be have the path to the process we want to restart.
+  $tbProcess = $tbProcess.Path | Select-Object -Unique -First 1
 }
 
 $locale = 'en-US' #https://github.com/chocolatey/chocolatey-coreteampackages/issues/933


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description

During installation of Thunderbird, and if the application was running the installation would fail due to there being multiple paths being passed in when we start the process. This pull request changes that to make sure that we only pass in the first unique path that is found from the running processes.
The reason for the multiple paths is due to there being more than 1 thunderbird process when the application is running.

## Motivation and Context

To make the package work when thunderbird is running.

## How Has this Been Tested?

### Test 1

1. Create a fix version of the package by running `.\test_all.ps1 thunderbird`
2. Set up or restore a snapshot of the chocolatey test environment.
3. Install a previous version of thunderbird (must be lower than the actual version of thunderbird. `choco install thunderbird --version 91.3.1`).
4. Launch thunderbird
5. Upgrade to the fix version that was created in step 1.
6. Verify that thunderbird is closed before running the installer.
7. Verify that thunderbird is started again after the installer had ran (may take some time sometimes).

### Test 2

1. Create a fix version of the package by running `.\test_all.ps1 thunderbird` (or re-use the same one created in Test 1).
2. Set up or restore a snapshot of the chocolatey test environment.
3. Install a previous version of thunderbird (must be lower than the actual version of thunderbird. `choco install thunderbird --version 91.3.1`).
4. Upgrade to the fix version that was created in step 1.
5. Verify that no processes was stopped.
6. Verify that no new applications was started.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this repository.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

## Related issues

fixes #1747