### PR TITLE
(seafile-client) Fix version detection

### DIFF
--- a/automatic/seafile-client/update.ps1
+++ b/automatic/seafile-client/update.ps1
@@ -21,9 +21,9 @@ function global:au_GetLatest {
   $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
   $re    = 'seafile.*en\.msi$'
-  $url   = $download_page.links | ? href -match $re | select -First 1 -expand href
+  $url   = $download_page.links | Where-Object href -match $re | Select-Object -Last 1 -expand href
 
-  $version  = $url -split '[-]' | select -Last 1 -Skip 1
+  $version  = $url -split '[-]' | Select-Object -Last 1 -Skip 1
 
   @{
     URL32 = $url


### PR DESCRIPTION
## Description
Updated the code to detect the new version of seafile-client.

Fixes #1755 

## Motivation and Context
They now publish the old v7 and the new v8 on their website (v7 is still Windows 7 compatible). The detection code was matching with this. I've changed it to match the v8 version. This may break in future but it's future proof in that it will always match the last version number they publish on their site.

## How Has this Been Tested?
Ran update.ps1 script.

## Screenshot (if appropriate, usually isn't needed):
N/A.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).