### PR TITLE
(filezilla)(#1881) Fix verification URLS

### DIFF
--- a/automatic/filezilla/legal/VERIFICATION.txt
+++ b/automatic/filezilla/legal/VERIFICATION.txt
@@ -5,10 +5,10 @@ in verifying that this package's contents are trustworthy.
 
 Package can be verified like this:
 
-1. Go to
+1. Go to the links below and download the correct files:
 
-   x32: https://dl1.cdn.filezilla-project.org/client/FileZilla_3.63.2.1_win32-setup.exe?h=yZYsOaOaFrJawIR-VDcNKw&x=1677870562
-   x64: https://dl1.cdn.filezilla-project.org/client/FileZilla_3.63.2.1_win64-setup.exe?h=-htIkgRCtpWTTfVuqWULAw&x=1677870562
+   x32: https://filezilla-project.org/download.php?show_all=1
+   x64: https://filezilla-project.org/download.php?show_all=1
 
    to download the installer.
 

--- a/automatic/filezilla/update.ps1
+++ b/automatic/filezilla/update.ps1
@@ -9,8 +9,6 @@ function global:au_SearchReplace {
         }
 
         ".\legal\VERIFICATION.txt" = @{
-          "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL32)"
-          "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
           "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
           "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
         }


### PR DESCRIPTION
## Description
Added the download page to the VERIFICATION.txt file.

## Motivation and Context
The download links for Filezilla use a unique value that is timed. Putting them into the VERIFCATION.txt file means that after the time has run out, the links don't work. Using the download page links instead.

## How Has this Been Tested?
This is a simple text file change so hasn't been tested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).