### PR TITLE
(openshift-cli) Updates to not use GitHub Releases

### DIFF
--- a/automatic/openshift-cli/update.ps1
+++ b/automatic/openshift-cli/update.ps1
@@ -23,12 +23,19 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $LatestRelease = Get-GitHubRelease openshift origin
+  $StableReleaseUrl = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/release.txt"
+  $LatestVersion = if ((Invoke-WebRequest -Uri $StableReleaseUrl -UseBasicParsing).Content -match "Version:\s+(?<Version>.+)") {
+    $Matches.Version
+  } else {
+    Write-Error "Could not identify latest version from '$StableReleaseUrl'" -ErrorAction Stop
+  }
+
+  # We could get the SHA256 value from /sha256sum.txt in the same directory, but we currently generate it
 
   return @{
-    Version    = $LatestRelease.tag_name.TrimStart("v")
-    URL64      = $LatestRelease.assets | Where-Object {$_.name.EndsWith("-windows.zip")} | Select-Object -ExpandProperty browser_download_url
-    ReleaseURL = $LatestRelease.html_url
+    Version    = $LatestVersion
+    URL64      = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$LatestVersion/openshift-client-windows-$LatestVersion.zip"
+    ReleaseURL = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$LatestVersion"
   }
 }
 

--- a/automatic/openshift-cli/update.ps1
+++ b/automatic/openshift-cli/update.ps1
@@ -3,9 +3,6 @@ param([switch] $Force)
 
 Import-Module AU
 
-$domain   = 'https://github.com'
-$releases = "$domain/openshift/origin/releases/latest"
-
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix -FileNameBase "openshift-origin-client-tools"
 }
@@ -26,17 +23,12 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-
-  $re = '-windows\.zip$'
-  $url = $download_page.links | ? href -match $re | % href | select -First 1
-
-  $version = (Split-Path ( Split-Path $url ) -Leaf).Substring(1)
+  $LatestRelease = Get-GitHubRelease openshift origin
 
   return @{
-    Version   = $version
-    URL64     = $domain + $url
-    ReleaseURL= "${domain}/openshift/origin/releases/tag/v${version}"
+    Version    = $LatestRelease.tag_name.TrimStart("v")
+    URL64      = $LatestRelease.assets | Where-Object {$_.name.EndsWith("-windows.zip")} | Select-Object -ExpandProperty browser_download_url
+    ReleaseURL = $LatestRelease.html_url
   }
 }
 


### PR DESCRIPTION
It was pointed out that OpenShift was no longer adding GitHub releases to track releases of openshift-cli.

## Description
Originally fixed the GH Releases issue, then found that even with it working it wasn't at the latest version.

This should solve that issue.

## Motivation and Context

Update for this package was broken.
Fixes #1983 

## How Has this Been Tested?
- Tested locally with `.\update_all.ps1 -Name openshift-cli`

![image](https://user-images.githubusercontent.com/1975761/198356688-07a4128d-58d3-4536-8206-0166c009d798.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).