### PR TITLE
(cygwin) Remove 32bit installation support

### DIFF
--- a/automatic/cygwin/Changelog.md
+++ b/automatic/cygwin/Changelog.md
@@ -3,6 +3,7 @@
 ## Upcoming
 
 - **BREAKING CHANGE:** Removed support for 32bit installation
+- **BREAKING CHANGE:** Remove dependencies used for compatibility
 
 ## Version: 3.0.7.20191022
 

--- a/automatic/cygwin/Changelog.md
+++ b/automatic/cygwin/Changelog.md
@@ -1,5 +1,9 @@
 # Package changelog for [cygwin](https://chocolatey.org/packages/cygwin)
 
+## Upcoming
+
+- **BREAKING CHANGE:** Removed support for 32bit installation
+
 ## Version: 3.0.7.20191022
 
 - **BUGS:** Fixed permission bug when package was installed when `$Env:ChocolateyToolsLocation` wasn't created yet [#1291](https://github.com/chocolatey-community/chocolatey-coreteampackages/issues/1291)

--- a/automatic/cygwin/cygwin.nuspec
+++ b/automatic/cygwin/cygwin.nuspec
@@ -44,10 +44,6 @@ Example: `choco install cygwin --params "/InstallDir:C:\your\install\path /NoSta
     </releaseNotes>
     <mailingListUrl>https://cygwin.com/lists.html</mailingListUrl>
     <projectSourceUrl>https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git</projectSourceUrl>
-    <dependencies>
-      <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="chocolatey" version="0.10.5" />
-    </dependencies>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/cygwin/legal/VERIFICATION.txt
+++ b/automatic/cygwin/legal/VERIFICATION.txt
@@ -7,7 +7,7 @@ location on <https://cygwin.com/>
 and can be verified by doing the following:
 
 1. Download the following:
-  32-Bit software: <https://cygwin.com/setup-x86.exe>
+  32-Bit software: NO LONGER SUPPORTED
   64-Bit software: <https://cygwin.com/setup-x86_64.exe>
 2. Get the checksum using one of the following methods:
   - Using powershell function 'Get-FileHash'
@@ -15,7 +15,7 @@ and can be verified by doing the following:
 3. The checksums should match the following:
 
   checksum type: sha256
-  checksum32: EC92025B2EBF22DFDECA292CFC50C7A126ED9F1610D72D87B0859A6977FB8D55
+  checksum32: NO LONGER SUPPORTED
   checksum64: CF57CA7AC4E1F57B5D152F310FB82FB0CE8E500BFF261E46B89FEBC673D04210
 
 The file 'LICENSE.txt' has been obtained from <https://cygwin.com/COPYING>

--- a/automatic/cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/cygwin/tools/chocolateyInstall.ps1
@@ -1,5 +1,9 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) {
+  throw "32bit installation is no longer supported. Please install version 3.3.6 if this is needed."
+}
+
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 $pp = Get-PackageParameters
 $toolsLocation = Get-ToolsLocation
@@ -41,7 +45,7 @@ $silentArgs = @(
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
-  file           = "$toolsPath\setup-x86.exe"
+  file           = ''
   file64         = "$toolsPath\setup-x86_64.exe"
   softwareName   = 'Cygwin*'
   silentArgs     = $silentArgs
@@ -52,7 +56,7 @@ Install-ChocolateyInstallPackage @packageArgs
 Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
-$setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
+$setup_path = $packageArgs.file64
 Move-Item $setup_path $cygwin_root\cygwinsetup.exe -Force
 
 Get-ChildItem $toolsPath\*.exe | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" "" }}

--- a/automatic/cygwin/update.ps1
+++ b/automatic/cygwin/update.ps1
@@ -18,14 +18,11 @@ function global:au_SearchReplace {
     }
     ".\legal\VERIFICATION.txt"      = @{
       "(?i)(^\s*location on\:?\s*)\<.*\>" = "`${1}<$releases>"
-      "(?i)(\s*32\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL32)>"
       "(?i)(\s*64\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL64)>"
-      "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType32)"
-      "(?i)(^\s*checksum(32)?\:).*"       = "`${1} $($Latest.Checksum32)"
+      "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType64)"
       "(?i)(^\s*checksum64\:).*"          = "`${1} $($Latest.Checksum64)"
     }
     ".\tools\chocolateyInstall.ps1" = @{
-      "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\).*"   = "`${1}$($Latest.FileName32)`""
       "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName64)`""
     }
   }
@@ -38,13 +35,14 @@ function global:au_GetLatest {
   $url = $download_page.links | ? href -match $re | select -First 2 -expand href | % { $releases + $_ }
   $rn = $download_page.links | ? href -match 'announce'
 
-  @{
-    URL32        = $url -notmatch 'x86_64' | select -First 1
-    URL64        = $url -match 'x86_64' | select -First 1
+  $result = @{
+    URL64        = $url | ? {$_ -match 'x86_64' } | select -First 1
     ReleaseNotes = $rn.href
     Version      = $rn.innerText
     PackageName  = 'Cygwin'
   }
+
+  $result
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
## Description

The main purpose of this pull request is to remove support for 32bit installation, which according to their latest changelog is no longer supported upstream.
Additionally, dependencies that only existing to provide compatibility support for versions older than Chocolatey CLI 0.11.0 has been removed as we no longer
support any versions that old.

## Motivation and Context

To be able to update the package.

## How Has this Been Tested?

1. Run `.\update_all.ps1 cygwin`

Additionally, using the test environment:

1. Run `choco install cygwin --source 'Location_of_your_built_package'
2. Ensure it installs successfully
3. Run `choco uninstall cygwin`
4. Ensure it uninstalls successfully
5. Run `choco install cygwin --x86 --source 'Location_of_your_built_package'
6. Ensure it fails with a message saying `32bit installation is no longe supported.`

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
