### PR TITLE
(composer) Updates Update.ps1 with Get-GitHubRelease

### DIFF
--- a/automatic/composer/update.ps1
+++ b/automatic/composer/update.ps1
@@ -1,7 +1,5 @@
 ﻿import-module au
 
-$releases = 'https://github.com/composer/windows-setup/releases'
-
 function global:au_SearchReplace {
   @{
     ".\tools\chocolateyInstall.ps1" = @{
@@ -25,14 +23,12 @@ function global:au_SearchReplace {
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-  $re = '\.exe$'
-  $url = $download_page.links | Where-Object href -match $re | Select-Object -First 1 -expand href
-  $version = ($url -split '/' | Select-Object -Last 1 -Skip 1).Replace('v', '')
+  $LatestRelease = Get-GitHubRelease composer windows-setup
+
   @{
-    URL32        = 'https://github.com' + $url
-    Version      = $version
-    ReleaseNotes = "https://github.com/composer/windows-setup/releases/tag/v${version}"
+    URL32        = $LatestRelease.assets | Where-Object {$_.name.EndsWith(".exe")} | Select-Object -ExpandProperty browser_download_url
+    Version      = $LatestRelease.tag_name.TrimStart("v")
+    ReleaseNotes = $LatestRelease.html_url
   }
 }
 


### PR DESCRIPTION
## Description
Updates to use the GitHub REST API for releases.

## Motivation and Context
The previous method for scraping GitHub assets from the release page has been broken.

This updates this package to use the REST API.

This adds to #2007.

## How Has this Been Tested?

- Successfully ran update_all.ps1 with this package. This was an improvement on the recent failures in the Appveyor logs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code (hopefully) follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
