### PR TITLE
(git*) Fix update script to use API

### DIFF
--- a/automatic/git.install/update.ps1
+++ b/automatic/git.install/update.ps1
@@ -3,7 +3,19 @@ import-module au
 $domain = 'https://github.com'
 $releases = "$domain/git-for-windows/git/releases/latest"
 
-function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
+function global:au_BeforeUpdate {
+  $releaseAssets = Get-GitHubRelease -Owner 'git-for-windows' -Name 'git' -Tag $Latest.TagName | % assets
+
+  $Latest.URL32 = $releaseAssets | ? name -match "Git-.+-32-bit.exe" | % browser_download_url
+  $Latest.URL64 = $releaseAssets | ? name -match "Git-.+-64-bit.exe" | % browser_download_url
+
+  if (!$Latest.URL32 -or !$Latest.URL64) {
+    throw "64bit or 32bit URL is missing"
+  }
+
+  Get-RemoteFiles -Purge -NoSuffix
+}
+
 function global:au_SearchReplace {
     @{
         ".\tools\chocolateyInstall.ps1" = @{
@@ -24,22 +36,14 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-    #https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-32-bit.exe
-    $re32  = "Git-.+-32-bit.exe"
-    $url32 = $download_page.links | Where-Object href -match $re32 | Select-Object -First 1 -expand href | % { $domain + $_ }
+    $tagUrl = $download_page.Links | Where-Object href -match 'releases/tag/.*windows' | select -First 1 -ExpandProperty href
+    $tagName = $tagUrl -split '\/' | Select -Last 1
 
-    #https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-64-bit.exe
-    $re64  = "Git-.+-64-bit.exe"
-    $url64 = $download_page.links | Where-Object href -match $re64 | Select-Object -First 1 -expand href | % { $domain + $_ }
-
-    $version32 = $url32 -split '-' | Select-Object -Skip 2 -Last 1
-    $version64 = $url64 -split '-' | Select-Object -Skip 2 -Last 1
-    if ($version32 -ne $version64) {  throw "Different versions for 32-Bit and 64-Bit detected." }
+    $version = $tagName -split '^v|\.windows' | select -Last 1 -Skip 1
 
     @{
-        Version = $version32
-        URL32   = $url32
-        URL64   = $url64
+        Version = $version
+        TagName = $tagName
     }
 }
 

--- a/automatic/git.portable/update.ps1
+++ b/automatic/git.portable/update.ps1
@@ -3,7 +3,19 @@ import-module au
 $domain = 'https://github.com'
 $releases = "$domain/git-for-windows/git/releases/latest"
 
-function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
+function global:au_BeforeUpdate {
+  $releaseAssets = Get-GitHubRelease -Owner 'git-for-windows' -Name 'git' -Tag $Latest.TagName | % assets
+
+  $Latest.URL32 = $releaseAssets | ? name -match "PortableGit-.+-32-bit.7z.exe" | % browser_download_url
+  $Latest.URL64 = $releaseAssets | ? name -match "PortableGit-.+-64-bit.7z.exe" | % browser_download_url
+
+  if (!$Latest.URL32 -or !$Latest.URL64) {
+    throw "64bit or 32bit URL is missing"
+  }
+
+  Get-RemoteFiles -Purge -NoSuffix
+}
+
 function global:au_SearchReplace {
     @{
         ".\legal\verification.txt" = @{
@@ -17,25 +29,17 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-    #https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/PortableGit-2.11.0-32-bit.7z.exe
-    $re32  = "PortableGit-.+-32-bit.7z.exe"
-    $url32 = $download_page.links | Where-Object href -match $re32 | Select-Object -First 1 -expand href | % { $domain + $_ }
+  $tagUrl = $download_page.Links | Where-Object href -match 'releases/tag/.*windows' | select -First 1 -ExpandProperty href
+  $tagName = $tagUrl -split '\/' | Select -Last 1
 
-    #https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/PortableGit-2.11.0-64-bit.7z.exe
-    $re64  = "PortableGit-.+-64-bit.7z.exe"
-    $url64 = $download_page.links | Where-Object href -match $re64 | Select-Object -First 1 -expand href | % { $domain + $_ }
+  $version = $tagName -split '^v|\.windows' | select -Last 1 -Skip 1
 
-    $version32 = $url32 -split '-' | Select-Object -Skip 2 -Last 1
-    $version64 = $url64 -split '-' | Select-Object -Skip 2 -Last 1
-    if ($version32 -ne $version64) {  throw "Different versions for 32-Bit and 64-Bit detected." }
-
-    @{
-        Version = $version32
-        URL32   = $url32
-        URL64   = $url64
-    }
+  @{
+      Version = $version
+      TagName = $tagName
+  }
 }
 
 if ($MyInvocation.InvocationName -ne '.') { # run the update only if script is not sourced


### PR DESCRIPTION
## Description
This commit updates the handling of how git packages
are being checked, to use the GitHub API when
we try to download/check for the files for the current
release.

## Motivation and Context

To have the package `git`, `git.install` and `git.portable` up to date.

## How Has this Been Tested?

Tested by running `.\update_all.ps1 Git*` (There will be failing packages not related to the three packages intended for this update).

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment (Not tested as no changes to the package itself is made).
- [x] The changes only affect a single package (not including meta package) (And portable package).
