### PR TITLE
Fix pkg name extraction from nupkg filename when it contains dots

### DIFF
--- a/scripts/Test-RepoPackage.ps1
+++ b/scripts/Test-RepoPackage.ps1
@@ -374,8 +374,11 @@ function RunChocoProcess() {
   $packageName = $arguments[1] -split ' ' | select -first 1
   $pkgDir = Get-ChildItem -Path "$PSScriptRoot\.." -Filter "$packageName" -Recurse -Directory | select -first 1
   $nupkgFile = Get-ChildItem -Path $pkgDir.FullName -Filter "*.nupkg" | select -first 1
-  $pkgNameVersion = Split-Path -Leaf $nupkgFile | % { ($_ -replace '((\.\d+)+(-[^-\.]+)?).nupkg', ':$1').Replace(':.', ':') -split ':' }
-  $packageName = $pkgNameVersion | select -first 1
+
+  $pkgNameVersion = (Split-Path -Leaf $nupkgFile).Substring($packageName.Length) | % {
+      ($_ -replace '((\.\d+)+(-[^-\.]+)?).nupkg', ':$1').Replace(':.', ':') -split ':'
+  }
+  $packageName += $pkgNameVersion | select -first 1
   $version     = $pkgNameVersion | select -last 1
   if ($packageName -ne $arguments[1]) { $args[1] = $packageName }
 


### PR DESCRIPTION
## Description
This improves the package name extraction from nupkg filename in `Test-RepoPackage.ps1` to properly detect the package name when it ends with a dot followed only by numbers, e.g. package name such as `python3.7`. This works as long as the folder name for the package contains that part of the package name as well.

## Motivation and Context
Required for #1993 to pass, seemed to make more sense as a separate PR.

## How Has this Been Tested?
I've tested in on a few cases:
- Package with no dots in it (e.g `audacity`).
- Package with dots where none of the segments (aside from the first one) contain only numbers (e.g. `autoit.install`, `7zip.install`)
- Packages whose names don't always match the folder name - `1password` and `360ts` can generate a variant of the package named `1password4` and `360tse`, respectively. To make this work, after stripping the "base" package name, I take the part that's before the first dot and add it to the "base" package name.
- Package with dots where one of the segments (aside from the first one) contains only numbers *and* that segment is part of the "base" package name (e.g. `python3.7`)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
