### PR TITLE
(vim) Fix vimtutor

### DIFF
--- a/automatic/vim/tools/chocolateybeforemodify.ps1
+++ b/automatic/vim/tools/chocolateybeforemodify.ps1
@@ -1,6 +1,7 @@
 ﻿$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $installDir = Get-Content "$toolsDir\installDir"
 $shortversion = '90'
+
 try {
   # Is dlls locked?
   Remove-Item "$installDir\vim\vim$shortversion\GvimExt32\gvimext.dll", "$installDir\vim\vim$shortversion\GvimExt64\gvimext.dll" -ErrorAction Stop

--- a/automatic/vim/tools/chocolateyinstall.ps1
+++ b/automatic/vim/tools/chocolateyinstall.ps1
@@ -20,8 +20,7 @@ $installArgs = @{
 
 '$installDir', ($installDir | Out-String), '$packageArgs', ($packageArgs | Out-String), '$installArgs', ($installArgs | Out-String) | ForEach-Object { Write-Debug $_ }
 
-Install-ChocolateyZipPackage @packageArgs
-Start-ChocolateyProcessAsAdmin @installArgs
-Copy-Item -Path "$installDir\vim\vim$shortversion\vimtutor.bat" -Destination $env:windir
+Install-ChocolateyZipPackage @packageArgs | Write-Debug
+Start-ChocolateyProcessAsAdmin @installArgs | Write-Debug
 Set-Content -Path "$toolsDir\installDir" -Value $installDir
 Create-SymbolicLink

--- a/automatic/vim/tools/chocolateyuninstall.ps1
+++ b/automatic/vim/tools/chocolateyuninstall.ps1
@@ -3,9 +3,10 @@ $installDir = Get-Content "$toolsDir\installDir"
 $shortversion = '90'
 $statement = '-nsis'
 $exeToRun  = "$installDir\vim\vim$shortversion\uninstall.exe"
+
 # From vim-tux.install.  Make input.
 Set-Content -Path "$env:TEMP\vimuninstallinput" -Value 'y'
 Start-Process -FilePath $exeToRun -ArgumentList $statement -RedirectStandardInput "$env:TEMP\vimuninstallinput" -Wait -WindowStyle Hidden
 Remove-Item "$env:TEMP\vimuninstallinput"
-Remove-Item "$env:windir\vimtutor.bat"
+
 Remove-Item "$installDir\vim" -Recurse -Force

--- a/automatic/vim/tools/helpers.ps1
+++ b/automatic/vim/tools/helpers.ps1
@@ -6,9 +6,10 @@
   }
   return Get-ToolsLocation
 }
+
 function Get-Statement()
 {
-  $options      = '-create-batfiles vim gvim evim view gview vimdiff gvimdiff -install-openwith -add-start-menu'
+  $options      = '-create-batfiles vim gvim evim view gview vimdiff gvimdiff vimtutor -install-openwith -add-start-menu'
   $createvimrc  = '-create-vimrc -vimrc-remap no -vimrc-behave default -vimrc-compat all'
   $installpopup = '-install-popup'
   $installicons = '-install-icons'
@@ -30,6 +31,7 @@ function Get-Statement()
   }
   return $options, $createvimrc, $installpopup, $installicons -join ' '
 }
+
 # Replace old ver dir with symlink
 # Use mklink because New-Item -ItemType SymbolicLink doesn't work in test-env
 # Use rmdir because Powershell cannot unlink directory symlink

--- a/automatic/vim/vim.nuspec
+++ b/automatic/vim/vim.nuspec
@@ -5,7 +5,7 @@
     <title>Vim</title>
     <version>9.0.0089</version>
     <authors>Bram Moolenaar, Vim Community</authors>
-    <owners>chocolatey-community, Rob Reynolds, matsuhav</owners>
+    <owners>chocolatey-community, Rob Reynolds</owners>
     <summary>Vim is an advanced text editor that seeks to provide the power of the de-facto Unix editor 'Vi', with a more complete feature set. It's useful whether you're already using vi or using a different editor.</summary>
     <description><![CDATA[Vim is a highly configurable text editor built to enable efficient text editing. It is an improved version of the vi editor distributed with most UNIX systems.
 


### PR DESCRIPTION
Stop manually generating `vimtutor.bat` and let `install.exe` generate it.
Add Write-Debug. Fix style.

<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
`vimtutor.bat` is a batch file which is generated in `windir` by `install.exe`.
Batch files like this provide vim related command on cmd.exe/Powershell: `vim`, `gvim`, `vimtutor` commands etc.
`install.exe` is a program which are to be invoked after unzipping Vim install archive.

We were copying `vimtutor.bat` from unzipped folder, but it's wrong. 
`vimtutor.bat` should be generated by `install.exe`.
This PR includes fix for `vimtutor.bat` and coding style for blank lines.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
`vimtutor.bat` from unzipped folder differs from what `install.exe` generates. We were using the wrong one and it keeps `vimtutor` command on cmd.exe/Powershell from launching with GVim, the GUI version of Vim.
The help description of `install.exe` doesn't include `vimtutor.bat` ([vim/dosinst.c#L2377](https://github.com/vim/vim/blob/a34b4460c2843c67a35a2d236b01e6cb9bc38734/src/dosinst.c#L2377)) and this led to this mistake.
I found this bug while inspecting the NSIS installer which utilizes `install.exe` to generate the correct `vimtutor.bat`.

<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
I found this bug while inspecting #1943, but it's not related to it.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
With [majkinetor/chocolatey-test-environment](https://github.com/majkinetor/chocolatey-test-environment),
I installed the package, ran `vimtutor` in Powershell and uninstalled it.
When installing, I checked batch files generated in `windir` are the correct ones.
And I executed `vimtutor` on Powershell and it launched on GVim without any warnings/bugs.
When uninstalling, I saw batch files were removed as expected when I uninstalled the package.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
