### PR TITLE
Fix VirtualBox extension pack checksum

### DIFF
--- a/automatic/virtualbox/tools/chocolateyInstall.ps1
+++ b/automatic/virtualbox/tools/chocolateyInstall.ps1
@@ -40,7 +40,7 @@ if ($pp.ExtensionPack) {
     Write-Warning "*** THIS IS A COMMERCIAL EXTENSION AND CAN INCURE SIGNIFICANT FINANCIAL COSTS ***"
 
     $url_ep       = 'https://download.virtualbox.org/virtualbox/7.0.6/Oracle_VM_VirtualBox_Extension_Pack-7.0.6.vbox-extpack'
-    $checksum_ep  = '21c3595361bb2365efe6139f1da724d362daa63fb92c38f686a01aa9200628b2'
+    $checksum_ep  = '292961aa8723b54f96f89f6d8abf7d8e29259d94b7de831dbffb9ae15d346434'
     $file_path_ep = (Get-PackageCacheLocation) + '\' + ($url_ep -split '/' | Select-Object -Last 1)
     Get-ChocolateyWebFile `
         -PackageName    'virtualbox-extensionpack' `


### PR DESCRIPTION
Hello,
the checksum of Oracle_VM_VirtualBox_Extension_Pack-7.0.6 have change.
I did the tests on virustotal and its good : https://www.virustotal.com/gui/url/a1342649aec9824c23bfccb5b93c511c6a7e1d3727df4844441be70eb88b2ab0?nocache=1

Can you accept the correction ?

Best regard

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).