### PR TITLE
(gimp) Update GIMP mailingListUrl to new URL

### DIFF
--- a/automatic/gimp/gimp.nuspec
+++ b/automatic/gimp/gimp.nuspec
@@ -13,7 +13,7 @@
     <projectSourceUrl>https://git.gnome.org/browse/gimp</projectSourceUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/gimp.svg</iconUrl>
     <docsUrl>https://www.gimp.org/docs/</docsUrl>
-    <mailingListUrl>https://www.gimp.org/mail_lists.html</mailingListUrl>
+    <mailingListUrl>https://www.gimp.org/discuss.html#mailing-lists</mailingListUrl>
     <bugTrackerUrl>https://www.gimp.org/bugs/</bugTrackerUrl>
     <summary>GNU Image Manipulation Program</summary>
     <!-- Do not touch the description here in the nuspec file. Description is imported during update from the Readme.md file -->


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
The latest version of GIMP is [failing in Chocolatey ](https://community.chocolatey.org/packages/gimp/2.10.32) due to a now removed link to the mailing lists. This update provides a link to the new mailing list listing.

## Motivation and Context
This is a simple URL update to allow the new version of GIMP to pass automatic inspection.

## How Has this Been Tested?
N/A

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
