### PR TITLE
(nodejs.install) Fix installer silent arguments

### DIFF
--- a/automatic/nodejs.install/tools/chocolateyInstall.ps1
+++ b/automatic/nodejs.install/tools/chocolateyInstall.ps1
@@ -13,7 +13,7 @@ $packageArgs = @{
   FileType       = 'msi'
   SoftwareName   = 'Node.js'
   File           = $installFile
-  SilentArgs     = '/quiet ADDLOCAL=ALL REMOVE=NodeEtwSupport'
+  SilentArgs     = '/quiet ADDLOCAL=ALL'
   ValidExitCodes = @(0)
 }
 Install-ChocolateyInstallPackage @packageArgs


### PR DESCRIPTION
## Description
Changed the SilentArgs in the package to remove `REMOVE=NodeEtwSupport`. I could find no information on this, but it looks like it's been removed from the MSI as an installer argument / property. Removing this allowed the installation to continue.

## Motivation and Context
Package is failing verification as it's exiting with a 1603 error.

## How Has this Been Tested?
Installed in a clean Windows Sandbox environment.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

Fixes #2027 