### PR TITLE
(7zip.install) Fixes broken checksumtype SearchReplace

### DIFF
--- a/automatic/7zip.install/update.ps1
+++ b/automatic/7zip.install/update.ps1
@@ -15,7 +15,7 @@ function global:au_SearchReplace {
       "(?i)(listed on\s*)\<.*\>" = "`${1}<$releases>"
       "(?i)(32-Bit.+)\<.*\>"     = "`${1}<$($Latest.URL32)>"
       "(?i)(64-Bit.+)\<.*\>"     = "`${1}<$($Latest.URL64)>"
-      "(?i)(checksum type:).*"   = "`${1} $($Latest.ChecksumType)"
+      "(?i)(checksum type:).*"   = "`${1} $($Latest.ChecksumType64)"
       "(?i)(checksum32:).*"      = "`${1} $($Latest.Checksum32)"
       "(?i)(checksum64:).*"      = "`${1} $($Latest.Checksum64)"
     }


### PR DESCRIPTION
## Description
This should fix the replacement of checksumtype in the verification file, which was not being updated by `au_SearchReplace`.

## Motivation and Context
The checksum type was missing from `7zip.install` in source. I checked [on CCR](https://community.chocolatey.org/packages/7zip.install#files) as well, to see that it wasn't just not present here.

As I was trying to replicate this in another package, I found that it should have been using the checksumtype64 (or the 32 version of the same variable) instead of just checksumtype. You can see this [in AU](https://github.com/chocolatey-community/chocolatey-au/blob/master/AU/Public/Get-RemoteFiles.ps1#L83).

`7zip.portable`, somewhat confusingly, sets `$Latest.Checksum` during the `BeforeUpdate` step, so I suspect this came across from there.

## How Has this Been Tested?
- Tested on the Jenkins PR

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
