### PR TITLE
(libreoffice-streams) add check for blank url being returned by update service

### DIFF
--- a/automatic/libreoffice-streams/tools/helpers.ps1
+++ b/automatic/libreoffice-streams/tools/helpers.ps1
@@ -265,6 +265,9 @@ function GetLibOVersionsWithoutFromVersion($fromVersion, $toVersion) {
 
 function GetLibOExactVersion($version) {
     $versions = GetLibOVersions $version $version
+    if (($versions.Rows[0].Url64 -eq '') -or ($versions.Rows[0].Url32 -eq '')) {
+        Throw "Libreoffice update service did not return download URLs"
+    }
     return $versions.Rows[0]
 }
 


### PR DESCRIPTION
## Description

Adds a check for empty URLs being returned by the update service.

## Motivation and Context

Fixes #1835

There is no need to check for being equal to null as the variables are explicitly created in another function.
The only requirement is to check if they are empty/blank.

## How Has this Been Tested?

I did install the package in the test environment, and ran `GetLibOExactVersion` manually to validate that the function does not throw when the update service is working. 

However, there is not really a good way to test that the check works property as the update service returning blank URLs is not something I can recreate locally.

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
