### PR TITLE
(ghostscript)(ghostscript.app) Fixed validation failures

### DIFF
--- a/automatic/ghostscript.app/ghostscript.app.nuspec
+++ b/automatic/ghostscript.app/ghostscript.app.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>http://www.gnu.org/licenses/agpl-3.0.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>http://git.ghostscript.com/?p=ghostpdl.git;a=summary</projectSourceUrl>
-    <docsUrl>http://www.ghostscript.com/doc/10.0.0/Readme.htm</docsUrl>
+    <docsUrl>https://ghostscript.readthedocs.io/en/latest/</docsUrl>
     <bugTrackerUrl>https://bugs.ghostscript.com/</bugTrackerUrl>
     <tags>ghostscript.app ghostscript postscript admin foss cross-platform</tags>
     <summary>an interpreter for the PostScript language and for PDF.</summary>
@@ -33,7 +33,7 @@ Ghostscript has been under active development for over 20 years, and offers an e
 
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 ]]></description>
-    <releaseNotes>https://ghostscript.com/doc/10.0.0/History10.htm</releaseNotes>
+    <releaseNotes>https://ghostscript.readthedocs.io/en/latest/News.html</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
     </dependencies>

--- a/automatic/ghostscript.app/update.ps1
+++ b/automatic/ghostscript.app/update.ps1
@@ -10,8 +10,6 @@ function global:au_BeforeUpdate {
 
 function global:au_SearchReplace {
   [version]$version = $Latest.RemoteVersion
-  $docsUrl = "http://www.ghostscript.com/doc/$($version)/Readme.htm"
-  $releaseNotesUrl = "https://ghostscript.com/doc/$($version)/History$($version.Major).htm"
   @{
     ".\legal\VERIFICATION.txt"        = @{
       "(?i)(^\s*location on\:?\s*)\<.*\>" = "`${1}<$releases>"
@@ -28,10 +26,6 @@ function global:au_SearchReplace {
     }
     ".\tools\chocolateyUninstall.ps1" = @{
       "(?i)^(\s*softwareName\s*=\s*)'.*'" = "`${1}'$softwareName'"
-    }
-    ".\Ghostscript.app.nuspec" = @{
-      "(?i)(^\s*\<docsUrl\>).*(\<\/docsUrl\>)" = "`${1}$docsUrl`${2}"
-      "(?i)(^\s*\<releaseNotes\>).*(\<\/releaseNotes\>)" ` = "`${1}$releaseNotesUrl`${2}"
     }
   }
 }

--- a/automatic/ghostscript/ghostscript.nuspec
+++ b/automatic/ghostscript/ghostscript.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>http://www.gnu.org/licenses/agpl-3.0.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>http://git.ghostscript.com/?p=ghostpdl.git;a=summary</projectSourceUrl>
-    <docsUrl>http://www.ghostscript.com/doc/10.0.0/Readme.htm</docsUrl>
+    <docsUrl>https://ghostscript.readthedocs.io/en/latest/</docsUrl>
     <bugTrackerUrl>https://bugs.ghostscript.com/</bugTrackerUrl>
     <tags>ghostscript.app ghostscript postscript admin foss cross-platform</tags>
     <summary>an interpreter for the PostScript language and for PDF.</summary>
@@ -30,7 +30,7 @@
 
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 ]]></description>
-    <releaseNotes>https://ghostscript.com/doc/10.0.0/History10.htm</releaseNotes>
+    <releaseNotes>https://ghostscript.readthedocs.io/en/latest/News.html</releaseNotes>
     <dependencies>
       <dependency id="ghostscript.app" version="[10.0.0]" />
     </dependencies>

--- a/automatic/ghostscript/update.ps1
+++ b/automatic/ghostscript/update.ps1
@@ -2,13 +2,9 @@
 
 function global:au_SearchReplace {
   [version]$version = $Latest.RemoteVersion
-  $docsUrl = "http://www.ghostscript.com/doc/$($version)/Readme.htm"
-  $releaseNotesUrl = "https://ghostscript.com/doc/$($version)/History$($version.Major).htm"
   @{
     ".\Ghostscript.nuspec" = @{
       "(\<dependency .+?`"$($Latest.PackageName).app`" version=)`"([^`"]+)`"" = "`$1`"[$($Latest.Version)]`""
-      "(?i)(^\s*\<docsUrl\>).*(\<\/docsUrl\>)" = "`${1}$docsUrl`${2}"
-      "(?i)(^\s*\<releaseNotes\>).*(\<\/releaseNotes\>)" ` = "`${1}$releaseNotesUrl`${2}"
     }
   }
 }


### PR DESCRIPTION
## Description
The docsUrl and releaseNotes URLs now point to a fixed readthedocs.io page. The use of version numbers in the URLs are no longer needed and are removed from the automatic update script.

Fixes #2127 

## Motivation and Context
Packages are failing Package Validator due to invalid URLs.

## How Has this Been Tested?
Not tested as this is only changes to the package metadata.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
