### PR TITLE
(php) Fix php projectSourceUrl

### DIFF
--- a/automatic/php/php.nuspec
+++ b/automatic/php/php.nuspec
@@ -30,7 +30,7 @@ For example: `choco install php --package-parameters='"/ThreadSafe ""/InstallDir
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@4e147ce52b1a2a7ac522ffbce6d176f257de6ac1/icons/php.svg</iconUrl>
     <bugTrackerUrl>https://bugs.php.net/</bugTrackerUrl>
     <docsUrl>https://secure.php.net/docs.php</docsUrl>
-    <projectSourceUrl>http://git.php.net</projectSourceUrl>
+    <projectSourceUrl>https://github.com/php/php-src</projectSourceUrl>
     <dependencies>
       <dependency id="vcredist140" version="14.28.29325.2" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />


### PR DESCRIPTION
## Description
This PR fixes the `projectSourceUrl` in `php` package.

## Motivation and Context
PHP now uses the GitHub repository [`php/php-src`](https://github.com/php/php-src), and the use of [`git.php.net`](http://git.php.net) has been discontinued.

This should fix the package validation error here - https://community.chocolatey.org/packages/php/8.1.0

## How Has this Been Tested?
The updated URL in this PR is valid and is the location of PHP source.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).