### PR TITLE
(openshift-cli) Remove invalid mailingListUrl

### DIFF
--- a/automatic/openshift-cli/openshift-cli.nuspec
+++ b/automatic/openshift-cli/openshift-cli.nuspec
@@ -15,7 +15,6 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/openshift/origin</projectSourceUrl>
     <docsUrl>https://docs.openshift.org/latest/welcome/index.html</docsUrl>
-    <mailingListUrl>https://lists.openshift.redhat.com/openshiftmm/listinfo</mailingListUrl>
     <bugTrackerUrl>https://github.com/openshift/origin/issues</bugTrackerUrl>
     <tags>openshift docker kubernetes containers development devops cli foss</tags>
     <summary>OpenShift Origin is a distribution of Kubernetes optimized for continuous application development and multi-tenant deployment. OpenShift Origin is the open source upstream project that powers OpenShift, Red Hat's container application platform.</summary>


### PR DESCRIPTION
## Description
The `mailingListUrl` is now invalid so it was removed.

**Once this is merged, the package will need to be pushed again.**

Fixes #2124 

## Motivation and Context
Package is failing Package Validator with an invalid `mailingListUrl`

## How Has this Been Tested?
It hasn't been tested. The line containing the `mailingListUrl` was removed from the .nuspec file.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).