### PR TITLE
(python3-streams) Drop temporary disables in Python packages

### DIFF
--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -133,9 +133,7 @@ function GetStreams() {
 
   $streams = @{ }
 
-  # Temporarily limit the amount of streams. This limit should be removed on
-  # first package approval (First stream is a pre-release)
-  $latest_versions.GetEnumerator() | Select-Object -First 2 | ForEach-Object {
+  $latest_versions.GetEnumerator() | ForEach-Object {
     $minor_version = $_.Name
     $latest_version = $_.Value
     $versionTwoPart = "3.$minor_version"


### PR DESCRIPTION
## Description
A follow-up to #1993, [python311](https://community.chocolatey.org/packages/python311) package was approved yesterday, we can drop previous limitations :tada: 

Hopefully, you don't mind this PR, I wasn't sure if it was fine for me to make this or if I should have just left it to maintainers.

## Motivation and Context
This was a temporary measure while we were waiting for python311 package to get pushed to and approved on the community repository.

## How Has this Been Tested?
It hasn't, I assume it was tested when it was committed to #1993.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
