### PR TITLE
(maint) Add check of package description length

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,7 @@
 - [ ] My code follows the code style of this repository.
 - [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
 - [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
+- [ ] I have updated the package description and it is less than 4000 characters.
 - [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
 - [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
 - [ ] The changes only affect a single package (not including meta package).


### PR DESCRIPTION
## Description
Added a checkbox into the PR template to confirm that the package description length.

## Motivation and Context
The package description has a maximum length of 4000 chars and if it above that length the package will error when being pushed. If somebody submits a PR that updates this field, we should remind them to check it's length.

## How Has this Been Tested?
It hasn't. This is a change to markdown.

## Screenshot (if appropriate, usually isn't needed):
N/A.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).