### PR TITLE
(lockhunter) Fix checksum for lockhunter

### DIFF
--- a/manual/lockhunter/tools/chocolateyInstall.ps1
+++ b/manual/lockhunter/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $packageArgs = @{
   packageName    = $env:chocolateyPackageName
   fileType       = 'EXE'
   url            = 'https://lockhunter.com/assets/exe/lockhuntersetup_3-4-3.exe'
-  checksum       = '2c0d52dca3e5ce9cfc8062cb72c7235e36ff650242fcb7d46a892d602dd3dd1'
+  checksum       = '2c0d52dca3e5ce9cfc8062cb72c7235e3c6ff650242fcb7d46a892d602dd3dd1'
   checksumType   = 'sha256'
   silentArgs     = "/VERYSILENT /NORESTART /SUPPRESSMSGBOXES /SP- /LOG=`"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).InnoInstall.log`""
   validExitCodes = @(0)


### PR DESCRIPTION
## Description
The checksum in the lockhunter package (for version 3.4.3) had a typo.

## Motivation and Context
A new Lockhunter package was released yesterday, but it fails to install with an error about the checksum not matching. On first glance, the checksum looks correct, but it's missing a `c` character in the middle 🤷🏻‍♂️

```
lockhunter v3.4.3.146 [Approved]
lockhunter package files upgrade completed. Performing other installation steps.
Downloading lockhunter
  from 'https://lockhunter.com/assets/exe/lockhuntersetup_3-4-3.exe'
Progress: 100% - Completed download of C:\Users\bdukes\AppData\Local\Temp\chocolatey\lockhunter\3.4.3.146\lockhuntersetup_3-4-3.exe (3.21 MB).
Download of lockhuntersetup_3-4-3.exe (3.21 MB) completed.
Error - hashes do not match. Actual value was '2C0D52DCA3E5CE9CFC8062CB72C7235E3C6FF650242FCB7D46A892D602DD3DD1'.
ERROR: Checksum for 'C:\Users\bdukes\AppData\Local\Temp\chocolatey\lockhunter\3.4.3.146\lockhuntersetup_3-4-3.exe' did not meet '2c0d52dca3e5ce9cfc8062cb72c7235e36ff650242fcb7d46a892d602dd3dd1' for checksum type 'sha256'. Consider passing the actual checksums through with --checksum --checksum64 once you validate the checksums are appropriate. A less secure option is to pass --ignore-checksums if necessary.
The upgrade of lockhunter was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\lockhunter\tools\chocolateyInstall.ps1'.
 See log for details.
```

## How Has this Been Tested?
I ran `choco upgrade lockhunter --checksum 2c0d52dca3e5ce9cfc8062cb72c7235e3c6ff650242f
cb7d46a892d602dd3dd1` and the package successfully upgraded:

```
lockhunter v3.4.3.146 [Approved]
lockhunter package files upgrade completed. Performing other installation steps.
File appears to be downloaded already. Verifying with package checksum to determine if it needs to be redownloaded.
Hashes match.
Hashes match.
Installing lockhunter...
lockhunter has been installed.
lockhunter installed to 'C:\Program Files\LockHunter'
lockhunter registered as lockhunter
Added C:\ProgramData\chocolatey\bin\lockhunter.exe shim pointed to 'c:\program files\lockhunter\lockhunter.exe'.
  lockhunter can be automatically uninstalled.
 The upgrade of lockhunter was successful.
  Software installed to 'C:\Program Files\LockHunter\'
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
