### PR TITLE
(maint) Bump version used for testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,7 @@ environment:
 
   #Chocolatey version we want to use when checking for updates (usually latest).
   choco_version: '1.2.0'
-  choco_version_pr: '0.11.3' # Should be kept to the version available one year ago
+  choco_version_pr: '0.12.1' # Should be kept to the version available one year ago
   nupkg_cache_path: C:\packages
 
 init:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -24,7 +24,6 @@ body:
         - 1.0.1
         - 1.0.0
         - 0.12.1
-        - 0.12.0
         - Other (note in the comments)
     validations:
       required: true


### PR DESCRIPTION
## Description

The latest version available exactly one year
ago. Because of this we are bumping the version
0.12.1


## Motivation and Context

We only support the versions of Chocolatey CLI that was the latest exactly 1 year ago and all versions that came after it.

## How Has this Been Tested?

N/A

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package has not been migrated from another location -->
## Original Location

N/A
