### PR TITLE
(notepadplusplus*) Add logic for stopping and restarting notepad++ process

### DIFF
--- a/automatic/notepadplusplus.commandline/README.md
+++ b/automatic/notepadplusplus.commandline/README.md
@@ -23,6 +23,7 @@ Based on the powerful editing component Scintilla, Notepad++ is written in C++ a
 
 ## Notes
 
-- To force the installation of x32 version, use the `--x86` argument with `choco install`.
-
-
+* To force the installation of x32 version, use the `--x86` argument with `choco install`.
+* Starting in v8.3.3.20220321 and above the Notepad++ process will be closed during upgrade and uninstalls.
+  This may in rare cases result in data loss if there are unsaved text files open. Make sure all files are
+  saved before upgrading or uninstalling this package.

--- a/automatic/notepadplusplus.commandline/notepadplusplus.commandline.nuspec
+++ b/automatic/notepadplusplus.commandline/notepadplusplus.commandline.nuspec
@@ -53,5 +53,6 @@ Based on the powerful editing component Scintilla, Notepad++ is written in C++ a
   <files>
     <file src="legal\**" target="legal" />
     <file src="tools\**" target="tools" />
+    <file src="..\notepadplusplus.install\tools\chocolateyBeforeModify.ps1" target="tools" />
   </files>
 </package>

--- a/automatic/notepadplusplus.commandline/tools/chocolateyInstall.ps1
+++ b/automatic/notepadplusplus.commandline/tools/chocolateyInstall.ps1
@@ -1,4 +1,9 @@
-﻿$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Stop'
+
+if (Test-Path "$env:TEMP\npp.running") {
+  $programRunning = Get-Content -Path "$env:TEMP\npp.running"
+  Remove-Item "$env:TEMP\npp.running"
+}
 
 $toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition
 
@@ -11,3 +16,8 @@ $packageArgs = @{
 
 Get-ChocolateyUnzip @packageArgs
 Remove-Item $toolsPath\*.zip -ea 0
+
+if ($programRunning -and (Test-Path $programRunning)) {
+  Write-Host "Running stopped program"
+  Start-Process $programRunning
+}

--- a/automatic/notepadplusplus.install/README.md
+++ b/automatic/notepadplusplus.install/README.md
@@ -6,7 +6,6 @@ Based on the powerful editing component Scintilla, Notepad++ is written in C++ a
 
 ## Features
 
-
 * Syntax Highlighting and Syntax Folding
 * User Defined Syntax Highlighting and Folding: [screenshot 1](https://notepad-plus-plus.org/assets/images/scsh/ulds_folder.gif), [screenshot 2](https://notepad-plus-plus.org/assets/images/scsh/ulds_keywords.gif), [screenshot 3](https://notepad-plus-plus.org/assets/images/scsh/ulds_comment.gif) and [screenshot 4](https://notepad-plus-plus.org/assets/images/scsh/ulds_op.gif)
 * PCRE (Perl Compatible Regular Expression) Search/Replace
@@ -24,5 +23,7 @@ Based on the powerful editing component Scintilla, Notepad++ is written in C++ a
 
 ## Notes
 
-- To force the installation of x32 version, use the `--x86` argument with `choco install`.
-
+* To force the installation of x32 version, use the `--x86` argument with `choco install`.
+* Starting in v8.3.3.20220321 and above the Notepad++ process will be closed during install, upgrade and uninstalls.
+  This may in rare cases result in data loss if there are unsaved text files open. Make sure all files are
+  saved before installing, upgrading or uninstalling this package.

--- a/automatic/notepadplusplus.install/tools/chocolateyBeforeModify.ps1
+++ b/automatic/notepadplusplus.install/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,10 @@
+﻿$process = Get-Process "Notepad++*" -ea 0
+
+if ($process) {
+  $runningFile = "$env:TEMP\npp.running"
+  $processPath = $process | Where-Object { $_.Path } | Select-Object -First 1 -ExpandProperty Path
+  Set-Content -Value "$processPath" -Path $runningFile
+
+  Write-Host "Found Running instance of Notepad++. Stopping processes..."
+  $process | Stop-Process
+}

--- a/automatic/notepadplusplus.install/tools/chocolateyInstall.ps1
+++ b/automatic/notepadplusplus.install/tools/chocolateyInstall.ps1
@@ -1,5 +1,21 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+if (Test-Path "$env:TEMP\npp.running") {
+  $programRunning = Get-Content -Path "$env:TEMP\npp.running"
+  Remove-Item "$env:TEMP\npp.running"
+}
+
+# Temporary code until we have at least one version with the before modify script
+$process = Get-Process "Notepad++*" -ea 0
+
+if ($process) {
+  $processPath = $process | Where-Object { $_.Path } | Select-Object -First 1 -ExpandProperty Path
+  Write-Host "Found Running instance of Notepad++. Stopping processes..."
+  $process | Stop-Process
+  $programRunning = $processPath
+}
+
+
 $toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
@@ -21,3 +37,8 @@ if (!$installLocation)  {  Write-Warning "Can't find $PackageName install locati
 
 Write-Host "$packageName installed to '$installLocation'"
 Install-BinFile -Path "$installLocation\notepad++.exe" -Name 'notepad++'
+
+if ($programRunning -and (Test-Path $programRunning)) {
+  Write-Host "Running stopped program"
+  Start-Process $programRunning
+}

--- a/automatic/notepadplusplus.install/tools/chocolateyUninstall.ps1
+++ b/automatic/notepadplusplus.install/tools/chocolateyUninstall.ps1
@@ -5,10 +5,8 @@ $packageArgs = @{
   softwareName  = 'Notepad++*'
   fileType      = 'exe'
   silentArgs    = '/S'
-  validExitCodes= @(@(0))
+  validExitCodes= @(0)
 }
-
-$uninstalled = $false
 
 [array]$key = Get-UninstallRegistryKey @packageArgs
 


### PR DESCRIPTION
## Description

This pull request updates the packages notepadplusplus.install and notepadplusplus.commandline to stop the npp process when it is already running.
If it is found to be running during the upgrade, it will relaunch the npp executable when possible without blocking the installation of the package.
There are no data lost because of the stopping of the process that I could found, with the exception if it is a very old installation of npp already running (version on test-environment installed.

## Motivation and Context

If the npp process is already running, there is only a partial upgrade of the software that happens. As such we need to stop the process first.

## How Has this Been Tested?

Tested in the chocolatey-test-environment, and both .install and .commandline is tested using the same steps.

1. Install an older version of the package
2. Launch Notepad++ and make an edit in the application, without saving.
3. While the application is running, upgrade the package to a custom build edition with the code in this PR.
4. Notice the application is stopped, then relaunched and no data is lost.
5. Repeat the installation and upgrading without launching the application (nothing should be launched in that case)
6. Uninstall the package while the application is running.
7. Repeat step 5 and uninstall again with the application not running.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package) (it made sense to do both .commandline and .install in this PR).


## Related Issues

fixes #1766