### PR TITLE
(brave) Fix Brave package version detection / automation

### DIFF
--- a/automatic/brave/README-beta.md
+++ b/automatic/brave/README-beta.md
@@ -10,4 +10,6 @@ Brave is a free and open-source web browser developed by Brave Software Inc. bas
 
 ## Notes
 
-* Beta is an early preview for new versions of Brave. This build showcases the newest advances and it’s ready for daily use. Brave Beta automatically sends crash reports, but you can turn this off if you’d like.
+- Beta is an early preview for new versions of Brave. This build showcases the newest advances and it’s ready for daily use. Brave Beta automatically sends crash reports, but you can turn this off if you’d like.
+
+- **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**

--- a/automatic/brave/README-beta.md
+++ b/automatic/brave/README-beta.md
@@ -11,5 +11,4 @@ Brave is a free and open-source web browser developed by Brave Software Inc. bas
 ## Notes
 
 - Beta is an early preview for new versions of Brave. This build showcases the newest advances and it’s ready for daily use. Brave Beta automatically sends crash reports, but you can turn this off if you’d like.
-
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**

--- a/automatic/brave/README-release.md
+++ b/automatic/brave/README-release.md
@@ -10,4 +10,6 @@ Brave is a free and open-source web browser developed by Brave Software Inc. bas
 
 ## Notes
 
-* This is an **official release version** of Brave. It is in continuous development with new releases landing approximately every three weeks. 
+- This is an **official release version** of Brave. It is in continuous development with new releases landing approximately every three weeks.
+
+- **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**

--- a/automatic/brave/README-release.md
+++ b/automatic/brave/README-release.md
@@ -11,5 +11,4 @@ Brave is a free and open-source web browser developed by Brave Software Inc. bas
 ## Notes
 
 - This is an **official release version** of Brave. It is in continuous development with new releases landing approximately every three weeks.
-
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**

--- a/automatic/brave/update.ps1
+++ b/automatic/brave/update.ps1
@@ -7,7 +7,7 @@ function global:au_GetLatest {
   # Beta releases
   $domainBeta = 'https://github.com'
   # Web url was provided at https://github.com/chocolatey-community/chocolatey-packages/issues/1791#issuecomment-1030152913
-  $releaseBetaVersion = (Invoke-WebRequest -Uri $releaseBetaUrl -UseBasicParsing).Content
+  $releaseBetaVersion = Invoke-RestMethod -Uri $releaseBetaUrl
   $url32_b = $domainBeta + ('/brave/brave-browser/releases/download/v{0}/BraveBrowserStandaloneSilentBetaSetup32.exe' -f $releaseBetaVersion)
   $url64_b = $domainBeta + ('/brave/brave-browser/releases/download/v{0}/BraveBrowserStandaloneSilentBetaSetup.exe' -f $releaseBetaVersion)
   $version_b = $releaseBetaVersion
@@ -15,7 +15,7 @@ function global:au_GetLatest {
   # Stable releases
   $domainStable = 'https://github.com'
   # Web url was provided at https://github.com/chocolatey-community/chocolatey-packages/issues/1791#issuecomment-1030152913
-  ($releaseStableVersion = Invoke-WebRequest -Uri $releaseStableUrl -UseBasicParsing).Content
+  $releaseStableVersion = Invoke-RestMethod -Uri $releaseStableUrl
   $url32 = $domainStable + ('/brave/brave-browser/releases/download/v{0}/BraveBrowserStandaloneSilentSetup32.exe' -f $releaseStableVersion)
   $url64 = $domainStable + ('/brave/brave-browser/releases/download/v{0}/BraveBrowserStandaloneSilentSetup.exe' -f $releaseStableVersion)
   $version = $releaseStableVersion
@@ -48,7 +48,7 @@ function global:au_GetLatest {
   # Just because we have a version returned does not mean there is a Windows version available
   # if the URL is valid, it won't throw
   try {
-    Invoke-WebRequest -Uri $url64 -UseBasicParsing -Method HEAD
+    Invoke-RestMethod -Uri $url64 -UseBasicParsing -Method HEAD
   }
   catch {
     $streams.stable = 'ignore'
@@ -58,7 +58,7 @@ function global:au_GetLatest {
   # Just because we have a version returned does not mean there is a Windows version available
   # if the URL is valid, it won't throw
   try {
-    Invoke-WebRequest -Uri $url64_b -UseBasicParsing -Method HEAD
+    Invoke-RestMethod -Uri $url64_b -UseBasicParsing -Method HEAD
   }
   catch {
     $streams.beta = 'ignore'

--- a/automatic/brave/update.ps1
+++ b/automatic/brave/update.ps1
@@ -1,47 +1,38 @@
 ﻿import-module au
 
-$releases = 'https://github.com/brave/brave-browser/releases'
+$releaseStableUrl = 'https://brave-browser-downloads.s3.brave.com/latest/release.version'
+$releaseBetaUrl = 'https://brave-browser-downloads.s3.brave.com/latest/beta.version'
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  # Beta releases
+  $domainBeta = 'https://github.com'
+  # Web url was provided at https://github.com/chocolatey-community/chocolatey-packages/issues/1791#issuecomment-1030152913
+  $releaseBetaVersion = (Invoke-WebRequest -Uri $releaseBetaUrl -UseBasicParsing).Content
+  $url32_b = $domainBeta + ('/brave/brave-browser/releases/download/v{0}/BraveBrowserStandaloneSilentBetaSetup32.exe' -f $releaseBetaVersion)
+  $url64_b = $domainBeta + ('/brave/brave-browser/releases/download/v{0}/BraveBrowserStandaloneSilentBetaSetup.exe' -f $releaseBetaVersion)
+  $version_b = $releaseBetaVersion
 
-  $domain = $releases -split '(?<=//.+)/' | select -First 1
-  $url32_b = $download_page.links | ? href -match 'SilentBetaSetup32.exe$' | select -First 1 -expand href
-  $url64_b = $download_page.links | ? href -match 'SilentBetaSetup.exe$' | select -First 1 -expand href
-  $version_b = $url32_b -split '/v?' | select -Skip 1 -Last 1
-
-  for ($i = 0; $i -lt 10; $i++) {
-    # We currently have disabled stable updates, as such we break early
-    break
-
-    $url32 = $download_page.links | ? href -match 'StandaloneSilentSetup32.exe$' | select -First 1 -expand href
-    $url64 = $download_page.links | ? href -match 'StandaloneSilentSetup.exe$' | select -First 1 -expand href
-    $version = $url32 -split '/v?' | select -Skip 1 -Last 1
-    if ($url32 -and $url64) {
-      break
-    }
-    $nextUrl = $download_page.Links | ? { $_.outerHTML -match "Next" -and $_.href -notmatch "join" } | select -First 1 -expand href
-    if (!$nextUrl) { break }
-
-    $nextUrl = [uri]::new([uri]$releases, $nextUrl)
-
-    $download_page = Invoke-WebRequest -Uri $nextUrl -UseBasicParsing
-  }
+  # Stable releases
+  $domainStable = 'https://github.com'
+  # Web url was provided at https://github.com/chocolatey-community/chocolatey-packages/issues/1791#issuecomment-1030152913
+  ($releaseStableVersion = Invoke-WebRequest -Uri $releaseStableUrl -UseBasicParsing).Content
+  $url32 = $domainStable + ('/brave/brave-browser/releases/download/v{0}/BraveBrowserStandaloneSilentSetup32.exe' -f $releaseStableVersion)
+  $url64 = $domainStable + ('/brave/brave-browser/releases/download/v{0}/BraveBrowserStandaloneSilentSetup.exe' -f $releaseStableVersion)
+  $version = $releaseStableVersion
 
   $streams = @{
-    #stable = @{
-    #  URL32         = $domain + $url32
-    #  URL64         = $domain + $url64
-    #  Version       = $version
-    #  RemoteVersion = $version
-    #  Title         = 'Brave Browser'
-    #  IconUrl       = 'https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@a23ca306537e2537a574ddc55e9c28dc1151ab30/icons/brave.svg'
-    #}
-    stable = 'ignore' # Temporarily disabled while investigation of how to continue parsing stable versions
+    stable = @{
+      URL32         = $url32
+      URL64         = $url64
+      Version       = $version
+      RemoteVersion = $version
+      Title         = 'Brave Browser'
+      IconUrl       = 'https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@a23ca306537e2537a574ddc55e9c28dc1151ab30/icons/brave.svg'
+    }
 
     beta   = @{
-      URL32         = $domain + $url32_b
-      URL64         = $domain + $url64_b
+      URL32         = $url32_b
+      URL64         = $url64_b
       Version       = $version_b + '-beta'
       RemoteVersion = $version_b
       Title         = 'Brave Browser (Beta)'
@@ -54,9 +45,26 @@ function global:au_GetLatest {
     return "ignore"
   }
 
-  if (!$url64) { $streams.stable = 'ignore'; Write-Host "No stable release is available" }
-  if (!$url64_b) { $streams.beta = 'ignore'; Write-Host "No beta release is available" }
-  elseif (!$url32_b) { $streams.beta = "ignore"; Write-Host "No 32bit beta release is available" }
+  # Just because we have a version returned does not mean there is a Windows version available
+  # if the URL is valid, it won't throw
+  try {
+    Invoke-WebRequest -Uri $url64 -UseBasicParsing -Method HEAD
+  }
+  catch {
+    $streams.stable = 'ignore'
+    Write-Host "No stable release is available"
+  }
+
+  # Just because we have a version returned does not mean there is a Windows version available
+  # if the URL is valid, it won't throw
+  try {
+    Invoke-WebRequest -Uri $url64_b -UseBasicParsing -Method HEAD
+  }
+  catch {
+    $streams.beta = 'ignore'
+    Write-Host "No beta release is available"
+  }
+
   @{ streams = $streams }
 }
 


### PR DESCRIPTION
## Description
Fixed the detection of the Brave browser software versions.

Fixes #1791 

## Motivation and Context
The automation for detecting the software versions of Brave was broken. I've used the feeds suggested in [this comment](https://github.com/chocolatey-community/chocolatey-packages/issues/1791#issuecomment-1030152913). Because there is a version returned does not mean there is a Windows artefact for it. So added some code to test if the software is actually there.

## How Has this Been Tested?
I ran the update.ps1 script with the current version numbers (from the feeds) and using different version numbers fed into the code and checked the created nupkg files. Somebody with more experience of how the builds work here would be better placed to do more extensive testing.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).