### PR TITLE
remove the jre8 dependency and warn the user to manually install a java runtime

### DIFF
--- a/automatic/umlet/tools/chocolateyInstall.ps1
+++ b/automatic/umlet/tools/chocolateyInstall.ps1
@@ -6,3 +6,5 @@ Install-ChocolateyZipPackage `
     -PackageName $env:ChocolateyPackageName `
     -File "$toolsDir\umlet-standalone-15.0.0.zip" `
     -UnzipLocation $toolsDir
+
+Write-Warning 'To run UMLet you need to install a Java Runtime (e.g. Temurin8jre)'

--- a/automatic/umlet/umlet.nuspec
+++ b/automatic/umlet/umlet.nuspec
@@ -30,7 +30,6 @@
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/umlet</packageSourceUrl>
     <bugTrackerUrl>https://github.com/umlet/umlet/issues</bugTrackerUrl>
     <dependencies>
-      <dependency id="jre8" version="8.0" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
## Description

This lets the user choose a java runtime instead of forcing one.

This closes #1942.

## Motivation and Context

The umlet package should be migrated away from the Oracle JRE due to licensing FUD.

## How Has this Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
