### PR TITLE
(thunderbird) add NoStop parameter

### DIFF
--- a/automatic/thunderbird/README.md
+++ b/automatic/thunderbird/README.md
@@ -6,11 +6,13 @@ Thunderbird is a free email application that's easy to set up and customize and 
 
 - `/l:LOCALE` - Install given Firefox locale. See the [official page](https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt) for a complete list of available locales.
 - `/UseMozillaFallback` Makes a request to mozilla.org and reads the supported Language Culture code from the website.
+- `/NoStop` - Do not stop Thunderbird before running the install if it is running or attempt to restart it after install.
 
 ### Examples
 
 `choco install thunderbird --params "/l=en-GB"`  
 `choco install thunderbird --params "/UseMozillaFallback"`
+`choco install thunderbird --params "/NoStop"`
 
 ## Notes
 

--- a/automatic/thunderbird/tools/chocolateyInstall.ps1
+++ b/automatic/thunderbird/tools/chocolateyInstall.ps1
@@ -9,6 +9,8 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 $packageName  = 'thunderbird'
 $softwareName = 'Mozilla Thunderbird'
 
+$pp = Get-PackageParameters
+
 if (Get-32bitOnlyInstalled -product $softwareName) { Write-Host 'Detected the 32-bit version of Thunderbird on a 64-bit system. This package will continue to install the 32-bit version of Thunderbird unless the 32-bit version is uninstalled.' }
 
 $alreadyInstalled = (AlreadyInstalled -product $softwareName -version '91.10.0')
@@ -19,11 +21,15 @@ if ($alreadyInstalled -and ($env:ChocolateyForce -ne $true)) {
 
 $tbProcess = Get-Process thunderbird -ea 0
 if ($tbProcess) {
-  Write-Host 'Stopping running thunderbird process'
-  Stop-Process $tbProcess
-  # We make an assumption that the first unique item found
-  # will be have the path to the process we want to restart.
-  $tbProcess = $tbProcess.Path | Select-Object -Unique -First 1
+  if ($pp.NoStop) {
+    Write-Warning "Not stopping running thunderbird process"  
+  } else {
+    Write-Host 'Stopping running thunderbird process'
+    Stop-Process $tbProcess
+    # We make an assumption that the first unique item found
+    # will be have the path to the process we want to restart.
+    $tbProcess = $tbProcess.Path | Select-Object -Unique -First 1
+  }
 }
 
 $locale = 'en-US' #https://github.com/chocolatey/chocolatey-coreteampackages/issues/933
@@ -50,7 +56,7 @@ if (!(Get-32bitOnlyInstalled($softwareName)) -and (Get-OSArchitectureWidth 64)) 
 }
 
 Install-ChocolateyPackage @packageArgs
-if ($tbProcess) {
+if ($tbProcess -and !$pp.NoStop) {
   Write-Host "Restarting thunderbird process"
   Start-Process $tbProcess
 }


### PR DESCRIPTION
## Description

Adds a `/NoStop` parameter.

## Motivation and Context

Fixes #1721

## How Has this Been Tested?

- Built package with `update.ps1`
- Installed thunderbird version 91.9.1 in the test environment
- Opened thunderbird
- Upgraded to the built package with `--params="'/NoStop'"`
- Validated that the warning about thunderbird not being stopped was shown and that thunderbird was not stopped
- Closed and restarted thunderbird manually and validated that it was updated to 91.10.0
- Uninstalled thunderbird

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
