### PR TITLE
(apache-httpd)(#2151) Replace private variables

### DIFF
--- a/automatic/apache-httpd/apache-httpd.nuspec
+++ b/automatic/apache-httpd/apache-httpd.nuspec
@@ -41,7 +41,8 @@ Example: `choco install apache-httpd --params '"/installLocation:C:\HTTPD /port:
 ]]></description>
     <tags>apache httpd webserver admin</tags>
     <dependencies>
-       <dependency id="vcredist140" version="14.32.31332" />
+      <dependency id="chocolatey" version="1.2.0" />
+      <dependency id="vcredist140" version="14.32.31332" />
    </dependencies>
   </metadata>
   <files>

--- a/automatic/apache-httpd/tools/helpers.ps1
+++ b/automatic/apache-httpd/tools/helpers.ps1
@@ -50,7 +50,7 @@ function Assert-TcpPortIsOpen {
 }
 
 function Get-ApacheInstallOptions {
-    $configFile = Join-Path $env:chocolateyPackageFolder 'config.xml'
+    $configFile = Join-Path -Path (Get-ChocolateyPath -PathType 'PackagePath') -ChildPath 'config.xml'
     $config = Import-CliXml $configFile
 
     return $config
@@ -132,7 +132,7 @@ function Set-ApacheInstallOptions {
         ServiceName = $arguments.serviceName
     }
 
-    $configFile = Join-Path $env:chocolateyPackageFolder 'config.xml'
+    $configFile = Join-Path -Path (Get-ChocolateyPath -PathType 'PackagePath') -ChildPath 'config.xml'
     Export-Clixml -Path $configFile -InputObject $config
 }
 


### PR DESCRIPTION
## Description
Replaced Chocolatey private variables with their cmdlet equivalents, whcih requires Chocolatey CLI 1.2.0 so I've added that as a dependency.

## Motivation and Context
Package is failing Package Validator.

## How Has this Been Tested?
Tested in the Windows Server 2019 Chocolatey Test Environment.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).