### PR TITLE
(gimp) add fallback from mirror to main site

### DIFF
--- a/automatic/gimp/tools/chocolateyInstall.ps1
+++ b/automatic/gimp/tools/chocolateyInstall.ps1
@@ -1,5 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+$fallbackUrl32 = 'https://download.gimp.org/pub/gimp/v2.10/windows/gimp-2.10.30-setup.exe'
+
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
@@ -9,6 +11,13 @@ $packageArgs = @{
   checksumType   = 'sha256'
   silentArgs     = "/VERYSILENT /NORESTART /RESTARTEXITCODE=3010 /SUPPRESSMSGBOXES /SP- /LOG=`"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).InnoInstall.log`""
   validExitCodes = @(0)
+}
+
+Try {
+    Get-WebHeaders -Url $packageArgs.url
+} Catch {
+    Write-Warning "The mirror URL is not available, falling back to the main site"
+    $packageArgs.url = $fallbackUrl32
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/automatic/gimp/update.ps1
+++ b/automatic/gimp/update.ps1
@@ -8,6 +8,7 @@ function global:au_SearchReplace {
       "(?i)^(\s*url\s*=\s*)'.*'" = "`${1}'$($Latest.URL32)'"
       "(?i)^(\s*checksum\s*=\s*)'.*'" = "`${1}'$($Latest.Checksum32)'"
       "(?i)^(\s*checksumType\s*=\s*)'.*'" = "`${1}'$($Latest.ChecksumType32)'"
+      "(^[$]fallbackUrl32\s*=\s*)('.*')" = "`$1'$($Latest.FallbackURL32)'"  
     }
   }
 }
@@ -17,12 +18,15 @@ function global:au_GetLatest {
 
   $re        = '\.exe$'
   $url32     = $download_page.Links | ? href -match $re | select -first 1 -expand href | % { 'https:' + $_ }
+  
+  $fallbackUrl32 = $url32 -replace "download.gimp.org/mirror", "download.gimp.org"
 
   $regex = "(?:[putesmigx]+)\-|\.exe"; $regex01 = "(\-)"; $regex02 = "RC"
   $version32 = ((($url32 -split("\/"))[-1]) -replace($regex,"") )
   if ($version32 -notmatch $regex02 ) { $version32 = $version32 -replace( $regex01, ".") }
   @{
     URL32    = $url32
+    FallbackURL32 = $fallbackUrl32
     Version  = Get-Version $version32
   }
 }


### PR DESCRIPTION
## Description

This adds a IWR HEAD check on the default mirror download URL. If it fails, it falls back to the main site download URL.

## Motivation and Context

Fixes #1847 

## How Has this Been Tested?

Install and uninstall in the test env. 
The fallback logic was tested with other invalid URLs.

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
