### PR TITLE
(libreoffice-streams) Add missing 64-bit arch pattern to filename search

### DIFF
--- a/automatic/libreoffice-streams/tools/helpers.ps1
+++ b/automatic/libreoffice-streams/tools/helpers.ps1
@@ -115,7 +115,8 @@ function GetFilename($url, $releasesMapping, $release, $arch) {
   )
   $filename64bitsPatterns = @(
     "x86_64",
-    "x64"
+    "x64",
+    "x86-64"
   )
   $filename32bitsPatterns = @(
     "x86"


### PR DESCRIPTION
## Description
This changeset fixes a recently introduced update error currently impacting `libreoffice-fresh` v7.5.0+ (and by extension, `libreoffice-fresh` v7.4.6 and `libreoffice-still` v7.4.6+, since these would be built in the same AU run).

## Motivation and Context
Fixes #2168.

Starting with LibreOffice v7.5.0.0.alpha1, the 64-bit installer adopted a new architecture string (`x86-64`) in its filename.

The Document Foundation's update service recently made v7.5.1 available for download on the Fresh branch, which triggered detection of a newly available software version which uses this pattern.

The update script makes use of some helper functions to construct the two streams (Fresh and Still) which reflect the branched release model of LibreOffice. `GetFilename` in particular probes The Document Foundation's Download Archives server for a valid download URL, based on several possible filenames for a given release. If a HEAD request for a given permutation succeeds, it is assumed to be the URL we are looking for.

`GetFileName` currently does not include the new architecture string in the list of expected patterns, which causes this function to return `$null`. A later URL validation check in AU's `Update-Package` function will fail and throw an error for this reason.

Resolved by adding the new string to `GetFilename`'s array of possible architecture strings, which enables it to succeed.

## How Has this Been Tested?

### Environments

#### Dev

* OS Build: Windows 11 Pro v10.0.22621.0 (64-bit)
* PowerShell version: 7.3.3
* Chocolatey version: 1.3.0

#### Chocolatey Test Environment
* Vagrant Box Version: 3.0.0
* VM Provider: Virtualbox (although practically Hyper-V, since I manually converted the resulting virtual disk)
* OS Build: Windows Server 2019 Datacenter v10.0.17763.0 (64-bit)
* PowerShell version: 5.1.17763.3770
* Chocolatey version: 1.3.0

### Steps

1. Executed `.\update.ps1` locally to confirm that the modified function behaves as expected, and that the update script completes without errors.
2. Inspected `chocolateyInstall.ps1` within each resulting package (`libreoffice-fresh.7.4.6`, `libreoffice-fresh.7.5.0`, `libreoffice-fresh.7.5.1`, `libreoffice-still.7.4.6`) and confirmed a valid `url64bit` and `checksum64` value was populated for each.
3. Within my local Chocolatey Testing Environment instance, installed the `libreoffice-fresh` v7.4.6 test package (i.e. `choco install libreoffice-fresh --version=7.4.6 --source="'.;https://community.chocolatey.org/api/v2/'"`), and confirmed the package installation completes without errors.
4. Uninstalled `libreoffice-fresh` (i.e. `choco uninstall libreoffice-fresh`), and confirmed the package uninstallation completes without errors.
5. Repeat steps 3-4, but with `libreoffice-fresh` v7.5.0, v7.5.1, and `libreoffice-still` v7.4.6.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).