### PR TITLE
(thunderbird) bring in package parameters from firefox

### DIFF
--- a/automatic/thunderbird/README.md
+++ b/automatic/thunderbird/README.md
@@ -8,9 +8,20 @@ Thunderbird is a free email application that's easy to set up and customize and 
 - `/UseMozillaFallback` Makes a request to mozilla.org and reads the supported Language Culture code from the website.
 - `/NoStop` - Do not stop Thunderbird before running the install if it is running or attempt to restart it after install.
 
+Command-line options for installer configuration. See the [official page](https://firefox-source-docs.mozilla.org/browser/installer/windows/installer/FullConfig.html) for details and defaults.
+
+- `/InstallDir:PATH`
+- `/NoTaskbarShortcut` Do not create Taskbar Shortcut
+- `/NoDesktopShortcut` Do not create Desktop Shortcut
+- `/NoStartMenuShortcut` Do not create Start Menu Shortcut
+- `/NoMaintenanceService` Do not install Maintenance Service
+- `/RemoveDistributionDir` Remove Distribution directory on installation/update. (This is the default behavior of the Thunderbird Installer, but not for this Chocolatey Package)
+- `/NoAutoUpdate` Sets a policies.json file to not update Thunderbird and does not install the Maintenance Service
+
 ### Examples
 
-`choco install thunderbird --params "/l=en-GB"`  
+`choco install thunderbird --params "/l=en-GB"`
+`choco install thunderbird --params "/NoTaskbarShortcut /NoDesktopShortcut /NoAutoUpdate"`    
 `choco install thunderbird --params "/UseMozillaFallback"`
 `choco install thunderbird --params "/NoStop"`
 

--- a/automatic/thunderbird/tools/chocolateyInstall.ps1
+++ b/automatic/thunderbird/tools/chocolateyInstall.ps1
@@ -92,16 +92,18 @@ else {
 
 if (-Not(Test-Path ($installPath + "\distribution\policies.json") -ErrorAction SilentlyContinue) -and ($pp.NoAutoUpdate) ) {
   if (-Not(Test-Path ($installPath + "\distribution") -ErrorAction SilentlyContinue)) {
-    new-item ($installPath + "\distribution") -itemtype directory
+    New-Item ($installPath + "\distribution") -ItemType directory
   }
 
-  $policies = @{
-    policies = @{
-      "DisableAppUpdate" = $true
-    }
-  }
-  $policies | ConvertTo-Json | Out-File -FilePath ($installPath + "\distribution\policies.json") -Encoding ascii
+  $policies = @"
+{
+    "policies":  {
+                     "DisableAppUpdate":  true
+                 }
+}
+"@
 
+  $policies | Out-File -FilePath ($installPath + "\distribution\policies.json") -Encoding ascii
 }
 
 if ($tbProcess -and !$pp.NoStop) {


### PR DESCRIPTION
## Description

This brings in the package parameters with the extra installer options from the firefox package, as both thunderbird and firefox have the same available arguments.

## Motivation and Context

Fixes #1593

## How Has this Been Tested?

Ran `update.ps1` to build the package. Installed in the test evironment with the added package parameters. Validated that the changed install location worked, that the shortcut were not created, that the update service was not installed, and that the `policy.json` was created. Then validated that the uninstall still worked.

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

