### PR TITLE
Do not create badly-behaved inkscape shim

### DIFF
--- a/automatic/inkscape/tools/chocolateyInstall.ps1
+++ b/automatic/inkscape/tools/chocolateyInstall.ps1
@@ -49,7 +49,6 @@ Get-ChildItem $toolsPath\*.msi | ForEach-Object { Remove-Item $_ -ea 0; if (Test
 $packageName = $packageArgs.packageName
 $installLocation = Get-AppInstallLocation $packageArgs['softwareName']
 if ($installLocation) {
-  Install-BinFile 'inkscape' $installLocation\bin\inkscape.exe
   Write-Host "$packageName installed to '$installLocation'"
 }
 else { Write-Warning "Can't find $PackageName install location" }


### PR DESCRIPTION
Shim is installed as GUI shim despite not being set as such, resulting in broken command line behaviour. As far as I can tell there is no way to explicitly install as a non-GUI shim.

But also switching to non-GUI behaviour is not an acceptable solution, since inkscape.exe is also a GUI program depending on the command line arguments.

Therefore no shim should be generated. If people want inkscape.exe in $PATH they can add it manually and chocolatey should not create a broken/semi-functional inkscape.exe there.

See: https://github.com/chocolatey/home/issues/211

Reverts: #1347

I have not removed the `Uninstall-BinFile` line for cleanup purposes.