### PR TITLE
Fix package name replacements in python3-streams

### DIFF
--- a/automatic/python3-streams/python3-streams.nuspec
+++ b/automatic/python3-streams/python3-streams.nuspec
@@ -22,7 +22,7 @@ Copyright © 1991-1995 Stichting Mathematisch Centrum. All rights reserved.</cop
 - `/InstallDir32:` - Installation directory for 32bit python on 64bit Operating Systems. **NOTE**: Do only use this parameter if you wish to install 32bit python alongside 64bit python. 32Bit python will not be added on PATH.
 - `/NoLockdown` - Installation directory will not be locked down with Administrator only write permissions.
 
-Example: `choco install python312x --params "/InstallDir:C:\your\install\path"`
+Example: `choco install python312 --params "/InstallDir:C:\your\install\path"`
 
 ## Notes
 
@@ -33,7 +33,7 @@ Example: `choco install python312x --params "/InstallDir:C:\your\install\path"`
     <summary>Python 3.x is a programming language that lets you work more quickly and integrate your systems more effectively. You can learn to use Python 3.x and see almost immediate gains in productivity and lower maintenance costs.</summary>
     <tags>python programming development foss cross-platform admin</tags>
     <licenseUrl>https://docs.python.org/3.12/license.html</licenseUrl>
-    <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/python312-streams</packageSourceUrl>
+    <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/python3-streams</packageSourceUrl>
     <projectSourceUrl>https://www.python.org/downloads/source</projectSourceUrl>
     <dependencies>
       <dependency id="vcredist2015" version="14.0.24215.20170201" />

--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -9,7 +9,7 @@ if ($MyInvocation.MyCommand -ne '.') {
 function global:au_SearchReplace {
   @{
     ".\python3-streams.nuspec" = @{
-      "python3\d*" = $Latest.PackageName
+      "python3(\d+|x)" = $Latest.PackageName
     }
 
     ".\tools\helpers.ps1"      = @{


### PR DESCRIPTION
## Description
Fixed the issues with package name replacements in python3-streams package that I mentioned in #1993.

## Motivation and Context
The package is failing automated package testing on Chocolatey Community Repository.

## How Has this Been Tested?
Checked the artifacts generated by AppVeyor

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
