### PR TITLE
(KeepassXC) Upstream doesn't provide 32 bit versions any more

### DIFF
--- a/automatic/keepassxc/update.ps1
+++ b/automatic/keepassxc/update.ps1
@@ -3,10 +3,6 @@
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
 
-  $url32Hash = Get-Hash -url $Latest.URL32 -filename $Latest.FileName32
-  if ($url32Hash -ne $Latest.Checksum32) {
-    throw "File checksum of downloaded 32bit executable do not match expected upstream checksum"
-  }
   $url64Hash = Get-Hash -url $Latest.URL64 -filename $Latest.FileName64
   if ($url64Hash -ne $Latest.Checksum64) {
     throw "File checksum of downloaded 64bit executable do not match expected upstream checksum"
@@ -16,7 +12,6 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\legal\verification.txt"      = @{
-      "(?i)(32-Bit.+)\<.*\>"                       = "`${1}<$($Latest.URL32)>"
       "(?i)(64-Bit.+)\<.*\>"                       = "`${1}<$($Latest.URL64)>"
       "(?i)(checksum type:\s+).*"                  = "`${1}$($Latest.ChecksumType64)"
       "(?i)(checksum32:\s+).*"                     = "`${1}$($Latest.Checksum32)"
@@ -62,13 +57,9 @@ function global:au_GetLatest {
       $url64 = $_.browser_download_url
 
     }
-    elseif ($_.browser_download_url -cmatch 'Win32') {
-      $url32 = $_.browser_download_url
-    }
   }
 
   return @{
-    url32          = $url32;
     url64          = $url64;
     checksumType32 = 'SHA256';
     checksumType64 = 'SHA256';


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
Upstream is not providing 32 bit versions any more which was making the AU based automated update.ps1 process fail due to malformed 32 bit URL (obviously). This patch fixes this.

## Motivation and Context
Package not automatically updated to 2.7.0. Fix this.

## How Has this Been Tested?
Local dev env.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

