### PR TITLE
qBittorrent update to version 4.5.0

### DIFF
--- a/automatic/qbittorrent/Readme.md
+++ b/automatic/qbittorrent/Readme.md
@@ -39,6 +39,7 @@ it for the BitTorrent protocol itself.
 ## Notes
 
 - This version includes the 64-bit version of qbittorrent, if you wish to continue using the 32-bit version you need to pass `--x86` when calling `choco install/update`
+- Beginning with v4.5.0, only 64-bit version is offered. If you have the 32-bit version installed, pin the version to 4.4.5 with command `choco pin add --name="'qbittorrent'" --version="'4.4.5'"`
 
 ![qbittorrent screenshot](https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/798547edb9c6cb22a4a58e08361da4450f0ab14c/automatic/qbittorrent/screenshot.png)
 

--- a/automatic/qbittorrent/qbittorrent.nuspec
+++ b/automatic/qbittorrent/qbittorrent.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>qbittorrent</id>
     <title>qBittorrent</title>
-    <version>4.5.0</version>
+    <version>4.4.5</version>
     <authors>Christophe Dumez</authors>
     <owners>chocolatey-community,nconrads</owners>
     <summary>qBittorrent is a free software cross-platform BitTorrent client GUI written with Qt4.</summary>
@@ -47,7 +47,6 @@ it for the BitTorrent protocol itself.
 ## Notes
 
 - This version includes the 64-bit version of qbittorrent, if you wish to continue using the 32-bit version you need to pass `--x86` when calling `choco install/update`
-- Beginning with v4.5.0, only 64-bit version is offered. If you have the 32-bit version installed, pin the version to 4.4.5 with command `choco pin add --name="'qbittorrent'" --version="'4.4.5'"`
 
 ![qbittorrent screenshot](https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/798547edb9c6cb22a4a58e08361da4450f0ab14c/automatic/qbittorrent/screenshot.png)
 

--- a/automatic/qbittorrent/qbittorrent.nuspec
+++ b/automatic/qbittorrent/qbittorrent.nuspec
@@ -47,7 +47,7 @@ it for the BitTorrent protocol itself.
 ## Notes
 
 - This version includes the 64-bit version of qbittorrent, if you wish to continue using the 32-bit version you need to pass `--x86` when calling `choco install/update`
-- Beginning with v4.5.0, only 64-bit version is offered. If you choose to install the 32-bit version, you will get v4.4.5!
+- Beginning with v4.5.0, only 64-bit version is offered. If you have the 32-bit version installed, pin the version to 4.4.5 with command `choco pin add --name="'qbittorrent'" --version="'4.4.5'"`
 
 ![qbittorrent screenshot](https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/798547edb9c6cb22a4a58e08361da4450f0ab14c/automatic/qbittorrent/screenshot.png)
 

--- a/automatic/qbittorrent/qbittorrent.nuspec
+++ b/automatic/qbittorrent/qbittorrent.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>qbittorrent</id>
     <title>qBittorrent</title>
-    <version>4.4.5</version>
+    <version>4.5.0</version>
     <authors>Christophe Dumez</authors>
     <owners>chocolatey-community,nconrads</owners>
     <summary>qBittorrent is a free software cross-platform BitTorrent client GUI written with Qt4.</summary>
@@ -47,6 +47,7 @@ it for the BitTorrent protocol itself.
 ## Notes
 
 - This version includes the 64-bit version of qbittorrent, if you wish to continue using the 32-bit version you need to pass `--x86` when calling `choco install/update`
+- Beginning with v4.5.0, only 64-bit version is offered. If you choose to install the 32-bit version, you will get v4.4.5!
 
 ![qbittorrent screenshot](https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/798547edb9c6cb22a4a58e08361da4450f0ab14c/automatic/qbittorrent/screenshot.png)
 

--- a/automatic/qbittorrent/tools/VERIFICATION.txt
+++ b/automatic/qbittorrent/tools/VERIFICATION.txt
@@ -14,6 +14,6 @@ and can be verified like this:
 
   checksum type: sha256
   checksum32: FEC32F28BD20C917298BC774D206B8B7D7C2B7B1645BF1742B0EF8477C0866AB
-  checksum64: 14ceeccc4473e02417726cd01614b6c1cc9556ab3aa899118552af82d69db22a
+  checksum64: 14CEECCC4473E02417726CD01614B6C1CC9556AB3AA899118552AF82D69DB22A
 
 File 'LICENSE.txt' is obtained from <https://github.com/qbittorrent/qBittorrent/blob/0070dcf5509e43c2c3457c4e3f1ed0b1ae087e36/COPYING>

--- a/automatic/qbittorrent/tools/VERIFICATION.txt
+++ b/automatic/qbittorrent/tools/VERIFICATION.txt
@@ -7,13 +7,13 @@ and can be verified like this:
 
 1. Download the following installers:
   32-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.4.5/qbittorrent_4.4.5_setup.exe/download>
-  64-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.4.5/qbittorrent_4.4.5_x64_setup.exe/download>
+  64-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.5.0/qbittorrent_4.5.0_x64_setup.exe/download>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
   checksum32: FEC32F28BD20C917298BC774D206B8B7D7C2B7B1645BF1742B0EF8477C0866AB
-  checksum64: EFB0298FAE1578033A334BA3ADBE0E93EA15239D623A26CE11F230EB0AF8654A
+  checksum64: 14ceeccc4473e02417726cd01614b6c1cc9556ab3aa899118552af82d69db22a
 
 File 'LICENSE.txt' is obtained from <https://github.com/qbittorrent/qBittorrent/blob/0070dcf5509e43c2c3457c4e3f1ed0b1ae087e36/COPYING>

--- a/automatic/qbittorrent/tools/VERIFICATION.txt
+++ b/automatic/qbittorrent/tools/VERIFICATION.txt
@@ -6,14 +6,12 @@ The installer have been downloaded from the alternative sourceforge mirror liste
 and can be verified like this:
 
 1. Download the following installers:
-  32-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.4.5/qbittorrent_4.4.5_setup.exe/download>
-  64-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.5.0/qbittorrent_4.5.0_x64_setup.exe/download>
+  64-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.4.5/qbittorrent_4.4.5_x64_setup.exe/download>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum32: FEC32F28BD20C917298BC774D206B8B7D7C2B7B1645BF1742B0EF8477C0866AB
-  checksum64: 14CEECCC4473E02417726CD01614B6C1CC9556AB3AA899118552AF82D69DB22A
+  checksum64: EFB0298FAE1578033A334BA3ADBE0E93EA15239D623A26CE11F230EB0AF8654A
 
 File 'LICENSE.txt' is obtained from <https://github.com/qbittorrent/qBittorrent/blob/0070dcf5509e43c2c3457c4e3f1ed0b1ae087e36/COPYING>

--- a/automatic/qbittorrent/tools/chocolateyinstall.ps1
+++ b/automatic/qbittorrent/tools/chocolateyinstall.ps1
@@ -7,7 +7,7 @@ $packageArgs = @{
   fileType       = 'exe'
   softwareName   = 'qBittorrent*'
   file           = "$toolsDir\qbittorrent_4.4.5_setup.exe"
-  file64         = "$toolsDir\qbittorrent_4.4.5_x64_setup.exe"
+  file64         = "$toolsDir\qbittorrent_4.5.0_x64_setup.exe"
   silentArgs     = '/S'
   validExitCodes = @(0, 1223)
 }

--- a/automatic/qbittorrent/tools/chocolateyinstall.ps1
+++ b/automatic/qbittorrent/tools/chocolateyinstall.ps1
@@ -1,4 +1,9 @@
-﻿$ErrorActionPreference = 'Stop'
+﻿$is64bit = Test-Path 'Env:ProgramFiles(x86)'
+if (-Not $is64bit) {
+  Write-Host "WARNING! qBittorrent is no longer available in 32-bit after version 4.4.5, pin the package version to 4.4.5 with command ``choco pin add --name=`"'qbittorrent'`" --version=`"'4.4.5'`"``"
+}
+
+$ErrorActionPreference = 'Stop'
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 

--- a/automatic/qbittorrent/tools/chocolateyinstall.ps1
+++ b/automatic/qbittorrent/tools/chocolateyinstall.ps1
@@ -1,9 +1,9 @@
-﻿$is64bit = Test-Path 'Env:ProgramFiles(x86)'
-if (-Not $is64bit) {
+﻿$ErrorActionPreference = 'Stop'
+
+$is32bit = Get-OSArchitectureWidth
+if ($is32bit -eq '32') {
   Write-Host "WARNING! qBittorrent is no longer available in 32-bit after version 4.4.5, pin the package version to 4.4.5 with command ``choco pin add --name=`"'qbittorrent'`" --version=`"'4.4.5'`"``"
 }
-
-$ErrorActionPreference = 'Stop'
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
@@ -12,7 +12,7 @@ $packageArgs = @{
   fileType       = 'exe'
   softwareName   = 'qBittorrent*'
   file           = "$toolsDir\qbittorrent_4.4.5_setup.exe"
-  file64         = "$toolsDir\qbittorrent_4.5.0_x64_setup.exe"
+  file64         = "$toolsDir\qbittorrent_4.4.5_x64_setup.exe"
   silentArgs     = '/S'
   validExitCodes = @(0, 1223)
 }

--- a/automatic/qbittorrent/tools/chocolateyinstall.ps1
+++ b/automatic/qbittorrent/tools/chocolateyinstall.ps1
@@ -1,8 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$is32bit = Get-OSArchitectureWidth
-if ($is32bit -eq '32') {
-  Write-Host "WARNING! qBittorrent is no longer available in 32-bit after version 4.4.5, pin the package version to 4.4.5 with command ``choco pin add --name=`"'qbittorrent'`" --version=`"'4.4.5'`"``"
+if (Get-OSArchitectureWidth -Compare 32) {
+  throw "qBittorrent is no longer available in 32-bit after version 4.4.5, pin the package version to 4.4.5 with command ``choco pin add --name=`"'qbittorrent'`" --version=`"'4.4.5'`"``"
 }
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/automatic/qbittorrent/tools/chocolateyinstall.ps1
+++ b/automatic/qbittorrent/tools/chocolateyinstall.ps1
@@ -10,7 +10,6 @@ $packageArgs = @{
   packageName    = 'qbittorrent'
   fileType       = 'exe'
   softwareName   = 'qBittorrent*'
-  file           = "$toolsDir\qbittorrent_4.4.5_setup.exe"
   file64         = "$toolsDir\qbittorrent_4.4.5_x64_setup.exe"
   silentArgs     = '/S'
   validExitCodes = @(0, 1223)

--- a/automatic/qbittorrent/update.ps1
+++ b/automatic/qbittorrent/update.ps1
@@ -7,14 +7,11 @@ function global:au_BeforeUpdate { Get-RemoteFiles -Purge -FileNameSkip 1 -NoSuff
 function global:au_SearchReplace {
   @{
     ".\tools\chocolateyInstall.ps1" = @{
-      "(?i)(^\s*file\s*=\s*`"[$]toolsDir\\).*" = "`${1}$($Latest.FileName32)`""
       "(?i)(^\s*file64\s*=\s*`"[$]toolsDir\\).*" = "`${1}$($Latest.FileName64)`""
     }
     ".\tools\verification.txt" = @{
-      "(?i)(32-Bit.+)\<.*\>" = "`${1}<$($Latest.URL32)>"
       "(?i)(64-Bit.+)\<.*\>" = "`${1}<$($Latest.URL64)>"
-      "(?i)(checksum type:\s+).*" = "`${1}$($Latest.ChecksumType32)"
-      "(?i)(checksum32:\s+).*" = "`${1}$($Latest.Checksum32)"
+      "(?i)(checksum type:\s+).*" = "`${1}$($Latest.ChecksumType64)"
       "(?i)(checksum64:\s+).*" = "`${1}$($Latest.Checksum64)"
     }
   }
@@ -33,22 +30,14 @@ function global:au_GetLatest {
   }
 
   $re    = 'setup\.exe\/download$'
-  $urls  = $download_page.links | ? href -match $re | select -First 2 -expand href
-  $url32 = $urls | ? { $_ -notmatch "x64" }  | select -first 1
+  $urls  = $download_page.links | ? href -match $re | select -First 1 -expand href
   $url64 = $urls | ? { $_ -match "x64" } | select -first 1
 
-  $version   = $url32 -split '[_]' | select -Last 1 -Skip 1
   $version64 = $url64 -split '[_]' | select -Last 1 -Skip 2
 
-#  Beginning with v4.5.0, only 64-bit version is avalable, so this check is not needed anymore.
-#  if ($version -ne $version64) {
-#    throw "32-bit and 64-bit version do not match. Please investigate."
-#  }
-
   return @{
-    URL32    = $url32
     URL64    = $url64
-    Version  = $version
+    Version  = $version64
     FileType = 'exe'
   }
 }

--- a/automatic/qbittorrent/update.ps1
+++ b/automatic/qbittorrent/update.ps1
@@ -40,9 +40,10 @@ function global:au_GetLatest {
   $version   = $url32 -split '[_]' | select -Last 1 -Skip 1
   $version64 = $url64 -split '[_]' | select -Last 1 -Skip 2
 
-  if ($version -ne $version64) {
-    throw "32-bit and 64-bit version do not match. Please investigate."
-  }
+#  Beginning with v4.5.0, only 64-bit version is avalable, so this check is not needed anymore.
+#  if ($version -ne $version64) {
+#    throw "32-bit and 64-bit version do not match. Please investigate."
+#  }
 
   return @{
     URL32    = $url32


### PR DESCRIPTION
qBittorrent update to version 4.5.0
For 64-bit version only, last 32-bit qBittorrent version will remain 4.4.5

## Description
I made necessary changes to files:
automatic/qbittorrent/Readme.md
automatic/qbittorrent/tools/VERIFICATION.txt
automatic/qbittorrent/tools/chocolateyinstall.ps1
automatic/qbittorrent/update.ps1

## Motivation and Context
choco will update to 4.5.0 on 64-bit systems

Fixes #2073

## How Has this Been Tested?
powershell

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).