### PR TITLE
(gitextensions) Fix update.ps1

### DIFF
--- a/automatic/gitextensions/update.ps1
+++ b/automatic/gitextensions/update.ps1
@@ -1,5 +1,4 @@
 Import-Module AU
-import-module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
 $softwareName = 'Git Extensions*'
 

--- a/automatic/gitextensions/update.ps1
+++ b/automatic/gitextensions/update.ps1
@@ -1,4 +1,5 @@
 Import-Module AU
+import-module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
 $softwareName = 'Git Extensions*'
 
@@ -19,27 +20,37 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri 'https://github.com/gitextensions/gitextensions/releases' -UseBasicParsing
+  $LatestRelease = Get-GitHubRelease -Owner "gitextensions" -Name "gitextensions"
 
-  $urls = $download_page.Links | ? href -match 'GitExtensions-(.+)\.msi$' | select -expand href | % { 'https://github.com' + $_ }
+  $re = 'GitExtensions-(.+)\.msi$'
+  $downloadUrl = $LatestRelease.assets.browser_download_url | Where-Object { $_ -match $re } | select -First 1
+  $releaseUrl = $LatestRelease.html_url
+  
+  $version = ($downloadUrl -split '\/' | select -last 1 -skip 1).Substring(1)
 
-  $streams = @{}
-  $urls | % {
-    $version = $_ -split '\/' | select -last 1 -skip 1
-    if ($version -match '\.[a-z][a-z\d]*$') {
-      $version = $version -replace '\.([a-z][a-z\d]*)$', "-`$1"
-    }
-    $version = Get-Version $version
+  $version = $version -replace ".RC", "-RC"
 
-    if (!($streams.ContainsKey($version.ToString(2)))) {
-      $streams.Add($version.ToString(2), @{
-          Version = $version.ToString()
-          URL32   = $_
-        })
-    }
+  if(($version.ToCharArray() | Where-Object {$_ -eq '.'} | Measure-Object).Count -eq 0) {
+    $version = $version + ".0.0"
+  } elseif(($version.ToCharArray() | Where-Object {$_ -eq '.'} | Measure-Object).Count -eq 1) {
+    $version = $version + ".0"
   }
 
-  return @{ Streams = $streams }
+  $pre = ""
+  if ($version -match '^.*(-.*?)\..*$') {
+    $pre = $version -replace '^.*(-.*?)\..*$', "`$1"
+    $version = $version -replace $pre, ""
+  }
+
+  $version = $version + $pre
+  
+  $version = Get-Version $version
+
+  return @{
+    Version        = $version
+    URL32          = $downloadUrl 
+    ReleaseURL     = $releaseUrl
+  }
 }
 
-Update-Package -ChecksumFor none
+update -ChecksumFor none


### PR DESCRIPTION
## Description
Fix the update.ps1 for gitextensions to correctly get the versions

## Motivation and Context
Currently updates are failing and there is a new unrelased version.
Fixes #2055 

## How Has this Been Tested?
Ran the update.ps1 and could see a v4 update

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
