### PR TITLE
(sysinternals) Removes processes in before modify

### DIFF
--- a/automatic/sysinternals/tools/chocolateyBeforeModify.ps1
+++ b/automatic/sysinternals/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,3 @@
+﻿$toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+Write-Host "Closing processes from sysinternals  package installation directory"
+Remove-Process -PathFilter ([regex]::escape('C:\ProgramData\chocolatey\lib\sysinternals\tools') + ".*") | Out-Null


### PR DESCRIPTION
## Description

This does a `Remove-Process` on anything that is inside the package `$toolsPath` during the beforemodify script.

## Motivation and Context

This closes any programs from sysinternals that are running, so as to allow
uninstalls and upgrades to continue without failing.

Fixes #1884 

## How Has this Been Tested?

1. Installed inside test environment.
2. Opened `procexp.exe`
3. Force upgraded, ensuring that the upgrade succeeds
4. Re-opened `procexp.exe` 
5. Uninstalled 

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
