### PR TITLE
(mpc-hc-clsid2) Fixes Mixed URLs

### DIFF
--- a/automatic/mpc-hc-clsid2/update.ps1
+++ b/automatic/mpc-hc-clsid2/update.ps1
@@ -5,7 +5,7 @@ function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt"      = @{
-      "(?i)(^\s*location on\:?\s*)\<.*\>" = "`${1}<$releases>"
+      "(?i)(^\s*location on\:?\s*)\<.*\>" = "`${1}<$($Latest.ReleaseUrl)>"
       "(?i)(\s*32\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL32)>"
       "(?i)(\s*64\-Bit Software.*)\<.*\>" = "`${1}<$($Latest.URL64)>"
       "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType32)"
@@ -23,9 +23,10 @@ function global:au_GetLatest {
   $LatestRelease = Get-GitHubRelease clsid2 mpc-hc
 
   @{
-    URL32   = $LatestRelease.assets | Where-Object {$_.name -match 'x64\.exe$'} | Select-Object -ExpandProperty browser_download_url
-    URL64   = $LatestRelease.assets | Where-Object {$_.name -match 'x86\.exe$'} | Select-Object -ExpandProperty browser_download_url
-    Version = $LatestRelease.tag_name.TrimStart("v")
+    URL32      = $LatestRelease.assets | Where-Object {$_.name -match 'x86\.exe$'} | Select-Object -ExpandProperty browser_download_url
+    URL64      = $LatestRelease.assets | Where-Object {$_.name -match 'x64\.exe$'} | Select-Object -ExpandProperty browser_download_url
+    Version    = $LatestRelease.tag_name.TrimStart("v")
+    ReleaseUrl = $LatestRelease.html_url
   }
 }
 


### PR DESCRIPTION
## Description
Reverses the x86 and x64 installer matching that I'd reversed.

## Motivation and Context
During the refactoring of a bunch of packages on Community Day, I pushed an update refactor that changed how we grabbed releases from GitHub and mixed up the x86 and x64 installer regexes. This sorts that out, as well as providing a release URL to add to the verification file.

Fixes #2095

## How Has this Been Tested?
Tested with a local run of `.\update_all.ps1 mpc-hc-clsid2 -ForcedPackages mpc-hc-clsid2`, double checking all resulting changes to the files on disk.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
