### PR TITLE
(audacity) Fix file name changed for installer

### DIFF
--- a/automatic/audacity/update.ps1
+++ b/automatic/audacity/update.ps1
@@ -11,7 +11,7 @@ function global:au_SearchReplace {
     }
 
     '.\legal\VERIFICATION.txt'      = @{
-      '(?i)(Go to.*)<.*>'   = "`${1} <$($releases)>"
+      '(?i)(Go to).*<.*>'   = "`${1} <$($releases)>"
       '(?i)(\s+x32:).*'     = "`${1} $($Latest.URL32)"
       '(?i)(\s+x64:).*'     = "`${1} $($Latest.URL64)"
       '(?i)(checksum32:).*' = "`${1} $($Latest.Checksum32)"
@@ -30,10 +30,10 @@ function global:au_GetLatest {
 
   $installers = $download_page.Links | Where-Object href -Match 'github.*\.exe$' | Select-Object -ExpandProperty href
 
-  $url64 = $installers | Where-Object { $_ -match '-64bit' } | Select-Object -First 1
+  $url64 = $installers | Where-Object { $_ -match '-64bit|-x64' } | Select-Object -First 1
   $version = $url64 -split '/' | Select-Object -Last 1 -Skip 1
   $version = $version.Replace('Audacity-', '')
-  $url32 = $installers | Where-Object { $_ -match "-32bit" } | Select-Object -First 1
+  $url32 = $installers | Where-Object { $_ -match "-32bit|-x32" } | Select-Object -First 1
 
   @{
     URL32   = $url32


### PR DESCRIPTION
## Description

This pull request fixes the updater to find the correct download URLs based on the new file name for the executables.
Without this change the binary files can not be found.

## Motivation and Context

To have a working updater.

## How Has this Been Tested?

1. Tested locally by running `.\update_all.ps1 audacity`

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
