### PR TITLE
(git.install) Terminate gpg-agent when indirectly upgrading

### DIFF
--- a/automatic/git.install/tools/chocolateyBeforeModify.ps1
+++ b/automatic/git.install/tools/chocolateyBeforeModify.ps1
@@ -1,17 +1,4 @@
-﻿$processName = 'gpg-agent*'
-$process = Get-Process -Name $processName
+﻿$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+. $toolsPath\helpers.ps1
 
-if ($process) {
-  Write-Warning "Stopping GPG Agent to prevent git upgrade/uninstall failure..."
-  Stop-Process -InputObject $process
-
-  Start-Sleep -Seconds 3
-
-  $process = Get-Process -Name $processName
-  if ($process) {
-    Write-Warning "Killing GPG Agent to prevent git upgrade/uninstall failure..."
-    Stop-Process -InputObject $process -Force
-  }
-
-  Write-Warning "GPG Agent will not be started by the package after upgradeing..."
-}
+Stop-GitGPGAgent

--- a/automatic/git.install/tools/chocolateyInstall.ps1
+++ b/automatic/git.install/tools/chocolateyInstall.ps1
@@ -17,7 +17,7 @@ $silentArgs += Get-InstallOptions $pp
 $packageArgs = @{
     PackageName    = 'git.install'
     FileType       = 'exe'
-    SoftwareName   = 'Git version *'
+    SoftwareName   = 'Git'
     File           = Get-Item $toolsPath\$fileName32
     File64         = Get-Item $toolsPath\$fileName64
     SilentArgs     = $silentArgs
@@ -27,8 +27,8 @@ Get-ChildItem $toolsPath\$fileName32, $toolsPath\$fileName64 | ForEach-Object { 
 
 $packageName = $packageArgs.packageName
 $installLocation = Get-AppInstallLocation $packageArgs.SoftwareName
-if (!$installLocation)  { Write-Warning "Can't find $packageName install location"; return }
-Write-Host "$packageName installed to '$installLocation'"
+if (!$installLocation)  { Write-Warning "Can't find $packageName install location" }
+else { Write-Host "$packageName installed to '$installLocation'" }
 
 if ($pp.NoCredentialManager) {
     Write-Host "Git credential manager will be disabled."

--- a/automatic/git.install/tools/chocolateyInstall.ps1
+++ b/automatic/git.install/tools/chocolateyInstall.ps1
@@ -6,6 +6,8 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 $pp = Get-PackageParameters
 
 Stop-GitSSHAgent
+# Workaround for chocolateyBeforeModify.ps1 being bypassed if upgrading via metapackage (chocolatey/choco#1092)
+Stop-GitGPGAgent
 
 $fileName32 = 'Git-2.36.1-32-bit.exe'
 $fileName64 = 'Git-2.36.1-64-bit.exe'

--- a/automatic/git.install/tools/helpers.ps1
+++ b/automatic/git.install/tools/helpers.ps1
@@ -70,18 +70,24 @@ function Get-ShellIntegrationComponents( [HashTable]$pp )
     return $shell
 }
 
+function Stop-GitProcess( [string]$ProcessName )
+{
+    $processes = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
+    if ($null -eq $processes) { return }
+
+    $installLocation = Get-AppInstallLocation 'Git'
+    if ($null -eq $installLocation) { return }
+
+    Write-Host "Killing any running git $ProcessName instances"
+    $processes | Where-Object {$_.Path -like "$installLocation\usr\bin\*"} | Stop-Process -Force
+}
+
 function Stop-GitSSHAgent()
 {
-    if (!(Get-Process ssh-agent -ea 0)) { return }
-
-    Write-Host "Killing any running git ssh-agent instances"
-    Get-Process ssh-agent | Where-Object {$_.Path -ilike "*\git\usr\bin\*"} | Stop-Process
+    Stop-GitProcess 'ssh-agent'
 }
 
 function Stop-GitGPGAgent()
 {
-    if (!(Get-Process gpg-agent -ea 0)) { return }
-
-    Write-Host "Killing any running gpg-agent instances"
-    Get-Process gpg-agent | Where-Object {$_.Path -ilike "*\git\usr\bin\*"} | Stop-Process -Force
+    Stop-GitProcess 'gpg-agent'
 }

--- a/automatic/git.install/tools/helpers.ps1
+++ b/automatic/git.install/tools/helpers.ps1
@@ -77,3 +77,11 @@ function Stop-GitSSHAgent()
     Write-Host "Killing any running git ssh-agent instances"
     Get-Process ssh-agent | Where-Object {$_.Path -ilike "*\git\usr\bin\*"} | Stop-Process
 }
+
+function Stop-GitGPGAgent()
+{
+    if (!(Get-Process gpg-agent -ea 0)) { return }
+
+    Write-Host "Killing any running gpg-agent instances"
+    Get-Process gpg-agent | Where-Object {$_.Path -ilike "*\git\usr\bin\*"} | Stop-Process -Force
+}


### PR DESCRIPTION
## Description
This changeset implements a package-level workaround for https://github.com/chocolatey/choco/issues/1092, as originally discussed in https://github.com/chocolatey-community/chocolatey-packages/discussions/1924.

Fixes #1938.

## Motivation and Context
When upgrading `git.install` indirectly (via either `choco upgrade git` or `choco upgrade all`, which will alphabetically iterate through `git` first), `choco` will fail to execute `chocolateyBeforeModify.ps1` of any package dependencies being installed. In the context of `git.install`, this contains commands to stop any running instances of `gpg-agent.exe`, which may run as a background process when commit signing is enabled. Commit signing is a commonly enabled feature to help certify the authenticity of a given commit's author.

While this would ideally be fixed upstream in `choco`, there is currently no ETA on when a fix would roll out. As a stopgap solution, wrapping this functionality within a new function defined in `helpers.ps1`, and calling the function from both `chocolateyBeforeModify.ps1` and `chocolateyInstall.ps1`. The former is required to accommodate uninstall commands, while the latter should cover any upgrade scenario, whether invoked directly (via `choco upgrade git.install`) or indirectly. 

## How Has this Been Tested?
### Setup
1. Manually download Git for Windows installer binaries to `git.install`'s `tools` directory, as they are not committed to this repository.
2. `choco pack` within both `git` and `git.install` directories of local repository to create test packages with proposed changeset.
3. Copy test packages to Chocolatey Test Environment VM. All steps from this point forward involve the VM.
4. Install previous version (assumed 2.36.1) of `git` and `git.install` packages with `choco install git --version=2.36.1 --params "/GitAndUnixToolsOnPath"`.
5. Confirm install command completes successfully.
6. Reopen PowerShell.
7. Create a GPG signing key with `gpg --full-generate-key`. Default options were used, with arbitrary user ID and passphrase.
8. Start `gpg-agent.exe` with `gpgconf --launch gpg-agent`.
9. Open Task Manager and confirm `gpg-agent.exe` has launched.

### Test Cases

#### Indirect Package Upgrade via Metapackage
1. Upgrade package to test package version with `choco upgrade git --source="."` (assuming packages are in current directory).
2. Confirm `gpg-agent.exe` is successfully closed, and the upgrade command completes without errors.

#### Direct Package Upgrade
1. Restart `gpg-agent.exe` with `gpgconf --launch gpg-agent`.
2. Force a direct package upgrade with `choco upgrade git.install --source="." --force` (assuming package is in current directory).
3. Confirm `gpg-agent.exe` is successfully closed, and the upgrade command completes without errors.

#### Uninstall
1. Restart `gpg-agent.exe` with `gpgconf --launch gpg-agent`.
2. Uninstall the test package version with `choco uninstall git`.
3. At runtime, confirm uninstallation of `git.install` package as well.
4. Confirm `gpg-agent.exe` is successfully closed, and the uninstall command completes without errors.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).