### PR TITLE
(git) Updates Release Scraping Method for Git and related packages

### DIFF
--- a/automatic/git-lfs/update.ps1
+++ b/automatic/git-lfs/update.ps1
@@ -1,31 +1,26 @@
 import-module au
 
-$releases = "https://github.com/github/git-lfs/releases"
-
 function global:au_SearchReplace {
    @{
         "$($Latest.PackageName).nuspec" = @{
-            "(<releaseNotes>https:\/\/github.com\/git-lfs\/git-lfs\/releases\/tag\/v)(.*)(<\/releaseNotes>)" = "`${1}$($Latest.Version.ToString())`$3"
+            "(<releaseNotes>)(.*)(<\/releaseNotes>)" = "`$1$($Latest.ReleaseUrl)`$3"
             "(\<dependency .+?`"$($Latest.PackageName).install`" version=)`"([^`"]+)`"" = "`$1`"[$($Latest.Version)]`""
         }
     }
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+    $LatestRelease = Get-LatestGitHubRelease github git-lfs
 
     #git-lfs-windows-1.4.4.exe
-    $re  = "git-lfs-windows-.+.exe"
-    $url = $download_page.links | ? href -match $re | select -First 1 -expand href
+    $LatestAsset = $LatestRelease.assets.Where{$_.name -match "git-lfs-windows-(?<Version>.+).exe"}
 
-    $url32 = "https://github.com" + $url
-
-    $filenameVersionPart = $url -split '-' | select -Last 1
-    $version = Get-Version ([IO.Path]::GetFileNameWithoutExtension($filenameVersionPart))
-
-    $filename = $url -split '/' | select -Last 1
-
-    return @{ URL32 = $url32; Version = $version; FileName = $filename }
+    @{
+        URL32 = $LatestAsset.browser_download_url
+        Version = $LatestRelease.tag_name.TrimStart("v")
+        FileName = $LatestAsset.name
+        ReleaseUrl = $LatestRelease.html_url
+    }
 }
 
 if ($MyInvocation.InvocationName -ne '.') { # run the update only if script is not sourced

--- a/automatic/git.install/update.ps1
+++ b/automatic/git.install/update.ps1
@@ -1,8 +1,5 @@
 import-module au
 
-$domain = 'https://github.com'
-$releases = "$domain/git-for-windows/git/releases/latest"
-
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 function global:au_SearchReplace {
     @{
@@ -22,15 +19,13 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+    $LatestRelease = Get-LatestGitHubRelease git-for-windows git
 
-    #https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-32-bit.exe
-    $re32  = "Git-.+-32-bit.exe"
-    $url32 = $download_page.links | Where-Object href -match $re32 | Select-Object -First 1 -expand href | % { $domain + $_ }
+    # https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-32-bit.exe
+    $url32 = $LatestRelease.assets.Where{$_.name -match "Git-.+-32-bit.exe"}.browser_download_url
 
-    #https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-64-bit.exe
-    $re64  = "Git-.+-64-bit.exe"
-    $url64 = $download_page.links | Where-Object href -match $re64 | Select-Object -First 1 -expand href | % { $domain + $_ }
+    # https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-64-bit.exe
+    $url64 = $LatestRelease.assets.Where{$_.name -match "Git-.+-64-bit.exe"}.browser_download_url
 
     $version32 = $url32 -split '-' | Select-Object -Skip 2 -Last 1
     $version64 = $url64 -split '-' | Select-Object -Skip 2 -Last 1

--- a/automatic/git.portable/update.ps1
+++ b/automatic/git.portable/update.ps1
@@ -1,8 +1,5 @@
 import-module au
 
-$domain = 'https://github.com'
-$releases = "$domain/git-for-windows/git/releases/latest"
-
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 function global:au_SearchReplace {
     @{
@@ -17,15 +14,13 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+    $LatestRelease = Get-LatestGitHubRelease git-for-windows git
 
     #https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/PortableGit-2.11.0-32-bit.7z.exe
-    $re32  = "PortableGit-.+-32-bit.7z.exe"
-    $url32 = $download_page.links | Where-Object href -match $re32 | Select-Object -First 1 -expand href | % { $domain + $_ }
+    $url32 = $LatestRelease.assets.Where{$_.name -match "PortableGit-.+-32-bit.7z.exe"}.browser_download_url
 
     #https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/PortableGit-2.11.0-64-bit.7z.exe
-    $re64  = "PortableGit-.+-64-bit.7z.exe"
-    $url64 = $download_page.links | Where-Object href -match $re64 | Select-Object -First 1 -expand href | % { $domain + $_ }
+    $url64 = $LatestRelease.assets.Where{$_.name -match "PortableGit-.+-64-bit.7z.exe"}.browser_download_url
 
     $version32 = $url32 -split '-' | Select-Object -Skip 2 -Last 1
     $version64 = $url64 -split '-' | Select-Object -Skip 2 -Last 1

--- a/automatic/git/update.ps1
+++ b/automatic/git/update.ps1
@@ -1,7 +1,7 @@
 . $PSScriptRoot\..\git.install\update.ps1
 
 function global:au_BeforeUpdate { 
-    cp  $PSScriptRoot\..\git.install\README.md $PSScriptRoot\README.md
+    cp $PSScriptRoot\..\git.install\README.md $PSScriptRoot\README.md
 }
 function global:au_SearchReplace {
    @{

--- a/scripts/Get-LatestGitHubRelease.ps1
+++ b/scripts/Get-LatestGitHubRelease.ps1
@@ -1,0 +1,35 @@
+﻿function Get-LatestGitHubRelease {
+  <#
+      .SYNOPSIS
+          Gets the latest release of a given GitHub repository
+
+      .EXAMPLE
+          Get-LatestGitHubRelease cloudflare cloudflared
+  #>
+  [CmdletBinding()]
+  param(
+      # Repository owner
+      [Parameter(Mandatory, Position=0)]
+      [string]$Owner,
+
+      # Repository name
+      [Parameter(Mandatory, Position=1)]
+      [string]$Name,
+
+      # GitHub token, used to reduce rate-limiting or access private repositories (needs repo scope)
+      [string]$Token = "$($env:github_api_key)"
+  )
+  end {
+      $Request = @{
+          Uri = "https://api.github.com/repos/$Owner/$Name/releases/latest"
+      }
+
+      if (-not [string]::IsNullOrEmpty($Token)) {
+        $Request.Headers = @{
+            Authorization = "Bearer $($Token)"
+        }
+      }
+
+      Invoke-RestMethod @Request
+  }
+}

--- a/scripts/au_extensions.psm1
+++ b/scripts/au_extensions.psm1
@@ -5,6 +5,7 @@
 # but the file containing the functions is expected
 # to be named using the same name.
 $funcs = @(
+  'Get-LatestGitHubRelease'
   'Set-DescriptionFromReadme'
   'Update-ChangelogVersion'
   'Update-OnETagChanged'


### PR DESCRIPTION
## Description
Updates Git and related packages to use the new Get-GitHubRelease function.

## Motivation and Context
This addresses the issue raised in #2007 for this package

## How Has this Been Tested?
- Run with Update_All.ps1 for each package before the function changes made to #2013 

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
    - Sort of
