### PR TITLE
(k9s) Switch AU to Get-GitHubRelease

### DIFF
--- a/automatic/k9s/update.ps1
+++ b/automatic/k9s/update.ps1
@@ -25,13 +25,18 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $LatestRelease = Get-GitHubRelease -Owner "derailed" -Name "k9s"
+  $latestRelease = Get-GitHubRelease -Owner "derailed" -Name "k9s"
 
   $re = '_Windows_x86_64\.tar.gz$'
-  $url = $latestrelease.assets.browser_download_url | Where-Object { $_ -match $re } | select -First 1
+  $asset = $latestRelease.assets | Where-Object { $_.name -match $re } | Select-Object -First 1
 
-  $version = (Split-Path ( Split-Path $url ) -Leaf).Substring(1)
-  $filename64 = Split-Path $url -Leaf
+  $version = if ($latestRelease.tag_name.StartsWith('v')) {
+      $latestRelease.tag_name.Substring(1)
+  }
+  else {
+      $latestRelease.tag_name
+  }
+  $filename64 = $asset.name
 
   $checksumAsset = $latestrelease.assets.browser_download_url | Where-Object { $_ -match "checksums\.txt$" } | select -First 1
   $checksum_page = Invoke-WebRequest -Uri $checksumAsset -UseBasicParsing

--- a/automatic/k9s/update.ps1
+++ b/automatic/k9s/update.ps1
@@ -25,15 +25,15 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $LatestRelease = Get-GitHubRelease -Owner "derailed" -Name "k9s"
 
   $re = '_Windows_x86_64\.tar.gz$'
-  $url = $download_page.links | ? href -match $re | % href | select -First 1
+  $url = $latestrelease.assets.browser_download_url | Where-Object { $_ -match $re } | select -First 1
 
   $version = (Split-Path ( Split-Path $url ) -Leaf).Substring(1)
   $filename64 = Split-Path $url -Leaf
 
-  $checksumAsset = $domain + ($download_page.Links | ? href -match "checksums\.txt$" | select -first 1 -expand href)
+  $checksumAsset = $latestrelease.assets.browser_download_url | Where-Object { $_ -match "checksums\.txt$" } | select -First 1
   $checksum_page = Invoke-WebRequest -Uri $checksumAsset -UseBasicParsing
 
   $checksum64 = [regex]::Match($checksum_page, "([a-f\d]+)\s*$([regex]::Escape($filename64))").Groups[1].Value


### PR DESCRIPTION
**(k9s) Switch AU to Get-GitHubRelease**

## Description
Switch the method used by update.ps1 to get the release download url from the GitHub releases pages from a simple _Invoke-WebRequest_ to _Get-GitHubRelease_ script 

## Motivation and Context
_update.ps1_ script no longer works ( fix #1999 ) because of the GitHub frontend changes ( #2007 )

## How Has this Been Tested?
Contains minimal changes tested locally

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).
