### PR TITLE
(#2007) Adds Get-LatestGitHubRelease

### DIFF
--- a/scripts/Get-GitHubRelease.ps1
+++ b/scripts/Get-GitHubRelease.ps1
@@ -1,0 +1,45 @@
+﻿function Get-GitHubRelease {
+  <#
+    .SYNOPSIS
+      Gets the latest or a specific release of a given GitHub repository
+
+    .EXAMPLE
+      Get-GitHubRelease cloudflare cloudflared
+  #>
+  [CmdletBinding()]
+  param(
+    # Repository owner
+    [Parameter(Mandatory, Position = 0)]
+    [string]$Owner,
+
+    # Repository name
+    [Parameter(Mandatory, Position = 1)]
+    [string]$Name,
+
+    # The Name of the tag to get the relase for. Will default to the latest release.
+    [string]$TagName,
+
+    # GitHub token, used to reduce rate-limiting or access private repositories (needs repo scope)
+    [string]$Token = "$($env:github_api_key)"
+  )
+  end {
+    $apiUrl = "https://api.github.com/repos/$Owner/$Name/releases/latest"
+
+    if ($TagName) {
+      $apiUrl = "https://api.github.com/repos/$Owner/$Name/releases/tags/$TagName"
+    }
+
+    $Request = @{
+      Uri = $apiUrl
+    }
+
+    if (-not [string]::IsNullOrEmpty($Token)) {
+      $Request.Headers = @{
+        Accept        = 'application/vnd.github+json'
+        Authorization = "Bearer $($Token)"
+      }
+    }
+
+    Invoke-RestMethod @Request
+  }
+}

--- a/scripts/au_extensions.psm1
+++ b/scripts/au_extensions.psm1
@@ -5,6 +5,7 @@
 # but the file containing the functions is expected
 # to be named using the same name.
 $funcs = @(
+  'Get-GitHubRelease'
   'Set-DescriptionFromReadme'
   'Update-ChangelogVersion'
   'Update-OnETagChanged'


### PR DESCRIPTION
## Description
Adds a script to address the updates to GitHub Release parsing. 

This has been kept simple, not addressing that wasn't needed for this issue.

## Motivation and Context
As discussed in #2007, the way we were using for scraping GitHub releases in this repository has changed / become unsupported. This function is now available in AU via Update_All (and within the repository). It allows us to simplify update scripts that were previously scraping GitHub releases.

This PR is a prerequisite for the numerous package updates for that issue.

## How Has this Been Tested?
- `Get-LatestGitHubRelease` has been tested against public releases
- `Get-LatestGitHubRelease` has been tested against private releases with a token
- `Get-LatestGitHubRelease` has been used with a PAT hoping to not get rate limited
- Tested using this in Update.ps1 scripts via Update_All.ps1
- Tested with all affected packages in issue #2007 (though with changes to those scripts)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- [x] New feature (non-breaking change which adds functionality)
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- ~[ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)~
- ~[ ] The added/modified package passed install/uninstall in the chocolatey test environment.~
- ~[ ] The changes only affect a single package (not including meta package).~
