### PR TITLE
(bleachbit.install) fix installer removal

### DIFF
--- a/automatic/bleachbit.install/tools/chocolateyInstall.ps1
+++ b/automatic/bleachbit.install/tools/chocolateyInstall.ps1
@@ -11,4 +11,4 @@ $packageArgs = @{
 }
 
 Install-ChocolateyInstallPackage @packageArgs
-Get-ChildItem "$toolsPath\*.exe" | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" '' } }
+Get-ChildItem "$toolsDir\*.exe" | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" '' } }


### PR DESCRIPTION
## Description

Changes `$toolsPath` to `$toolsDir`, because `$toolsPath` is not defined in this package.

## Motivation and Context

Fixes #1850

## How Has this Been Tested?

Installed in the test environment and ensured that the installer was removed.


## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
