### PR TITLE
(#1973) Update to match new filenames

### DIFF
--- a/automatic/vagrant/update.ps1
+++ b/automatic/vagrant/update.ps1
@@ -22,12 +22,12 @@ function global:au_GetLatest {
     $version_url   = 'https://releases.hashicorp.com' + $version_url
 
     $download_page = Invoke-WebRequest -Uri $version_url -UseBasicParsing
-    $link = $download_page.links | ? href -match '\.msi$' 
-    $url = 'https://releases.hashicorp.com'
+    $link = $download_page.links | ? href -match '\.msi$'
+
     @{
         Version  = $link.'data-version' | select -first 1
-        URL32    = $url + ($link.href -notmatch '_64' | select -First 1)
-        URL64    = $url + ($link.href -match '_64'    | select -First 1)
+        URL32    = $link.href -notmatch '_amd64' | select -First 1
+        URL64    = $link.href -match '_amd64'    | select -First 1
     }
 }
 


### PR DESCRIPTION
## Description
Looks like Vagrant have changed the filename and the links on the page being scraped.

## Motivation and Context
Fixes #1973 

## How Has this Been Tested?
Ran the `update.ps1` file and checked the amended `.nuspec` and `chocolateyInstall.ps1`

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).