### PR TITLE
(intunewinapputil) Don't include files with the package

### DIFF
--- a/automatic/intunewinapputil/update.ps1
+++ b/automatic/intunewinapputil/update.ps1
@@ -17,10 +17,6 @@ function global:au_GetLatest {
 
 }
 
-function global:au_BeforeUpdate {
-  Get-RemoteFiles -Purge -NoSuffix
-}
-
 function global:au_SearchReplace {
   @{
     "./tools/chocolateyInstall.ps1" = @{
@@ -31,4 +27,4 @@ function global:au_SearchReplace {
   }
 }
 
-update -ChecksumFor none
+update -ChecksumFor 32


### PR DESCRIPTION
## Description

Update the script logic to exclude the zip file from the package as we don't have the rights to distribute it.

## Motivation and Context

We don't have permissions to distribute the zip file, so it should not be included in the package.

## How Has this Been Tested?

I have manually run the `update.ps1` file and ensured that the generated `nupkg` file does not include the zip file.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).