### PR TITLE
(blender) Uninstall fails when multiple software versions installed

### DIFF
--- a/automatic/blender/Readme.md
+++ b/automatic/blender/Readme.md
@@ -29,4 +29,6 @@ Blender is a free and open-source professional-grade 3D computer graphics and vi
 
 ### Notes
 
+- If you have multiple installations of the Blender software, the uninstallation of the Chocolatey package will likely fail. Please manually uninstall the Blender software (through 'Add and Remove Programs' or 'Programs and Features') and then run `choco uninstall blender` to remove the package.
+
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**

--- a/automatic/blender/Readme.md
+++ b/automatic/blender/Readme.md
@@ -30,5 +30,4 @@ Blender is a free and open-source professional-grade 3D computer graphics and vi
 ### Notes
 
 - If you have multiple installations of the Blender software, the uninstallation of the Chocolatey package will likely fail. Please manually uninstall the Blender software (through 'Add and Remove Programs' or 'Programs and Features') and then run `choco uninstall blender` to remove the package.
-
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**


### PR DESCRIPTION
## Description
Updated the description notes to warn that when multiple versions of Blender are installed, the package will fail to uninstall.

Fixes #1795 

## Motivation and Context
The installer allows multiple versions to be installed and Chocolatey doesn't know which one to uninstall, so it fails. In the [comment](https://github.com/chocolatey-community/chocolatey-packages/issues/1795#issuecomment-1040041182) it was agreed that it wasn't desirable for all versions to be uninstalled.

## How Has this Been Tested?
It hasn't. This is an update to the description field.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).