### PR TITLE
(python3-streams) improve reliability of docs zip URL

### DIFF
--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -141,7 +141,11 @@ function GetStreams() {
 
     $urls = $all_versions[$latest_version]
     $zip_name = "python-$latest_version-docs-text"
-    $zip_url = "https://docs.python.org/$versionTwoPart/archives/$zip_name.zip"
+    if ($version.Prerelease -eq "" -or $version.Prerelease.StartsWith("rc")) {
+      $zip_url = "https://www.python.org/ftp/python/doc/$latest_version/$zip_name.zip"
+    } else {
+      $zip_url = "https://docs.python.org/$versionTwoPart/archives/$zip_name.zip"
+    }
     $license_url = "https://docs.python.org/$versionTwoPart/license.html"
     $streams[$versionTwoPart] = @{
       URL32          = $urls['86']


### PR DESCRIPTION
## Description

As it turns out, docs archives for EOL releases at docs.python.org do eventually get evicted. Therefore, I used the more reliable ftp.python.org instead. Note that I still had to keep the old docs.python.org for the version that's currently in development (3.12 right now) as the documentation on ftp.python.org only starts to appear when the RC phase starts. This is described in more detail in the "Doing Python Releases 101" document at https://peps.python.org/pep-0101/

Note that it is unlikely to ever get hit in the future once each package has at least one version since then it would simply never get to the point of downloading a zip for such an old release since it would have already been on Chocolatey by that point and update script would skip it due to no new version being available.

@AdmiringWorm turns out there's one more bump on the road 😄 

## Motivation and Context
python3-streams script doesn't work currently due to a 404 error when trying to download docs zip for 3.5.

## How Has this Been Tested?
I ran `./update.ps1` locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
