### PR TITLE
(vim)(#2147) Add note about AV detections

### DIFF
--- a/automatic/vim/README.md
+++ b/automatic/vim/README.md
@@ -26,9 +26,9 @@ Example: `choco install vim --params "'/NoDesktopShortcuts /InstallDir:C:\path\t
 
 ## Notes
 
+- **Antivirus Detections**. Some files in the package are being picked up by VirusTotal as malicious. Please see these [GitHub issues](https://github.com/vim/vim-win32-installer/issues?q=is%3Aissue+is%3Aclosed+virus) for more information.
 - This package uses the ZIP build to install to provide installation parameters.
 - All compilation of the software is automated and performed on Appveyor. The building status is open.
 - This package provides an official build. Similar package `vim-tux` is from a well-known unofficial vim building project. Unlike `vim-tux`, this package can take some installation parameters.
-- See https://github.com/vim/vim-win32-installer for more information.
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 


### PR DESCRIPTION
## Description
Added a note about the VirusTotal AV detections to the package description. I also removed a note just pointing to the GitHub page as that is covered in package metadata.

## Motivation and Context
The package cannot be approved on the Chocolatey Community Repository due to a high AV detections count. This will allow the package to be exempted.

## How Has this Been Tested?
This is a README change so no testing done.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).