### PR TITLE
(mp3tag) Add support 64-bit installer and update AU version detection

### DIFF
--- a/automatic/mp3tag/legal/VERIFICATION.txt
+++ b/automatic/mp3tag/legal/VERIFICATION.txt
@@ -7,13 +7,15 @@ location on <https://community.mp3tag.de/t/mp3tag-development-build-status/455>
 and can be verified by doing the following:
 
 1. Download the following:
-  32-Bit software: <http://download.mp3tag.de/mp3tagv314dsetup.exe>
+  32-Bit software: <http://download.mp3tag.de/mp3tagv316setup.exe>
+  64-Bit software: <http://download.mp3tag.de/mp3tagv316-x64-setup.exe>
 2. Get the checksum using one of the following methods:
   - Using powershell function 'Get-FileHash'
   - Use chocolatey utility 'checksum.exe'
 3. The checksums should match the following:
 
   checksum type: sha256
-  checksum32: 48039F584DE1E3B7E32D018A47FD6BDADFFE7A47DA99D9A12B112F1EA7286548
+  checksum32: 0C98FD97FD0FD808DC294CF0FBDEE2BCAE96B45AB8A832F2FD8E7D1435B34D95
+  checksum64: 9BF5D267AA8D8F82A6CFA282A1AE74CBE828BD0B2DD8FDAA8E215B44DAEB1620
 
 The file 'LICENSE.txt' has been obtained from <http://help.mp3tag.de/misc_license.html>

--- a/automatic/mp3tag/tools/ChocolateyInstall.ps1
+++ b/automatic/mp3tag/tools/ChocolateyInstall.ps1
@@ -24,7 +24,8 @@ New-Item $iniFile -type file -force -value $iniContent
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
-  file           = "$toolsPath\mp3tagv314dsetup.exe"
+  file           = "$toolsPath\mp3tagv316setup.exe"
+  file64         = "$toolsPath\mp3tagv316-x64-setup.exe"
   silentArgs     = "/S"
   validExitCodes = @(0)
 }


### PR DESCRIPTION
## Description

This updates the package to include the new 64-bit installer.
Additionally, the update posts changed format recently as well, this updates the regex to work with the new format.

## Motivation and Context

Fixes #1895 
An up-to-date package with all installer architectures is desirable. 

## How Has this Been Tested?

Ran `update.ps1` locally, it updated the package no issues. Installed and uninstall 32 and 64 bit versions in the test environment.

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
