### PR TITLE
(notepadplusplus) Update AU script with GitHub release script

### DIFF
--- a/automatic/notepadplusplus/update.ps1
+++ b/automatic/notepadplusplus/update.ps1
@@ -10,22 +10,14 @@ function global:au_SearchReplace {
  }
 
 function global:au_GetLatest {
-    $tags = "https://github.com/notepad-plus-plus/notepad-plus-plus/tags"
-    $release = Invoke-WebRequest $tags -UseBasicParsing
-    $new = (( $release.links -match "\/v\d+\.\d+(\.\d+)?" ) -split " " | select -First 10 | Select -Last 1 )
-    $new = $new.Substring(1,$new.Length-2)
-    $https = "https://github.com"
-    $releases = "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/tag/v$new/"
-    $download_page = Invoke-WebRequest $releases -UseBasicParsing
-    $url_i         = $download_page.Links | ? href -match '.exe$' | Select-Object -Last 2 | % { $https + $_.href }
-    $url_p         = $download_page.Links | ? href -match '.7z$' | % { $https + $_.href }
+    $LatestRelease = Get-GitHubRelease -Owner "notepad-plus-plus" -Name "notepad-plus-plus"
 
     @{
-        Version = Get-Version ( $url_i -notmatch 'x64' | select -First 1 )
-        URL32_i = $url_i -notmatch 'x64' | select -First 1
-        URL64_i = $url_i -match 'x64'  | select -First 1
-        URL32_p = $url_p -notmatch 'x64' -notmatch 'minimalist'  | select -First 1
-        URL64_p = $url_p -match 'x64' -notmatch 'minimalist'  | select -First 1
+        Version = $LatestRelease.tag_name.Trim("v")
+        URL32_i = $LatestRelease.assets | Where-Object {$_.name.EndsWith("Installer.exe")} | Select-Object -ExpandProperty browser_download_url
+        URL64_i = $LatestRelease.assets | Where-Object {$_.name.EndsWith("x64.exe")} | Select-Object -ExpandProperty browser_download_url
+        URL32_p = $LatestRelease.assets | Where-Object {$_.name.EndsWith("portable.7z")} | Select-Object -ExpandProperty browser_download_url
+        URL64_p = $LatestRelease.assets | Where-Object {$_.name.EndsWith("portable.x64.7z")} | Select-Object -ExpandProperty browser_download_url
     }
 }
 


### PR DESCRIPTION
## Description

Switches notepadplusplus to use the `Get-GitHubRelease` helper function for AU updates.
Also fixes `notepadplusplus.install` and `.commandline` as they dotsource the `notepadplusplus` AU script.

## Motivation and Context

Fixes #2000
Once this is merged, update the list in #2007 

## How Has this Been Tested?

Ran AU locally for metapackage, .install and .commandline, and all worked.

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

