### PR TITLE
[graphviz] Update auto update installer match string

### DIFF
--- a/automatic/graphviz/update.ps1
+++ b/automatic/graphviz/update.ps1
@@ -20,7 +20,7 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
-  $re  = "stable_windows_10_cmake_Release.+-win64\.exe"
+  $re  = "windows_10_cmake_Release.+-win64\.exe"
   $link = $download_page.links | ? outerHtml -match $re | select -first 1
   $link.outerHtml -match '>(.+)</a>' | Out-Null
   $fileName = $Matches[1]


### PR DESCRIPTION
## Description
Not tested but looking at https://www.graphviz.org/download/ the `stable_` prefix was dropped since version 2.50

## Motivation and Context
automatic updates are not working, this should fix it