### PR TITLE
(everything) remove es.exe and add notice

### DIFF
--- a/automatic/everything/legal/VERIFICATION.txt
+++ b/automatic/everything/legal/VERIFICATION.txt
@@ -18,7 +18,6 @@ Package can be verified like this:
 
    checksum32: 80E10255B3C4A653EDC2AE162CC0BA78EA4D269F9B80F309007ED39046CAED53
    checksum64: 3FA21697C132FB04B9C2FE539CB86ACC995605323165520FF902924DD48D88B7
-   checksum es.exe: 5AE97E10B832B8B94427B685E3C733896524B2269D8E096D40194F3CCB05A073
 
 Using AU:
 
@@ -26,7 +25,4 @@ Using AU:
 
 File 'License.txt' is obtained from:
     https://www.voidtools.com/License.txt
-
-File 'es.exe' is obtained from:
-    https://www.voidtools.com/es.exe
 

--- a/automatic/everything/tools/chocolateyInstall.ps1
+++ b/automatic/everything/tools/chocolateyInstall.ps1
@@ -34,3 +34,6 @@ Write-Host "Post install command line:" $cmd
 
 Write-Host "Starting $packageName"
 Start-Process "$installLocation\Everything.exe" -ArgumentList "-startup"
+
+Write-Warning "The Everything Command Line, es.exe has been removed from this package."
+Write-Warning "It now can be installed via the 'es' package"

--- a/automatic/everything/update.ps1
+++ b/automatic/everything/update.ps1
@@ -14,16 +14,12 @@ function global:au_SearchReplace {
           "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
           "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
           "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
-          "(?i)(checksum es.exe:).*"   = "`${1} $($Latest.ChecksumEsExe)"
           "(?i)(Get-RemoteChecksum).*" = "`${1} $($Latest.URL64)"
         }
     }
 }
 function global:au_BeforeUpdate {
     Get-RemoteFiles -Purge -NoSuffix
-    iwr 'https://www.voidtools.com/ES-1.1.0.9.zip' -OutFile $env:TMP\ES-1.1.0.9.zip
-    7z x $env:TMP\ES-1.1.0.9.zip es.exe -o"$PSScriptRoot\tools"
-    $Latest.ChecksumEsExe = Get-FileHash $PSScriptRoot\tools\es.exe | % Hash
 }
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing


### PR DESCRIPTION
## Description

This removes the Everything Command Line, es.exe and adds a notice that it can be installed with the `es` package.

## Motivation and Context

Part of #1705 

## How Has this Been Tested?

`update.ps1` tested locally. 
Updated package installed and uninstalled in the test environment.

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

