### PR TITLE
(paint.net) Changed .exe to .msi installer

### DIFF
--- a/automatic/paint.net/tools/ChocolateyInstall.ps1
+++ b/automatic/paint.net/tools/ChocolateyInstall.ps1
@@ -4,8 +4,8 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
   PackageName    = $env:ChocolateyPackageName
-  fileType       = 'msi'
-  file64         = Get-Item $toolsPath\*.msi
+  fileType       = "msi"
+  file64         = "$toolsPath\paintdotnet.msi"
   silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
   validExitCodes = @(0, 1641, 3010)
   softwareName   = 'Paint.NET*'

--- a/automatic/paint.net/tools/ChocolateyInstall.ps1
+++ b/automatic/paint.net/tools/ChocolateyInstall.ps1
@@ -12,7 +12,7 @@ $packageArgs = @{
 }
 
 Install-ChocolateyInstallPackage @packageArgs
-Get-ChildItem $toolsPath\*.exe | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" '' }}
+Get-ChildItem $toolsPath\*.msi | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" '' }}
 
 $packageName = $packageArgs.packageName
 $installLocation = Get-AppInstallLocation $packageArgs.softwareName

--- a/automatic/paint.net/tools/ChocolateyInstall.ps1
+++ b/automatic/paint.net/tools/ChocolateyInstall.ps1
@@ -4,9 +4,9 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
   PackageName    = $env:ChocolateyPackageName
-  fileType       = 'exe'
-  file64         = Get-Item $toolsPath\*.exe
-  silentArgs     = '/auto'
+  fileType       = 'msi'
+  file64         = Get-Item $toolsPath\*.msi
+  silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
   validExitCodes = @(0, 1641, 3010)
   softwareName   = 'Paint.NET*'
 }

--- a/automatic/paint.net/update.ps1
+++ b/automatic/paint.net/update.ps1
@@ -22,7 +22,7 @@ function global:au_GetLatest {
 
     @{
         Version = $LatestRelease.tag_name.TrimStart("v")
-        Url64   = $LatestRelease.assets | Where-Object {$_.name -match 'paint.net.+.install.x64.zip'} | Select-Object -ExpandProperty browser_download_url
+        Url64   = $LatestRelease.assets | Where-Object {$_.name -match 'paint.net.+.winmsi.x64.zip'} | Select-Object -ExpandProperty browser_download_url
     }
 }
 

--- a/automatic/paint.net/update.ps1
+++ b/automatic/paint.net/update.ps1
@@ -7,7 +7,7 @@ function global:au_SearchReplace {
         "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
       }
       ".\tools\chocolateyInstall.ps1" = @{
-        "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName64)`""
+        "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileNameMsi64)`""
       }
   }
 }
@@ -26,7 +26,7 @@ function global:au_GetLatest {
     @{
         Version = $LatestRelease.tag_name.TrimStart("v")
         Url64   = $LatestRelease.assets | Where-Object {$_.name -match 'paint.net.+.winmsi.x64.zip'} | Select-Object -ExpandProperty browser_download_url
-        FileNameMsi64  = $LatestRelease.assets | Where-Object {$_.name -match 'paint.net.+.winmsi.x64.zip'} | Select-Object -Property Name | ForEach-Object {$_ -replace "zip","msi"}
+        FileNameMsi64  = $LatestRelease.assets | Where-Object {$_.name -match 'paint.net.+.winmsi.x64.zip'} | Select-Object -ExpandProperty Name | ForEach-Object {$_ -replace "zip","msi"}
       }
 }
 

--- a/automatic/paint.net/update.ps1
+++ b/automatic/paint.net/update.ps1
@@ -6,6 +6,9 @@ function global:au_SearchReplace {
         "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
         "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
       }
+      ".\tools\chocolateyInstall.ps1" = @{
+        "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName64)`""
+      }
   }
 }
 
@@ -23,7 +26,8 @@ function global:au_GetLatest {
     @{
         Version = $LatestRelease.tag_name.TrimStart("v")
         Url64   = $LatestRelease.assets | Where-Object {$_.name -match 'paint.net.+.winmsi.x64.zip'} | Select-Object -ExpandProperty browser_download_url
-    }
+        FileNameMsi64  = $LatestRelease.assets | Where-Object {$_.name -match 'paint.net.+.winmsi.x64.zip'} | Select-Object -Property Name | ForEach-Object {$_ -replace "zip","msi"}
+      }
 }
 
 update -ChecksumFor none

--- a/automatic/paint.net/update.ps1
+++ b/automatic/paint.net/update.ps1
@@ -15,8 +15,8 @@ function global:au_SearchReplace {
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
 
-  Set-Alias 7z $Env:chocolateyInstall\tools\7z.exe
-  7z e tools\*.zip -otools *.exe -r -y
+  Set-Alias -Name 7z -Value $Env:chocolateyInstall\tools\7z.exe
+  7z e tools\*.zip -otools *.msi -r -y
   Remove-Item tools\*.zip -ea 0
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
I have made simple changes to the download part of Get-GithubRelease by specifying the MSI file instead of the exe file.
Adapted all the commands referencing the exe.
Adapted the silentinstall in the PackageArgs to conform with the basic MSI arguments as they are supplied when creating a new chocolatey package using choco new

## Motivation and Context
See discussion:  #1978
See previous (failed/closed) PR: #1987

## How Has this Been Tested?
Tested the installation from a private repository.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).


