### PR TITLE
(etcd) Fix update script

### DIFF
--- a/scripts/Get-AllGitHubReleases.ps1
+++ b/scripts/Get-AllGitHubReleases.ps1
@@ -1,0 +1,38 @@
+﻿function Get-AllGitHubReleases {
+  <#
+    .SYNOPSIS
+      Get all of the releases of the given GitHub repository (may be limited by GitHub themself).
+
+    .EXAMPLE
+      Get-AllGitHubReleases etcd-io etcd
+  #>
+  [CmdletBinding()]
+  param(
+    # Repository owner
+    [Parameter(Mandatory, Position = 0)]
+    [string]$Owner,
+
+    # Repository name
+    [Parameter(Mandatory, Position = 1)]
+    [string]$Name,
+
+    # GitHub token, used to reduce rate-limiting or access private repositories (needs repo scope)
+    [string]$Token = "$($env:github_api_key)"
+  )
+  end {
+    $apiUrl = "https://api.github.com/repos/$Owner/$Name/releases"
+
+    $Request = @{
+      Uri = $apiUrl
+    }
+
+    if (-not [string]::IsNullOrEmpty($Token)) {
+      $Request.Headers = @{
+        Accept        = 'application/vnd.github+json'
+        Authorization = "Bearer $($Token)"
+      }
+    }
+
+    Invoke-RestMethod @Request
+  }
+}

--- a/scripts/au_extensions.psm1
+++ b/scripts/au_extensions.psm1
@@ -7,6 +7,7 @@
 $funcs = @(
   'Add-Dependency'
   'Clear-DependenciesList'
+  'Get-AllGitHubReleases'
   'Get-GitHubRelease'
   'Set-DescriptionFromReadme'
   'Update-ChangelogVersion'


### PR DESCRIPTION
## Description

This pull request fixes the update script for the etcd package by introducing a new helper to acquire github releases.
This new helpers grabs all of the github releases (may be limited by github themself).

## Motivation and Context

To have a working package

## How Has this Been Tested?

1. Run `.\update_all.ps1 etcd`

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).