### PR TITLE
(tortoisegit) Skip install when the packaged version is already installed

### DIFF
--- a/automatic/tortoisegit/tools/chocolateyInstall.ps1
+++ b/automatic/tortoisegit/tools/chocolateyInstall.ps1
@@ -1,28 +1,36 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+. $toolsPath\helpers.ps1
 
 $filePath32 = Resolve-Path "$toolsPath\*_x32.msi"
 $filePath64 = Resolve-Path "$toolsPath\*_x64.msi"
 
-$installFile = if ((Get-OSArchitectureWidth 64) -and $env:chocolateyForceX86 -ne 'true') {
-  Write-Host "Installing 64 bit version"
-  $filePath64
+[version] $softwareVersion = '2.14.0.0'
+$installedVersion = Get-InstalledVersion
+
+if ($installedVersion -and ($softwareVersion -eq $installedVersion) -and !$env:ChocolateyForce) {
+  Write-Host "TortoiseGit v$installedVersion is already installed - skipping download and installation."
 } else {
-  Write-Host "Installing 32 bit version"
-  $filePath32
-}
+  $installFile = if ((Get-OSArchitectureWidth 64) -and $env:chocolateyForceX86 -ne 'true') {
+    Write-Host "Installing 64 bit version"
+    $filePath64
+  } else {
+    Write-Host "Installing 32 bit version"
+    $filePath32
+  }
 
-$packageArgs = @{
-  PackageName = 'tortoisegit'
-  FileType = 'msi'
-  SoftwareName = 'TortoiseGit*'
-  File = $installFile
-  SilentArgs = '/quiet /qn /norestart REBOOT=ReallySuppress'
-  ValidExitCodes = @(0,3010)
-}
+  $packageArgs = @{
+    PackageName = 'tortoisegit'
+    FileType = 'msi'
+    SoftwareName = 'TortoiseGit*'
+    File = $installFile
+    SilentArgs = '/quiet /qn /norestart REBOOT=ReallySuppress'
+    ValidExitCodes = @(0,3010)
+  }
 
-Install-ChocolateyInstallPackage @packageArgs
+  Install-ChocolateyInstallPackage @packageArgs
+}
 
 # Lets remove the installer as there is no more need for it.
 Remove-Item -Force $filePath32 -ea 0

--- a/automatic/tortoisegit/tools/helpers.ps1
+++ b/automatic/tortoisegit/tools/helpers.ps1
@@ -1,0 +1,9 @@
+﻿function Get-InstalledVersion() {
+  [array] $keys = Get-UninstallRegistryKey -SoftwareName 'TortoiseGit*'
+
+  if ($keys.Length -ge 1) {
+      return [version] ($keys[0].DisplayVersion)
+  }
+
+  return $null
+}

--- a/automatic/tortoisegit/update.ps1
+++ b/automatic/tortoisegit/update.ps1
@@ -10,6 +10,9 @@ function global:au_BeforeUpdate {
 
 function global:au_SearchReplace {
   @{
+    "tools\chocolateyInstall.ps1" = @{
+      "(?i)([$]softwareVersion\s*=\s*)'.*'" = "`${1}'$($Latest.RemoteVersion)'"
+    }
     ".\tortoisegit.nuspec" = @{
       "(<releaseNotes>https:\/\/tortoisegit.org\/docs\/releasenotes\/#Release_)(.*)(<\/releaseNotes>)" = "`${1}$($Latest.Version.ToString())`$3"
     }
@@ -45,6 +48,7 @@ function global:au_GetLatest {
     URL32 = "https:" + $url32
     URL64 = "https:" + $url64
     Version = $version32
+    RemoteVersion = $version32
   }
 }
 


### PR DESCRIPTION
## Description
This changeset implements an install-time version-check for `tortoisegit`, intended to allow package installs/upgrades to succeed when the packaged software version is already installed. This should gracefully handle both new package installs for pre-existing installations, as well as software upgrades that happen outside of Chocolatey.

## Motivation and Context
Fixes #2159.

I recently found myself in this situation when TortoiseGit itself prompted me to update to v2.14.0.0. Seeing an update prompt in Chocolatey-managed software normally triggers me running `choco outdated --ignore-pinned` to check if an updated package is available from the Community Repository. 

As no such package was available at the time, I opted to upgrade the software manually, with the understanding that I'd pick up an updated package later when it became available. When an updated package for TortoiseGit became available. I tried to upgrade and ran into the documented issue.

Implementing this for behavior consistency with some other community packages (e.g. `brave`, `firefox`, `flightgear`, `googlechrome`, `inkscape`, `opera`, `thunderbird`), as well as to prevent the need for workarounds (e.g. using the `--skip-powershell` switch, waiting for the next package release, etc.) to get the software and package versions synchronized.

## How Has this Been Tested?

### Environments 

#### Dev

* OS Build: Windows 11 Pro v10.0.22621.0 (64-bit)
* PowerShell version: 7.3.3
* Chocolatey version: 1.3.0

#### Chocolatey Test Environment
* Vagrant Box Version: 3.0.0
* VM Provider: Virtualbox (although practically Hyper-V, since I manually converted the resulting virtual disk)
* OS Build: Windows Server 2019 Datacenter v10.0.17763.0 (64-bit)
* PowerShell version: 5.1.17763.3770
* Chocolatey version: 1.3.0

### Steps

#### Create a Test Package

1. Revert `tortoisegit.nuspec` to fa29f721dad264ebc38ce59a20c54372cfc8cb94.
2. Manually change newly introduced `$softwareVersion` variable in `tools\chocolateyInstall.ps1` to `'2.13.0.1'`.
3. Executed `.\update_all.ps1 -Name tortoisegit -ForcedPackages tortoisegit` to download software installers, test `update.ps1` changes, and create a test package based on v2.14.0.0.

#### Clean Install Test

> **Note**
>TortoiseGit (both the package and software) is assumed to be currently uninstalled.

1. Install the test package version (i.e. `choco install tortoisegit --source="'.;https://community.chocolatey.org/api/v2/'"` [to prioritize local packages while sourcing dependencies from the Community Repository]).
2. Confirm software and package install succeeds without errors.

#### Existing Install Test

1. Uninstall the existing package (i.e. `choco uninstall tortoisegit`).
2. Manually [download and execute TortoiseGit v2.14.0.0's 64-bit installer](https://download.tortoisegit.org/tgit/2.14.0.0/TortoiseGit-2.14.0.0-64bit.msi).
3. Reinstall the test package version (i.e. `choco install tortoisegit --source="'.'"`).
4. Confirm the package skips installing TortoiseGit, and the package install succeeds without errors.

#### Chocolatey-Managed Upgrade Test

1. Downgrade to a previous version of TortoiseGit (e.g. `choco install tortoisegit --version=2.13.0.1 --allow-downgrade`).
2. Upgrade to the test package version (i.e. `choco upgrade tortoisegit --source="'.'"`).
3. Confirm that both the software and package upgrade succeeds without errors.

#### Upgrade Catchup Test

1. Downgrade to a previous version of TortoiseGit (e.g. `choco install tortoisegit --version=2.13.0.1 --allow-downgrade`).
2. If not already installed, install the `git.install` package to gain access to TortoiseGit's Settings dialog (e.g. `choco install git.install`).
3. In File Explorer/Desktop, right-click on a blank space, browse to and press the **TortoiseGit** > **Settings** context menu item.
4. In TortoiseGit's **Settings** dialog, on the **General** page, in the **TortoiseGit** groupbox, press the **Check now** button.
5. In the Check For Updates dialog, press the **Download** button.
6. When the installer download completes, press the **Install** button.
7. Manually step through the installer to completion.
8. Upgrade to the test package version (i.e. `choco upgrade tortoisegit --source="'.'"`).
9. Confirm the package skips installing TortoiseGit, and the package upgrade succeeds without errors.

#### Forced Reinstallation Test

1. Force reinstallation of the test package in non-silent mode (i.e. `choco install tortoisegit --source="'.'" --force --not-silent`.
2. Confirm the installer is started without issues.
3. Browse to the next page in the installer, confirm the user is prompted to Modify/Repair/Remove the current installation.
4. To gracefully progress the "installation", select the **Modify** or **Repair** option. Step through the installer to completion.
5. Confirm that both the software and package "installation" succeeds without errors.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).