### PR TITLE
(gitextensions) Add .NET 6 dependency

### DIFF
--- a/automatic/gitextensions/gitextensions.nuspec
+++ b/automatic/gitextensions/gitextensions.nuspec
@@ -47,7 +47,7 @@
     <dependencies>
       <dependency id="git" version="2.17.1.2" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="dotnet4.6.1" version="4.6.01055.20170308" />
+      <dependency id="dotnet-6.0-desktopruntime" version="6.0.13" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
## Description
Added .NET 6 dependency for Git Extensions.

Fixes #2111 

## Motivation and Context
Git Extensions now requires .NET 6.

## How Has this Been Tested?
1. Ran current `gitextensions` install and saw it failed, just like #2111 indicates.
2. Installed the `dotnet-6.0-desktopruntime` package.
3. Ran Git Extensions again and it worked.
4. Added dependency to the .nuspec file.
5. Created a test package using new dependency.
6. Installed test package.
7. Everything worked as it should.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).