### PR TITLE
(freecad) Clarify where to raise issues / questions

### DIFF
--- a/automatic/freecad/freecad.nuspec
+++ b/automatic/freecad/freecad.nuspec
@@ -18,10 +18,6 @@
 
 FreeCAD is based on OpenCasCade, a powerful geometry kernel, features an Open Inventor-compliant 3D scene representation model provided by the Coin 3D library, and a broad Python API. The interface is built with Qt. FreeCAD runs exactly the same way on Windows, Mac OSX and Linux platforms.
 
-### Notes
-
-This package may install a 32bit version that is not the same version number as the 64bit version.
-
 ## Features
 
 - A full parametric model,and modular architecture that allows plugin extensions (modules) to add functionality to the core application.
@@ -41,6 +37,11 @@ This package may install a 32bit version that is not the same version number as 
 - `/WindowStyle` - The normal window setting for most Applications is as a Window. Maximised Window would be 3.
 
 Example: `choco install freecad --params "/InstallDir:'C:\FreeCAD' /NoShortcut"`
+
+### Notes
+
+- This package may install a 32bit version that is not the same version number as the 64bit version.
+- **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 ]]></description>
     <summary>A parametric 3D CAD modeler</summary>
     <releaseNotes>https://www.freecadweb.org/wiki/Release_notes_0.20</releaseNotes>


### PR DESCRIPTION
## Description
I've updated the README.md file for several packages. These should flow into the `description` in the .nupspec file. I also moved the `Notes` section of the `description` to the bottom to make it more prominent (first thing people see when they scroll up / last when they scroll down).

## Motivation and Context

Questions are still being asked via Disqus for many packages. As Disqus is generally not responded to, it makes sense to clarify where questions and issues should be raised. Going forward, we should add this to all packages.

## How Has this Been Tested?
I haven't tested it as its markdown.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).