### PR TITLE
(sysinternals) Fix registry key for ShellRunas EULA

### DIFF
--- a/automatic/sysinternals/tools/helpers.ps1
+++ b/automatic/sysinternals/tools/helpers.ps1
@@ -11,7 +11,8 @@ $tools = `
 "PsInfo",           "PsKill",                    "PsList",     "PsLoggedon",      "PsLoglist",
 "PsPasswd",         "PsService",                 "PsShutdown", "PsSuspend",       "RamMap",
 "RegDelNull",       "Regjump",                   "Regsize",    "RootkitRevealer", "Share Enum",
-"ShellRunas",       "SigCheck",                  "Streams",    "Strings",         "Sync",
+"ShellRunas - Sysinternals: www.sysinternals.com",
+"EulaAccepted",       "SigCheck",                "Streams",    "Strings",         "Sync",
 "System Monitor",   "TCPView",                   "VMMap",      "VolumeID",        "Whois",
 "Winobj",           "ZoomIt"
 


### PR DESCRIPTION
## Description
Creates the correct registry key to accept automatically accept the EULA for Sysinternals at package install.

Fixes #1777 

## Motivation and Context
The registry key created to accept the EULA for ShellRunas was incorrect, and it was therefore prompting for the EULA to be accepted when run.

## How Has this Been Tested?
* Created a new package with the changes.
* Installed the new package.
* Run `ShellRunas`.
* No EULA was promoted for.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [z] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).