### PR TITLE
(kubernetes-cli) add streams for recent minor versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ automatic/_output/
 /Update-Force-Test*.md
 /update_vars.ps1
 /update_info.xml
+*.gz

--- a/automatic/kubernetes-cli/update.ps1
+++ b/automatic/kubernetes-cli/update.ps1
@@ -3,14 +3,14 @@ param($IncludeStream, [switch] $Force)
 
 Import-Module AU
 
-$releases = 'https://github.com/kubernetes/kubernetes/releases/latest'
+$changelogs = 'https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md'
 
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
 function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt" = @{
-      "(?i)(^\s*location on\:?\s*)\<.*\>"   = "`${1}<$($Latest.ReleaseURL)>"
+      "(?i)(^\s*location on\:?\s*)\<.*\>"   = "`${1}<$($Latest.ReleaseNotes)>"
       "(?i)(^\s*32\-bit software.*)\<.*\>"  = "`${1}<$($Latest.URL32)>"
       "(?i)(^\s*64\-bit software.*)\<.*\>"  = "`${1}<$($Latest.URL64)>"
       "(?i)(^\s*checksum\s*type\:).*"       = "`${1} $($Latest.ChecksumType32)"
@@ -25,20 +25,27 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $url = Get-RedirectedUrl $releases
-
-  $version = $url -split '\/v' | select -last 1
-  $majorVersion = $version.Substring(0, 3)
-
-  $streams = @{}
-
-  $streams.Add($majorVersion, @{
-    Version     = $version
-    URL32       = "https://dl.k8s.io/v${version}/kubernetes-client-windows-386.tar.gz"
-    URL64       = "https://dl.k8s.io/v${version}/kubernetes-client-windows-amd64.tar.gz"
-    ReleaseNotes= "https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-${majorVersion}.md#v$($version -replace '\.','')"
-    ReleaseURL  = "$releases"
-  })
+    $changelog_page = Invoke-WebRequest -Uri $changelogs -UseBasicParsing
+    #Only the latest three minor versions are supported: https://github.com/kubernetes/sig-release/blob/master/release-engineering/versioning.md
+    #However, there are prereleases before the version is released, so the latest four changelogs/minor versions need to be checked.
+    $minor_version_changelogs = $changelog_page.links | ? href -match "CHANGELOG-[\d\.]+\.md" | Select-Object -Expand href -First 4
+    
+    $streams = @{}
+    
+    $minor_version_changelogs | ForEach-Object {
+        $minor_version = ($_ -split "CHANGELOG-" | Select-Object -Last 1).trim(".md")
+        $minor_changelog_page = Invoke-WebRequest -UseBasicParsing -Uri ("https://github.com" + $_)
+        $url64 = $minor_changelog_page.links | ? href -match "/v(?<version>[\d\.]+)/kubernetes-client-windows-amd64.tar.gz" | Select-Object -First 1 -Expand href
+        $patch_version = $matches.version
+        $url32 = $minor_changelog_page.links | ? href -match "/v[\d\.]+/kubernetes-client-windows-386.tar.gz" | Select-Object -First 1 -Expand href
+        
+        $streams.Add($minor_version, @{
+            Version     = $patch_version
+            URL32       = $url32
+            URL64       = $url64
+            ReleaseNotes= ("https://github.com" + $_)
+        })
+    }
 
   return @{ Streams = $streams }
 }


### PR DESCRIPTION
## Description

One commit ignores `.gz` files.
The other adds streams for recent minor versions.

## Motivation and Context

Fixes #1674

## How Has this Been Tested?

Ran `update.ps1` locally, and installed resulting packages in test environment.

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
