### PR TITLE
updated qBittorrent to version 4.5.0, 32-bit version is no longer pro…

### DIFF
--- a/automatic/qbittorrent/qbittorrent.nuspec
+++ b/automatic/qbittorrent/qbittorrent.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>qbittorrent</id>
     <title>qBittorrent</title>
-    <version>4.4.5</version>
+    <version>4.5.0</version>
     <authors>Christophe Dumez</authors>
     <owners>chocolatey-community,nconrads</owners>
     <summary>qBittorrent is a free software cross-platform BitTorrent client GUI written with Qt4.</summary>
@@ -47,6 +47,7 @@ it for the BitTorrent protocol itself.
 ## Notes
 
 - This version includes the 64-bit version of qbittorrent, if you wish to continue using the 32-bit version you need to pass `--x86` when calling `choco install/update`
+- Beginning with v4.5.0, only 64-bit version is offered. If you choose to install the 32-bit version, you will get v4.4.5!
 
 ![qbittorrent screenshot](https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/798547edb9c6cb22a4a58e08361da4450f0ab14c/automatic/qbittorrent/screenshot.png)
 

--- a/automatic/qbittorrent/tools/VERIFICATION.txt
+++ b/automatic/qbittorrent/tools/VERIFICATION.txt
@@ -7,13 +7,13 @@ and can be verified like this:
 
 1. Download the following installers:
   32-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.4.5/qbittorrent_4.4.5_setup.exe/download>
-  64-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.4.5/qbittorrent_4.4.5_x64_setup.exe/download>
+  64-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.5.0/qbittorrent_4.5.0_x64_setup.exe/download>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
   checksum32: FEC32F28BD20C917298BC774D206B8B7D7C2B7B1645BF1742B0EF8477C0866AB
-  checksum64: EFB0298FAE1578033A334BA3ADBE0E93EA15239D623A26CE11F230EB0AF8654A
+  checksum64: 14ceeccc4473e02417726cd01614b6c1cc9556ab3aa899118552af82d69db22a
 
 File 'LICENSE.txt' is obtained from <https://github.com/qbittorrent/qBittorrent/blob/0070dcf5509e43c2c3457c4e3f1ed0b1ae087e36/COPYING>

--- a/automatic/qbittorrent/tools/chocolateyinstall.ps1
+++ b/automatic/qbittorrent/tools/chocolateyinstall.ps1
@@ -7,7 +7,7 @@ $packageArgs = @{
   fileType       = 'exe'
   softwareName   = 'qBittorrent*'
   file           = "$toolsDir\qbittorrent_4.4.5_setup.exe"
-  file64         = "$toolsDir\qbittorrent_4.4.5_x64_setup.exe"
+  file64         = "$toolsDir\qbittorrent_4.5.0_x64_setup.exe"
   silentArgs     = '/S'
   validExitCodes = @(0, 1223)
 }


### PR DESCRIPTION
qBittorrent update to version 4.5.0
For 64-bit version only, last 32-bit qBittorrent version will remain 4.4.5

## Description
I made necessary changes to files:
automatic/qbittorrent/qbittorrent.nuspec
automatic/qbittorrent/tools/VERIFICATION.txt
automatic/qbittorrent/tools/chocolateyinstall.ps1

## Motivation and Context
choco will update to 4.5.0 on 64-bit systems

## How Has this Been Tested?
powershell

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).