### PR TITLE
(peazip) update metadata links to new site

### DIFF
--- a/automatic/peazip.install/peazip.install.nuspec
+++ b/automatic/peazip.install/peazip.install.nuspec
@@ -15,17 +15,17 @@ The program supports over 150 archive formats including 7Z, ACE, ARC, ARJ, BZ2, 
 
 Features of PeaZip includes extract, create and convert multiple archives at once, create self-extracting archives, split/join, encrypted password manager, strong encryption with two factor authentication, secure deletion, find duplicate files, calculate hashes, manage graphic files (rotate, crop, resize, convert).
 ]]></description>
-    <projectUrl>http://www.peazip.org/</projectUrl>
+    <projectUrl>https://peazip.github.io/</projectUrl>
     <projectSourceUrl>https://osdn.net/projects/peazip/releases/</projectSourceUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/peazip.install</packageSourceUrl>
-    <docsUrl>http://www.peazip.org/peazip-help.html</docsUrl>
+    <docsUrl>https://peazip.github.io/peazip-help-faq.html</docsUrl>
     <bugTrackerUrl>https://sourceforge.net/p/peazip/tickets/</bugTrackerUrl>
     <tags>foss cross-platform file-manager file-encryption file-compression zip rar 7zip tar admin peazip</tags>
-    <licenseUrl>http://www.peazip.org/peazip-tos-privacy.html</licenseUrl>
+    <licenseUrl>https://peazip.github.io/peazip-tos-privacy.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>Copyright © PeaZip srl</copyright>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@a09d7c32df1ac4b8028df11d2b2b5196b8de2435/icons/peazip.svg</iconUrl>
-    <releaseNotes>[PeaZip changelog](http://www.peazip.org/changelog.html)</releaseNotes>
+    <releaseNotes>[PeaZip changelog](https://peazip.github.io/changelog.html)</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/peazip/peazip.nuspec
+++ b/automatic/peazip/peazip.nuspec
@@ -19,17 +19,17 @@ Features of PeaZip includes extract, create and convert multiple archives at onc
 
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 ]]></description>
-    <projectUrl>http://www.peazip.org/</projectUrl>
+    <projectUrl>https://peazip.github.io/</projectUrl>
     <projectSourceUrl>https://osdn.net/projects/peazip/releases/</projectSourceUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/peazip</packageSourceUrl>
-    <docsUrl>http://www.peazip.org/peazip-help.html</docsUrl>
+    <docsUrl>https://peazip.github.io/peazip-help-faq.html</docsUrl>
     <bugTrackerUrl>https://sourceforge.net/p/peazip/tickets/</bugTrackerUrl>
     <tags>foss cross-platform file-manager file-encryption file-compression zip rar 7zip tar admin peazip</tags>
-    <licenseUrl>http://www.peazip.org/peazip-tos-privacy.html</licenseUrl>
+    <licenseUrl>https://peazip.github.io/peazip-tos-privacy.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>Copyright © PeaZip srl</copyright>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@a09d7c32df1ac4b8028df11d2b2b5196b8de2435/icons/peazip.svg</iconUrl>
-    <releaseNotes>[PeaZip changelog](http://www.peazip.org/changelog.html)</releaseNotes>
+    <releaseNotes>[PeaZip changelog](https://peazip.github.io/changelog.html)</releaseNotes>
     <dependencies>
       <dependency id="peazip.install" version="[8.6.0]" />
     </dependencies>


### PR DESCRIPTION
## Description

Updates the `peazip` and `peazip.install` `.nuspec`s with the new URLs as `peazip.org` as switched to `https://peazip.github.io`

## Motivation and Context

Fixes #1879

## How Has this Been Tested?

N/A

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
