### PR TITLE
(1password) Fix to support version 8

### DIFF
--- a/automatic/1password/update.ps1
+++ b/automatic/1password/update.ps1
@@ -43,6 +43,8 @@ function Get-LatestOPW {
   $verRe = 'Setup-|word-|\.exe$'
   $version = $url32 -split $verRe | select -last 1 -skip 1
   $version = $version -replace ('\.BETA', ' beta')
+  $version = $version -replace ('\.NIGHTLY', 'nightly')
+  $version = $version -replace ('-', '.')
   $version = Get-Version $version
   $major = $version.ToString(1)
 
@@ -55,13 +57,15 @@ function Get-LatestOPW {
 
 $releases_opw4 = 'https://app-updates.agilebits.com/download/OPW4'
 $kind_opw4 = '1password4'
-$releases_opw = 'https://app-updates.agilebits.com/download/OPW7/Y'
+$releases_opw7 = 'https://app-updates.agilebits.com/download/OPW7/Y'
 $kind_opw = '1password'
+$releases_opw8 = 'https://app-updates.agilebits.com/download/OPW8/Y'
 
 function global:au_GetLatest {
   $streams = [ordered] @{
     OPW4 = Get-LatestOPW -url $releases_opw4 -kind $kind_opw4
-    OPW  = Get-LatestOPW -url $releases_opw -kind $kind_opw
+    OPW7 = Get-LatestOPW -url $releases_opw7 -kind $kind_opw
+    OPW8 = Get-LatestOPW -url $releases_opw8 -kind $kind_opw
   }
 
   return @{ Streams = $streams }


### PR DESCRIPTION
Fix for 1pawword8 https://github.com/chocolatey-community/chocolatey-packages/pull/1972

Adding the links to the redirection url and adding support for v8

## Motivation and Context
It will ad version 8 to the epository

## How Has this Been Tested?
./update.ps1

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).