### PR TITLE
1password Fix #1773 missing v8.x.x updates

### DIFF
--- a/automatic/1password/1password.nuspec
+++ b/automatic/1password/1password.nuspec
@@ -3,10 +3,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>1password</id>
-    <version>7.9.832</version>
+    <version>8.8.0</version>
     <title>1Password</title>
-    <authors>AgileBits</authors>
-    <owners>chocolatey-community, AgileBits</owners>
+    <authors>1Password</authors>
+    <owners>chocolatey-community</owners>
     <licenseUrl>https://1password.com/legal/terms-of-service</licenseUrl>
     <projectUrl>https://1password.com/</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@09451a71b28e4ee0b3ea3841ab130b1bbf46f9b0/icons/1password.png</iconUrl>

--- a/automatic/1password/tools/chocolateyInstall.ps1
+++ b/automatic/1password/tools/chocolateyInstall.ps1
@@ -3,8 +3,10 @@
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
-  url            = 'https://downloads.1password.com/win/1PasswordSetup-latest.exe'
+  url            = 'https://downloads.1password.com/win/1PasswordSetup-8.8.0.exe'
   softwareName   = '1Password*'
+  checksum       = '73F3193FC8AC34FDDB4CB5EF2F4A6986CE29DFEB148DA1ABE951E432FDD388DE'
+  checksumType   = 'sha256'
   silentArgs     = "--silent"
   validExitCodes = @(0)
 }

--- a/automatic/1password/tools/chocolateyInstall.ps1
+++ b/automatic/1password/tools/chocolateyInstall.ps1
@@ -3,10 +3,8 @@
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
-  url            = 'https://c.1password.com/dist/1P/win6/1PasswordSetup-7.9.832.exe'
+  url            = 'https://downloads.1password.com/win/1PasswordSetup-latest.exe'
   softwareName   = '1Password*'
-  checksum       = '578022880cbb9f9dc1e0d61e77077ad105e51727ad09f2565fe512ba06107611'
-  checksumType   = 'sha256'
   silentArgs     = "--silent"
   validExitCodes = @(0)
 }

--- a/automatic/1password/update.ps1
+++ b/automatic/1password/update.ps1
@@ -62,13 +62,13 @@ function global:au_GetLatest {
   (Get-ItemProperty $destination).VersionInfo.ProductVersion
 
   $version = Get-Item $destination | ForEach-Object { [System.Diagnostics.FileVersionInfo]::GetVersionInfo($_).FileVersion }
-  $checksum64 = Get-FileHash $destination | ForEach-Object Hash
+  $checksum = Get-FileHash $destination | ForEach-Object Hash
   Remove-Item $destination -ErrorAction:Stop
   @{
-      Version    = $version
-      URL64      = $releases
-      Checksum64 = $checksum64
+      Version     = $version
+      URL         = $releases
+      Checksum    = $checksum
   }
 }
 
-update -ChecksumFor 64 -Force:$Force
+update -ChecksumFor 32 -Force:$Force

--- a/automatic/1password/update.ps1
+++ b/automatic/1password/update.ps1
@@ -53,10 +53,10 @@ function Get-LatestOPW {
   }
 }
 
-$releases = 'https://downloads.1password.com/win/1PasswordSetup-latest.exe'
+$releases = 'https://downloads.1password.com/win/1PasswordSetup-8.8.0.exe'
 
 function global:au_GetLatest {
-  $destination = Join-Path -Path $env:TEMP -ChildPath '1PasswordSetup-latest.exe'
+  $destination = Join-Path -Path $env:TEMP -ChildPath '1PasswordSetup-8.8.0.exe'
   Invoke-WebRequest -Uri $releases -UseBasicParsing -OutFile $destination
 
   (Get-ItemProperty $destination).VersionInfo.ProductVersion


### PR DESCRIPTION
## Description

Agilebits doesn't enlist the latest version of 1password. I've re-engineer the latest version obtaining and redirect the installation link to the latest version publicly available.

1password has a general link to download the latest version, so the current installation needs to be downloaded in order to extract the installation version.

## Motivation and Context

Security.

Choco keeps ignoring v8.x.x. update for some time now. These updates boosts the security by supporting Windows Hello and other features. #1773 

## How Has this Been Tested?

None. You should put some tutorial how to test it into template.
I will be more than happy to do testing if somebody will tell how.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).