### PR TITLE
(audacity) Update docsUrl to pass Package Validator

### DIFF
--- a/automatic/audacity/audacity.nuspec
+++ b/automatic/audacity/audacity.nuspec
@@ -36,7 +36,7 @@
       <dependency id="chocolatey-core.extension" version="1.3.3" />
       <dependency id="vcredist2015" version="14.0.24215.20170201" />
     </dependencies>
-    <docsUrl>https://www.audacityteam.org/help/</docsUrl>
+    <docsUrl>https://support.audacityteam.org/</docsUrl>
     <projectSourceUrl>https://github.com/audacity/audacity</projectSourceUrl>
   </metadata>
   <files>


### PR DESCRIPTION
## Description
Package is failing Package Validator due to invalid docsUrl.

## Motivation and Context
Failing Package Validator.

## How Has this Been Tested?
This is just an update to the package metadata.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).