### PR TITLE
(k9s) Include new Amd 64 version

### DIFF
--- a/automatic/k9s/tools/chocolateyinstall.ps1
+++ b/automatic/k9s/tools/chocolateyinstall.ps1
@@ -1,11 +1,11 @@
 ﻿$ErrorActionPreference = 'Stop';
 
-$packageName   = $env:ChocolateyPackageName
-$toolsDir      = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$packageName = $env:ChocolateyPackageName
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   PackageName    = $packageName
-  FileFullPath64 = Get-Item $toolsDir\k9s_*Windows_x86_64.tar.gz
+  FileFullPath64 = "$toolsDir\k9s_Windows_amd64.tar.gz"
   Destination    = $toolsDir
 }
 
@@ -13,10 +13,10 @@ Get-ChocolateyUnzip @packageArgs
 
 $packageArgs2 = @{
   PackageName    = $packageName
-  FileFullPath64 = Get-Item $toolsDir\k9s_*Windows_x86_64.tar
+  FileFullPath64 = "$toolsDir\k9s_Windows_amd64.tar"
   Destination    = $toolsDir
 }
 
 Get-ChocolateyUnzip @packageArgs2
 
-Remove-Item "$toolsDir\k9s_*Windows_*.tar*"
+Remove-Item "$toolsDir\k9s_Windows_amd64.tar*"

--- a/automatic/k9s/update.ps1
+++ b/automatic/k9s/update.ps1
@@ -9,7 +9,7 @@ function global:au_BeforeUpdate {
 
 function global:au_SearchReplace {
   @{
-    ".\legal\VERIFICATION.txt" = @{
+    ".\legal\VERIFICATION.txt"      = @{
       "(?i)(^\s*64\-bit software.*)\<.*\>" = "`${1}<$($Latest.URL64)>"
       "(?i)(^\s*checksum\s*type\:).*"      = "`${1} $($Latest.ChecksumType64)"
       "(?i)(^\s*checksum(64)?\:).*"        = "`${1} $($Latest.Checksum64)"
@@ -24,13 +24,13 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
   $LatestRelease = Get-GitHubRelease derailed k9s
 
-  $checksumAsset = $LatestRelease.assets | Where-Object {$_.name -eq 'checksums.txt'} | Select-Object -ExpandProperty browser_download_url
+  $checksumAsset = $LatestRelease.assets | Where-Object { $_.name -eq 'checksums.txt' } | Select-Object -ExpandProperty browser_download_url
   $checksum_page = Invoke-WebRequest -Uri $checksumAsset -UseBasicParsing
   $checksum64 = [regex]::Match($checksum_page, "([a-f\d]+)\s*$([regex]::Escape($filename64))").Groups[1].Value
 
   return @{
     Version        = $LatestRelease.tag_name.TrimStart("v")
-    URL64          = $LatestRelease.assets | Where-Object {$_.name -eq 'k9s_Windows_x86_64.tar.gz'} | Select-Object -ExpandProperty browser_download_url
+    URL64          = $LatestRelease.assets | Where-Object { $_.name -eq 'k9s_Windows_amd64.tar.gz' } | Select-Object -ExpandProperty browser_download_url
     ReleaseNotes   = "https://github.com/derailed/k9s/blob/$($LatestRelease.tag_name)/change_logs/release_$($LatestRelease.tag_name).md"
     ReleaseURL     = $LatestRelease.html_url
     Checksum64     = $checksum64


### PR DESCRIPTION
In PR https://github.com/derailed/k9s/pull/1910 the x86_64 in the release was changed to amd64
so that :
`k9s_Windows_x86_64.tar.gz`
changed into
`k9s_Windows_amd64.tar.gz`

## Description
This will check for both and select the correct version

This will also close https://github.com/chocolatey-community/chocolatey-packages/issues/1999

## Motivation and Context
It is really annoying that it is still not up to date to the latest version available

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).


