### PR TITLE
(codelite) Remove 32-bit installer support

### DIFF
--- a/automatic/codelite/legal/VERIFICATION.txt
+++ b/automatic/codelite/legal/VERIFICATION.txt
@@ -3,15 +3,13 @@ Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
 1. Download the following:
-  32-Bit software <https://downloads.codelite.org/downloads.php?windows>
   64-Bit software <https://downloads.codelite.org/downloads.php?windows_64>
 2. Get the checksum using one of the following methods:
   - Using powershell function 'Get-FileHash'
   - Use chocolatey utility 'checksum.exe'
-3. The checksums should match the following:
+3. The checksum should match the following:
 
   checksum type: sha256
-  checksum32: 475BCFDBDE9E37594A3D18DC3B7E5DA03CB26183D3C8FC94327DCC1317D276EC
-  checksum64: FA7D6E6FB62F595DF35697931937D7451E7B32F540707A5B245B140BFC2FF550
+  checksum64: FD8CA4E996998BFDDABE5B16445A783B675FE94198867780D15F0ACCEA8CE348
 
 The file 'LICENSE.txt' has been obtained from <https://github.com/eranif/codelite/blob/5c29b6cb2a48dbf2d9b243a173c540cf85d70f4f/LICENSE>

--- a/automatic/codelite/tools/chocolateyInstall.ps1
+++ b/automatic/codelite/tools/chocolateyInstall.ps1
@@ -5,6 +5,7 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 $packageArgs = @{
   packageName    = 'codelite'
   fileType       = 'exe'
+  file           = ''
   file64         = "$toolsPath\codelite_x64.exe"
   silentArgs     = '/VERYSILENT /SP- /SUPPRESSMSGBOXES'
   validExitCodes = @(0)

--- a/automatic/codelite/tools/chocolateyInstall.ps1
+++ b/automatic/codelite/tools/chocolateyInstall.ps1
@@ -5,7 +5,6 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 $packageArgs = @{
   packageName    = 'codelite'
   fileType       = 'exe'
-  file           = "$toolsPath\codelite_x32.exe"
   file64         = "$toolsPath\codelite_x64.exe"
   silentArgs     = '/VERYSILENT /SP- /SUPPRESSMSGBOXES'
   validExitCodes = @(0)

--- a/automatic/codelite/update.ps1
+++ b/automatic/codelite/update.ps1
@@ -5,14 +5,11 @@ $releases = "https://downloads.codelite.org/"
 function global:au_SearchReplace {
   @{
     ".\tools\chocolateyInstall.ps1" = @{
-      "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\).*"   = "`${1}$($Latest.FileName32)`""
       "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName64)`""
     }
     ".\legal\VERIFICATION.txt"      = @{
-      "(?i)(\s*32\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL32)>"
       "(?i)(\s*64\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL64)>"
       "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType64)"
-      "(?i)(^\s*checksum32\:).*"          = "`${1} $($Latest.Checksum32)"
       "(?i)(^\s*checksum64\:).*"          = "`${1} $($Latest.Checksum64)"
     }
 
@@ -29,15 +26,12 @@ function global:au_BeforeUpdate {
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-  $re = 'windows$'
   $re64 = 'windows_64$'
-  $url = $download_page.links | ? href -match $re | select -First 1 -Expand href | % { Get-RedirectedUrl $_  3>$null }
   $url64 = $download_page.links | ? href -match $re64 | select -First 1 -Expand href { % Get-RedirectedUrl $_  3>$null }
   $version = $download_page.content -match "CodeLite ([\d\.]+) - Stable Release" | select -first 1 | % { $Matches[1] }
 
   @{
     URL64        = $url64
-    URL32        = $url
     Version      = $version
     ReleaseNotes = "https://github.com/eranif/codelite/releases/tag/$version"
     FileType     = "exe"


### PR DESCRIPTION
## Description
This changeset resolves `codelite`'s current update script failure by removing 32-bit support from the package.

Fixes #1965.

## Motivation and Context
The upgrade script is failing as follows:
```shell
codelite - checking updates using AU version 2021.7.18

URL check
Exception: D:\Cloud\Dropbox\Documents\PowerShell\Modules\AU\2021.7.18\Public\Update-Package.ps1:110:67
Line |
 110 |  … heck_url $url -Options $Latest.Options) { throw "${res}:$url" } else  …
     |                                              ~~~~~~~~~~~~~~~~~~~
     | URL syntax is invalid:
```

The root cause is that `$Latest.URL32` is not being populated with a valid URL, because [the download page](https://downloads.codelite.org/) no longer contains a link that matches the URL pattern historically used by the latest stable 32-bit installer. Browsing directly to [the intended link](https://downloads.codelite.org/downloads.php?windows) returns HTTP 500 (Internal Server Error).

Looking through [the release archive](https://downloads.codelite.org/ReleaseArchive.php), I noticed i686 (i.e. 32-bit installer) binaries stopped being published with weekly version v15.0.4. This practice has carried forward to the current stable version (v16.0.0).

Interestingly, [v16.0.0's release notes](https://wiki.codelite.org/pmwiki.php/Main/ReleaseNotesCodeLite16) make no direct mention of this or why it has happened. However, this appears intentional based on https://github.com/eranif/codelite/commit/cafbe70e5bb6fd3494a6fec38fb64a1f40487726. I would conclude support for the 32-bit installer has been unceremoniously dropped.

I've updated the package accordingly to remove all references to the 32-bit URL, binary, and verification checksum.

## How Has this Been Tested?
Executed the modified `update.ps1` script locally in my environment:
- **Operating System Version:** Microsoft Windows NT 10.0.22000.0
- **OS Edition:** Windows 11 Pro
- **OS Architecture:** 64-bit
- **PowerShell Version Table:** 
```
Name                           Value
----                           -----
PSVersion                      7.2.6
PSEdition                      Core
GitCommitId                    7.2.6
OS                             Microsoft Windows 10.0.22000
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```
- **Shell:** PowerShell 7.2.6
- **Terminal Emulator:** Windows Terminal v1.14.1963.0
- **Chocolatey Version:** 1.1.0

As far as I can tell, the script succeeds and produces a package that is both valid and up-to-date. The resulting package upgrades (from the latest published version, 15.0.0), uninstalls, and installs as expected in both my environment as well as the Chocolatey Testing Environment.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
