### PR TITLE
(owncloud-client) Query auto-update endpoint for update checks

### DIFF
--- a/automatic/owncloud-client/update.ps1
+++ b/automatic/owncloud-client/update.ps1
@@ -23,14 +23,12 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-
-  $re = 'ownCloud-.+\.x64\.msi$'
-  $url = $download_page.Links | ? href -match $re | select -expand href
+  $updateEndpoint = 'https://updates.owncloud.com/client/?platform=win32&currentArch=x86_64&msi=true&version=0.0.0'
+  $xmlResponse = Invoke-RestMethod -Uri $updateEndpoint -UseBasicParsing
 
   @{
-    Version = $url -split "/" | select -last 1 -skip 2
-    URL64   = $url
+    Version = $xmlResponse.owncloudclient.version
+    URL64   = $xmlResponse.owncloudclient.downloadurl
   }
 }
 


### PR DESCRIPTION
## Description
This changeset should modify ownCloud's update script to use an endpoint query, similarly to what ownCloud itself uses, to check for software updates.

## Motivation and Context
Fixes #1985.

I came across the mentioned issue and felt inclined to help triage the issue. The root cause ended up being a web scraping related failure. Not long ago, I resolved a similar issue with `ccleaner`, and it turns out this package could also benefit from a similar conversion.

Using Fiddler, I sniffed ownCloud's traffic and came across a request to the following URL:
https://updates.owncloud.com/client/?version=2.10.1.7187&platform=win32&oem=ownCloud&buildArch=x86_64&currentArch=x86_64&versionsuffix=&msi=true

I then took this to Postman and removed a few unnecessary query parameters (`oem`, `buildArch` and `versionSuffix`), then modified `version` to an arbitrarily low value (0.0.0) to ensure the latest version number is reliably returned.

The resulting request as used in the script creates a response body similar to this:
```xml
<?xml version="1.0"?>
<owncloudclient>
    <version>2.11.1.8438</version>
    <versionstring>ownCloud Client 2.11.1 (build 8438)</versionstring>
    <web>https://owncloud.com/desktop-app/</web>
    <downloadurl>https://download.owncloud.com/desktop/ownCloud/stable/2.11.1.8438/win/ownCloud-2.11.1.8438.x64.msi</downloadurl>
</owncloudclient>
```

This response is deserialized to a `PSCustomObject`, and we simply reference the relevant values.

## How Has this Been Tested?
Executed the modified `update.ps1` script locally in my environment:
- **Operating System Version:** Microsoft Windows NT 10.0.22000.0
- **OS Edition:** Windows 11 Pro
- **OS Architecture:** 64-bit
- **PowerShell Version Table:** 
```
Name                           Value
----                           -----
PSVersion                      7.2.6
PSEdition                      Core
GitCommitId                    7.2.6
OS                             Microsoft Windows 10.0.22000
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```
- **Shell:** PowerShell 7.2.6
- **Terminal Emulator:** Windows Terminal v1.14.2282.0
- **Chocolatey Version:** 1.1.0

As far as I can tell, the script succeeds and produces a package that is both valid and up-to-date. The resulting package upgrades (from the latest published version, 2.10.1.7187), uninstalls, and installs as expected in both my environment as well as the Chocolatey Testing Environment.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
