### PR TITLE
(firefox) Stop using Convert-ToJson and fix formatting

### DIFF
--- a/automatic/firefox/tools/chocolateyInstall.ps1
+++ b/automatic/firefox/tools/chocolateyInstall.ps1
@@ -85,14 +85,16 @@ else {
 
 if (-Not(Test-Path ($installPath + "\distribution\policies.json") -ErrorAction SilentlyContinue) -and ($pp.NoAutoUpdate) ) {
   if (-Not(Test-Path ($installPath + "\distribution") -ErrorAction SilentlyContinue)) {
-    new-item ($installPath + "\distribution") -itemtype directory
+    New-Item ($installPath + "\distribution") -ItemType directory
   }
 
-  $policies = @{
-    policies = @{
-      "DisableAppUpdate" = $true
-    }
-  }
-  $policies | ConvertTo-Json | Out-File -FilePath ($installPath + "\distribution\policies.json") -Encoding ascii
+  $policies = @"
+{
+    "policies":  {
+                     "DisableAppUpdate":  true
+                 }
+}
+"@
+  $policies | Out-File -FilePath ($installPath + "\distribution\policies.json") -Encoding ascii
 
 }


### PR DESCRIPTION
## Description

Removes usage of `Convert-ToJson` and fixes formatting.

## Motivation and Context

Fixes #1931

Discovered in #1918

## How Has this Been Tested?

Installed with `/NoAutoUpdate` in the test environment, and ensured that the `policies.json` file was still created correctly.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

