### PR TITLE
Ffmpeg libraries

### DIFF
--- a/automatic/ffmpeg-full/README.md
+++ b/automatic/ffmpeg-full/README.md
@@ -10,4 +10,5 @@ Security is a high priority and code review is always done with security in mind
 ## Notes
 
 * This package is for the stable static full ffmpeg version.
-
+* For a list of libraries included, go to https://www.gyan.dev/ffmpeg/builds/#libraries
+* (provides everything included in the 'essentials' build with additional libraries)

--- a/automatic/ffmpeg-full/README.md
+++ b/automatic/ffmpeg-full/README.md
@@ -10,5 +10,7 @@ Security is a high priority and code review is always done with security in mind
 ## Notes
 
 * This package is for the stable static full ffmpeg version.
-* For a list of libraries included, go to https://www.gyan.dev/ffmpeg/builds/#libraries
-* (provides everything included in the 'essentials' build with additional libraries)
+  For a list of libraries included, go to https://www.gyan.dev/ffmpeg/builds/#libraries
+  (provides everything included in the 'essentials' build with additional libraries)
+  note that the list of libraries at the URL above will give those for the most recent version and may differ slightly from this package version
+  

--- a/automatic/ffmpeg/README.md
+++ b/automatic/ffmpeg/README.md
@@ -10,4 +10,5 @@ Security is a high priority and code review is always done with security in mind
 ## Notes
 
 * This package is for the stable static essentials ffmpeg version.
+* For a list of libraries included, go to https://www.gyan.dev/ffmpeg/builds/#libraries
 * With version 4.4 the format of the version-number changed up until the next two releases it is expected that the flag `--version` is broken

--- a/automatic/ffmpeg/README.md
+++ b/automatic/ffmpeg/README.md
@@ -10,5 +10,6 @@ Security is a high priority and code review is always done with security in mind
 ## Notes
 
 * This package is for the stable static essentials ffmpeg version.
-* For a list of libraries included, go to https://www.gyan.dev/ffmpeg/builds/#libraries
+  For a list of libraries included, go to https://www.gyan.dev/ffmpeg/builds/#libraries
+  note that the list of libraries at the URL above will give those for the most recent version and may differ slightly from this package version
 * With version 4.4 the format of the version-number changed up until the next two releases it is expected that the flag `--version` is broken


### PR DESCRIPTION
added links to descriptions of which libraries are included for ffmpeg packages

## Description
For the ffmpeg and ffmpeg-full packages, in the readme, I added links to the site that shows the libraries included for each

## Motivation and Context
* Currently, packages refer to an "essentials" and "full" build, but in the upstream project there is no such thing as either of those. Long-time users of ffmpeg could/do look at it wondering what either of them mean.
* fixes https://github.com/chocolatey-community/chocolatey-packages/issues/1765

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [X] My change requires a change to documentation (this usually means the notes in the description of a package).
- [X] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- ~[ ] The added/modified package passed install/uninstall in the chocolatey test environment.~
- [ ] The changes only affect a single package (not including meta package).