### PR TITLE
(totalcommander) Fix and update package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,7 @@
 */jenkins*            @chocolatey-community/chocolatey-team-maintainers
 */brave*              @AdmiringWorm
 */nexus-repository*   @chocolatey-community/chocolatey-team-maintainers
+*/totalcommander*     @pauby
 
 # Other
 # This can be any file other that won't be matched as a package

--- a/automatic/totalcommander/README.md
+++ b/automatic/totalcommander/README.md
@@ -30,9 +30,10 @@ But Total Commander uses a different approach: it has two fixed windows, which m
 
 The following package parameters can be set:
 
-* `/DesktopIcon` - Add an icon for Total Commander to the Desktop. By default no icon is added.
-* `/InstallPath` - Use custom install path. By default Total Commander is installed to the `%ProgramFiles%\totalcmd` directory.
-* `/DefaultFM`   - Use TC as default file manager instead of Explorer. Use `/DefaultFM:explorer` to return to Explorer.
+* `/NoDesktopIcon`  - Do not add an icon for Total Commander to the Desktop. By default an icon is added.
+* `/InstallPath`    - Use custom install path. By default Total Commander is installed to the `%ProgramFiles%\totalcmd` directory.
+* `/DefaultFM`      - Use TC as default file manager instead of Explorer. You cannot use this with `/ResetDefaultFM`.
+* `/ResetDefaultFM` - Use Explorer as the default file manager. You cannot use this with `/DefaultFM`.
 * `/ShellExtension` - Add Total Commander in shell context menu for directories.
 
 These parameters can be passed to the installer with the use of `--params`. For example: `--params '/DesktopIcon'`.

--- a/automatic/totalcommander/TotalCommander.nuspec
+++ b/automatic/totalcommander/TotalCommander.nuspec
@@ -66,7 +66,7 @@ These parameters can be passed to the installer with the use of `--params`. For 
     <releaseNotes>http://ghisler.com/whatsnew.htm</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="autohotkey.portable" version="1.1.26.01" />
+      <dependency id="autohotkey.portable" version="2.0.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/totalcommander/legal/VERIFICATION.txt
+++ b/automatic/totalcommander/legal/VERIFICATION.txt
@@ -7,7 +7,6 @@ The installer has been downloaded from TotalCommander website and can be verifie
 
 1. Download the following installers:
   setup: <https://totalcommander.ch/win/tcmd1052x32_64.exe>
-  installer: <http://ghisler.fileburst.com/addons/installer.zip>
 
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
@@ -15,6 +14,5 @@ The installer has been downloaded from TotalCommander website and can be verifie
 
   checksum type: sha256
   checksum-setup: B7A1454C9ABCEDF11A7581902557565BB0140245913382F18D6372E562590663
-  checksum-installer: 80DE9C2C49FC63965CF0E9BCB1A0E6D25187A1613BDE2086BDA79EFBDC8FCEB8
 
 File 'LICENSE.txt' is obtained from help file of the application.

--- a/automatic/totalcommander/tools/chocolateyUninstall.ahk
+++ b/automatic/totalcommander/tools/chocolateyUninstall.ahk
@@ -1,32 +1,31 @@
 ﻿; default environment
-DetectHiddenWindows, off
-SetControlDelay, 20
+DetectHiddenWindows false
+SetControlDelay 20
 
 ; modified environment
-#NoEnv
 #NoTrayIcon
-DetectHiddenText, off
-SetTitleMatchMode, 2  ;contains
+DetectHiddenText false
+SetTitleMatchMode 2  ;contains
 
 ; variables
-winTitle1 = Uninstall /Repair Total Commander ahk_class #32770
-winTitle2 = Uninstall Total Commander ahk_class #32770
-winTitle3 = Uninstall ahk_class #32770
+winTitle1 := "Uninstall /Repair Total Commander ahk_class #32770"
+winTitle2 := "Uninstall Total Commander ahk_class #32770"
+winTitle3 := "Uninstall ahk_class #32770"
 
-WinWait, %winTitle1%, Removes the program, 20
-ControlClick, Button1 ; &Uninstall
+WinWait(winTitle1, "Removes the program", 20)
+ControlClick "Button1" ; &Uninstall
 
-WinWait, %winTitle2%, Uninstall Program, 20
-ControlClick, Button4 ; Remove configuration files
-ControlClick, Button5 ; Uninstall
+WinWait(winTitle2, "Uninstall Program", 20)
+ControlClick "Button4" ; Remove configuration files
+ControlClick "Button5" ; Uninstall
 
-WinWait, %winTitle3%, Warning: This will, 20
-ControlClick, Button1 ; Yes
+WinWait(winTitle3, "Warning: This will", 20)
+ControlClick "Button1" ; Yes
 
-WinWait, %winTitle3%, The following, 20
-ControlClick, Button1 ; OK
+WinWait(winTitle3, "The following", 20)
+ControlClick "Button1" ; OK
 
-WinWait, %winTitle3%, Program removed, 20
-ControlClick, Button1 ; OK
+WinWait(winTitle3, "Program removed", 20)
+ControlClick "Button1" ; OK
 
 ExitApp

--- a/automatic/totalcommander/tools/chocolateyUninstall.ps1
+++ b/automatic/totalcommander/tools/chocolateyUninstall.ps1
@@ -4,11 +4,20 @@ $installerType = 'exe'
 $silentArgs = ''
 $validExitCodes = @(0)
 
+$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+. $toolsPath\helpers.ps1
+
+# Remove the shell integration, if added
+Remove-TCShellExtension
+
+# Rser back to Explorere being the default File Manager
+Set-ExplorerAsDefaultFM
+
 $scriptPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$ahkFile = Join-Path $scriptPath "chocolateyUninstall.ahk"
+$ahkFile = Join-Path -Path $scriptPath -ChildPath "chocolateyUninstall.ahk"
 $ahkExe = 'AutoHotKey'
 $ahkRun = "$Env:Temp\$(Get-Random).ahk"
-Copy-Item $ahkFile "$ahkRun" -Force
+Copy-Item -Path $ahkFile -Destination "$ahkRun" -Force
 
 Start-Process $ahkExe $ahkRun
 Get-ItemProperty -Path @('HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
@@ -21,4 +30,4 @@ Get-ItemProperty -Path @('HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVe
                                               -SilentArgs "$($silentArgs)" `
                                               -File "$($_.UninstallString.Replace('"',''))" `
                                               -ValidExitCodes $validExitCodes}
-Remove-Item "$ahkRun" -Force
+Remove-Item -Path "$ahkRun" -Force

--- a/automatic/totalcommander/tools/helpers.ps1
+++ b/automatic/totalcommander/tools/helpers.ps1
@@ -1,59 +1,74 @@
-﻿function Get-TCInstallArgs() {
-    $s = '/AHUG'
-    $s += if ($pp.DesktopIcon) { 'D' } else { '' }
-    $s += " "
-    $s += if ($pp.InstallPath) { $pp.InstallPath } else { '%ProgramFiles%\totalcmd' }
-    $s
-}
-
-function Set-TCShellExtension() {
+﻿function Set-TCShellExtension() {
     Write-Host "Setting shell extension"
 
-    New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT -ea 0 | Out-Null
+    New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT -ErrorAction SilentlyContinue | Out-Null
     #sp HKCR:\Directory\shell -name "(Default)" -Value "Total_Commander"
-    mkdir HKCR:\Directory\shell\Total_Commander\command -force | Out-Null
-    Set-ItemProperty HKCR:\Directory\shell\Total_Commander -name "(Default)" -Value "Total Commander"
-    Set-ItemProperty HKCR:\Directory\shell\Total_Commander\command  -name "(Default)" -Value "$installLocation\$tcExeName /O ""%1"""
+    New-Item -Path 'HKCR:\Directory\shell\Total_Commander\command' -Force | Out-Null
+    Set-ItemProperty 'HKCR:\Directory\shell\Total_Commander' -Name '(Default)' -Value 'Total Commander'
+    Set-ItemProperty 'HKCR:\Directory\shell\Total_Commander\command'  -Name '(Default)' -Value "$installLocation\$tcExeName /O ""%1"""
 }
 
-function Set-ExplorerAsDefaultFM() {
-    Write-Host "Setting Explorer as default file manager"
+function Remove-TCShellExtension {
+    Write-Host 'Removing shell extension, if added.'
 
-    New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT -ea 0 | Out-Null
-    'HKCR:\Directory', 'HKCR:\Drive' | ForEach-Object {
-        $key = Get-Item $_
-        $key = $key.OpenSubKey('shell', 'ReadWriteSubTree')
-        $key.DeleteValue('')
+    New-PSDrive -Name 'HKCR' -PSProvider Registry -Root 'HKEY_CLASSES_ROOT' -ErrorAction SilentlyContinue | Out-Null
+    Remove-Item -Path 'HKCR:\Directory\shell\Total_Commander' -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
+}
+
+function Set-ExplorerAsDefaultFM {
+    Write-Host 'Setting Explorer as default File Manager.'
+
+    New-PSDrive -Name 'HKCR' -PSProvider Registry -Root 'HKEY_CLASSES_ROOT' -ErrorAction SilentlyContinue | Out-Null
+
+    $key = Get-ItemProperty -Path 'HKCR:\Directory\shell\open\command' -Name '(default)'
+    if ($key.'(default)' -match 'totalcmd.exe /O "%1"$') {
+      Write-Host "Removing Total Commander as default File Manager for directories."
+      Remove-Item -Path $key.PSParentPath -Recurse -ErrorAction SilentlyContinue | Out-Null
+    }
+
+  $key = Get-ItemProperty -Path 'HKCR:\Drive\shell\open\command' -Name '(default)'
+  if ($key.'(default)' -match 'totalcmd.exe /O "%1"$') {
+    Write-Host "Removing Total Commander as default File Manager for drives."
+    Remove-Item -Path $key.PSParentPath -Recurse -ErrorAction SilentlyContinue | Out-Null
+  }
+}
+
+function Set-TCAsDefaultFM {
+    Write-Host "Setting Total Commander as default file manager."
+
+    New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT -ErrorAction SilentlyContinue | Out-Null
+
+    Set-ItemProperty 'HKCR:\Drive\shell' -Name '(Default)' -Value 'open'
+    New-Item -Path 'HKCR:\Drive\shell\open\command' -Force | Out-Null
+    Set-ItemProperty 'HKCR:\Drive\shell\open\command'  -Name '(Default)' -Value "$installLocation\$tcExeName /O ""%1"""
+
+    Set-ItemProperty 'HKCR:\Directory\shell' -Name '(Default)' -Value 'open'
+    New-Item -Path 'HKCR:\Directory\shell\open\command' -Force | Out-Null
+    Set-ItemProperty 'HKCR:\Directory\shell\open\command' -Name '(Default)' -Value "$installLocation\$tcExeName /O ""%1"""
+}
+
+function Get-TCInstallLocation {
+    if ($env:COMMANDER_PATH) {
+      return $env:COMMANDER_PATH
+    }
+
+    $key = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Ghisler\Total Commander' -ErrorAction SilentlyContinue
+    if ($key) {
+      return $key.InstallDir
+    }
+
+    $installLocation = Get-AppInstallLocation -AppNamePattern 'totalcmd'
+    if ($installLocation) {
+      return $installLocation
+    }
+
+    $localPath = Join-Path -Path $env:SystemDrive -ChildPath 'totalcmd'
+    if (Test-Path -Path $localPath) {
+      return $localPath
     }
 }
 
-function Set-TCAsDefaultFM() {
-    Write-Host "Setting Total Commander as default file manager"
-
-    New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT -ea 0 | Out-Null
-
-    Set-ItemProperty HKCR:\Drive\shell -name "(Default)" -Value "open"
-    mkdir HKCR:\Drive\shell\open\command -force | Out-Null
-    Set-ItemProperty HKCR:\Drive\shell\open\command  -name "(Default)" -Value "$installLocation\$tcExeName /O ""%1"""
-
-    Set-ItemProperty HKCR:\Directory\shell -name "(Default)" -Value "open"
-    mkdir HKCR:\Directory\shell\open\command -force | Out-Null
-    Set-ItemProperty HKCR:\Directory\shell\open\command  -name "(Default)" -Value "$installLocation\$tcExeName /O ""%1"""
-}
-
-function Get-TCInstallLocation() {
-    if ($Env:COMMANDER_PATH) { return $Env:COMMANDER_PATH }
-
-    $key = Get-ItemProperty 'HKLM:\SOFTWARE\Ghisler\Total Commander' -ea 0
-    if ($key) { return $key.InstallDir }
-
-    $installLocation = Get-AppInstallLocation totalcmd
-    if ($installLocation) { return $installLocation }
-
-    if (Test-Path c:\totalcmd) { return "c:\totalcmd" }
-}
-
-function Set-TCIniFilesLocation() {
-    Set-ItemProperty 'HKCU:\SOFTWARE\Ghisler\Total Commander' IniFileName '%COMMANDER_PATH%\wincmd.ini'
-    Set-ItemProperty 'HKCU:\SOFTWARE\Ghisler\Total Commander' FtpIniName  '%COMMANDER_PATH%\wcx_ftp.ini'
+function Set-TCIniFilesLocation {
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Ghisler\Total Commander' -Name 'IniFileName' -Value '%COMMANDER_PATH%\wincmd.ini'
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Ghisler\Total Commander' -Name 'FtpIniName' -Value '%COMMANDER_PATH%\wcx_ftp.ini'
 }

--- a/automatic/totalcommander/update.ps1
+++ b/automatic/totalcommander/update.ps1
@@ -4,33 +4,31 @@ $releases = 'https://www.ghisler.com/download.htm'
 
 function global:au_SearchReplace {
     @{
+        ".\tools\chocolateyInstall.ps1" = @{
+            '(^\s*file\s*=\s*)(".*")'      = "`$1""`$toolsPath\$($Latest.FileName32)"""
+        }
         ".\legal\verification.txt" = @{
             "(?i)(setup:.+)\<.*\>"           = "`${1}<$($Latest.URL32)>"
-            "(?i)(installer:.+)\<.*\>"       = "`${1}<$($Latest.URL64)>"
             "(?i)(checksum-setup:\s+).*"     = "`${1}$($Latest.Checksum32)"
-            "(?i)(checksum-installer:\s+).*" = "`${1}$($Latest.Checksum64)"
         }
-     }
+    }
 }
 
 function global:au_BeforeUpdate {
     Get-RemoteFiles -Purge -NoSuffix
-    mv $PSScriptRoot\tools\installer.exe $PSScriptRoot\tools\installer.zip -ea 0
 }
 
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
     $re = 'x32_64.exe'
-    $url = $download_page.links | ? href -match $re | % href | select -First 1
+    $url = $download_page.links | Where-Object href -match $re | ForEach-Object href | Select-Object -First 1
     $download_page.RawContent -match 'Download\s+version\s+([0-9][0-9.a]+)\s+' | Out-Null
     $version = $Matches[1] -replace 'a', '.01'
 
     # Put combined installer as URL32 and installerzip as URL64 so I can use Get-RemoteFiles to download both later
     @{
         URL32    = $url
-        URL64    = "http://ghisler.fileburst.com/addons/installer.zip"
         Version  = ([version]$version).ToString()  #prevent leading 0es, see https://github.com/chocolatey/chocolatey-coreteampackages/issues/600
-        FileType = 'exe'
     }
 }
 


### PR DESCRIPTION
## Description
When digging into #2121 I had to rewrite the AHK file for the uninstallation. I then started testing the package parameters, and they were fairly, so I rewrote the package to make it work on the Chocolatey test Environment (Windows Server 2019) and Windows 10.

The changes:

* I rewrote the Autohotkey uninstall script to be version 2 compatible and it now works. Updated the dependency for `authotkey.portable` to minimum of 2.
* The package has a `/DesktopIcon` switch, and the description suggests that the package does not by default add a desktop icon. However, a desktop icon is added every time. I've removed the `/DesktopIcon` parameter (as it doesn't make sense anymore) and added a `/NoDesktopIcon` parameter. This is in keeping with most other packages (that add a desktop icon by default, and you have to tell it not to).
* The switch `/DefaultFM` sets TC as the default file manager. However, it's counterpart `/DefaultFM:explorer` didn't make a lot of sense as it only supported explorer. A new switch `/ResetDefaultFM` was added to make it clearer how to reset the default file manager to Explorer.
* Similar to above, the function that reset the default file manager back to Explorer didn't actually work in my testing. I rewrote that function, which now works.
* It was the case that if you set the `/ShellExtension` or `/DefaultFM` then when you uninstalled, you were left with a broken system. The Shell Extension was still there (but obviously no longer worked) and you could browse directories or drives. I removed the Shell Extension and reset the file manager back to Explorer on uninstall.
* The 'installer' as it was called didn't seem to be used for anything. It was a Zip file that was downloaded and added to the package. It wasn't used by the TC installer either (as far as I could see - it was for plugins and no plugins were added). So, I removed it from everywhere.
* I refactored a large amount of the package code.
* I've added myself to the `CODEOWNERS` file.

Fixes #2121 

## Motivation and Context
I started off fixing #2121, then had to rewrite the Autohotkey uninstall script and then ended up testing and then fixing the package.

## How Has this Been Tested?
In the Windows 2019 Chocolatey Test Environment. If I can get my Windows 10 test VM to start I will test it in that too.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).