### PR TITLE
(brave) Update helpers.ps1 to support Brave major version with more of 2 digits

### DIFF
--- a/automatic/brave/tools/helpers.ps1
+++ b/automatic/brave/tools/helpers.ps1
@@ -1,8 +1,9 @@
 ﻿function Get-InstalledVersion() {
   [array]$key = Get-UninstallRegistryKey -SoftwareName 'Brave*'
   if ($key.Length -ge 1) {
-    $installedVersion = $key.Version[3..($key.Version.length - 1)]
-    $installedVersion = "$installedVersion" -replace '\s', ''
+    
+    # Exclude the first number in version (9999.1.2.3 => 1.2.3)
+    $installedVersion = $key.Version -replace "\d+\.(.*)", '$1'
 
     if ($installedVersion -and (-not $env:ChocolateyForce)) {
       return [version]$installedVersion


### PR DESCRIPTION
The first number in brave version contains now 3 digits instead 2 (major version of Brave is now "100").
I suggest this change to support major versions with any number of digits.
See https://github.com/chocolatey-community/chocolatey-packages/issues/1848 for more details.

<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->

` $installedVersion = $key.Version[3..($key.Version.length - 1)]`
works only with Brave major version with 2 digits (less than version 100.x.y.z)

To support any number of digits, My proposal is to replace with:
`$installedVersion = $key.Version -replace "\d+\.(.*)", '$1'`

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Previous helpers.ps1 does not allow to install new Chocolatey packages for Brave since the version of Brave has reached 100.x.y.z

<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/chocolatey-community/chocolatey-packages/issues/1848
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->

```
[ChocolateyPS] C:\> [version]$installedVersion
Impossible de convertir la valeur «.1.37.111» en type «System.Version». Erreur: «Le format de la chaîne d'entrée est
incorrect.»
Au caractère Ligne:1 : 1
+ [version]$installedVersion
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument : (:) [], RuntimeException
    + FullyQualifiedErrorId : InvalidCastParseTargetInvocation

[ChocolateyPS] C:\> $key.Version -replace "\d+\.(.*)", '$1'
1.37.111
```

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package has not been migrated from another location -->
## Original Location
- [Original Repository](add_link_to_original_repository_location)
- [Open Issues](link_to_the_generic_location_of_open_issues) *Add the different issues underneath, and tick those that are fixed in this PR*
  - [x] Issue 1 [link ](https://github.com/chocolatey-community/chocolatey-packages/issues/1848)
  - [ ] Issue 2 Link
- [ ] *Include the link to the opened PR that removes the package from the original location*
- [ ] The [migration guidelines](https://github.com/chocolatey-community/chocolatey-packages/wiki/Package-migration-process) have been followed
