### PR TITLE
(bulk-crap-uninstaller) Switch AU to Get-GitHubRelease

### DIFF
--- a/automatic/bulk-crap-uninstaller/update.ps1
+++ b/automatic/bulk-crap-uninstaller/update.ps1
@@ -23,12 +23,12 @@ function global:au_SearchReplace {
  function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+    $latestrelease = Get-GitHubRelease -Owner "Klocman" -Name "Bulk-Crap-Uninstaller"
     $re      = '\.exe$'
-    $url     = $download_page.links | ? href -match $re | select -First 1 -expand href
+    $url     = $latestrelease.assets.browser_download_url | Where-Object { $_ -match $re } | select -First 1
     $version = ($url -split '/' | select -Last 1 -Skip 1).Replace('v','')
     @{
-        URL32        = 'https://github.com' + $url
+        URL32        = $url
         Version      = $version
         ReleaseNotes = "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/tag/v${version}"
     }


### PR DESCRIPTION
## Description

Switches bulk-crap-uninstaller to use Get-GitHubRelease

## Motivation and Context

Part of #2007

## How Has this Been Tested?

Ran AU script locally, it updated the package correctly.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
