### PR TITLE
(ccleaner) Query auto-update endpoint for update checks

### DIFF
--- a/automatic/ccleaner/update.ps1
+++ b/automatic/ccleaner/update.ps1
@@ -28,10 +28,8 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest https://www.piriform.com/ccleaner/version-history -UseBasicParsing
-  $Matches = $null
-  $download_page.Content -match '\<h6\>v((?:[\d]\.)[\d\.]+)'
-  $version = $Matches[1]
+  $download_page = Invoke-WebRequest 'https://www.ccleaner.com/auto?p=cc' -UseBasicParsing
+  $version = $download_page.Content.Split('|')[2]
 
   $url = 'https://download.ccleaner.com/ccsetup{0}.exe' -f ($version -replace '^(\d+)\.(\d+).*$', '$1$2')
 


### PR DESCRIPTION
## Description
This changeset should modify CCleaner's update script to use an endpoint query, similarly to what CCleaner itself uses, to check for software updates.

Fixes #1960.

## Motivation and Context
I came across the mentioned issue and felt inclined to chime in with an alternative approach to updating the script's regex pattern. Using a regular expression match against a web page's contents can be brittle and subject to failure with unanticipated structural/formatting changes to the web page, as evidenced by the issue raised.

Using Fiddler, I sniffed CCleaner's traffic and came across a request to the following URL:
https://www.ccleaner.com/auto?a=0&p=cc&v=5.92.9652&l=1033&lk=&mk=CMS6-NK32-VYSM-VVU6-EYIH-5FXW-9YH2-XVB8-VTTT&o=10.0W6&au=1&mx=4B6BA6B23E286D4C292C528C1D940CB787BD38E84DD5D0F7D9FE3D10662915C3&gd=1891ed9c-bcbf-470c-abcb-2b81e2fa4c2f&isAdmin=1&isElevated=1

I then took this to Postman and played around with the URL to remove unnecessary query params in the URL. The resulting query as used in the script creates a response body similar to this:
```
$$$|1|6.02.9938|0|0|$$$
```

This response is then tokenized to extract the version number required by the script.

Per @RedBaron2's request, raising this pull request with my proposed change.

## How Has this Been Tested?
~~Executed `Set-StrictMode -Version 2.0` to help ensure PSv2 compatibility, then~~ Executed the modified `update.ps1` script locally in my environment:
- **Operating System Version:** Microsoft Windows NT 10.0.22000.0
- **OS Edition:** Windows 11 Pro
- **OS Architecture:** 64-bit
- **PowerShell Version Table:** 
```
Name                           Value
----                           -----
PSVersion                      7.2.5
PSEdition                      Core
GitCommitId                    7.2.5
OS                             Microsoft Windows 10.0.22000
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```
- **Shell:** PowerShell 7.2.5
- **Terminal Emulator:** Windows Terminal v1.14.1963.0
- **Chocolatey Version:** 1.1.0

As far as I can tell, the script succeeds and produces a package that is both valid and up-to-date. The resulting package upgrades (from the latest published version, 5.92.9652), uninstalls, and installs as expected in both my environment as well as the Chocolatey Testing Environment.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
