### PR TITLE
(maint) Create basic template for features

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,44 @@
+title: "(packageName) Summary of feature or enhancement"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for wishing to improve packages that we host in this repository.
+
+        Before you fill out the template here, please make sure that the title contains a short summary of the the new enhancement or feature, that the title starts with `(packageName)`, and gives an idea of what the discussion is about.
+
+        **For Example, if you request a feature or an enhancement for the 7zip.install package, the title of the discussion should always start with `(7zip.install)`.**
+  - type: checkboxes
+    attributes:
+      label: Before starting, ensure that you have done the following.
+      options:
+        - label: I have verified that there is no other issue or discussion covering the feature or enhancement
+          required: true
+        - label: I have verified there is no open pull request for the feature or enhancement
+          required: true
+        - label: I have verified the package to improve is located in this repository
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What do you want to add?
+      description: Please explain what the feature or enhancement is about, and explain it in a way you would normally explain it to people if you had to convince them of why it would be a benefit to add this feature or enhancement.
+    validations:
+      required: true
+  - type: textarea
+    id: problem-related
+    attributes:
+      label: What problem will the feature/enhancement solve?
+      description: |
+        If the feature or enhancement is added, what problem will this improvement solve?
+
+        Please try explaining the problem as simply as you can, such that someone that does not know anything about the package or software could understand.
+  - type: checkboxes
+    attributes:
+      label: 'If the feature or enhancement is approved:'
+      options:
+        - label: I am willing to create a pull request to implement the feature or enhancement
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Please include any other information here that you feel may be relevant to the feature or enhancement you want to implement that is not already covered.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@ contact_links:
   - name: Request a new Feature or Enhancement to package.
     # This annoying url is used so it can pre-fill some parts of the new discussion that needs to be created.
     # Follow the link to see what will be displayed.
-    url: https://github.com/chocolatey-community/chocolatey-packages/discussions/new?category=ideas&title=(packageName)&body=%3C%21--%20Please%20update%20the%20title%20with%20a%20summary%20of%20the%20feature%20or%20enhancement%20you%20wish%20to%20see.%20The%20discussion%20needs%20to%20be%20prefixed%20with%20the%20package%20name%20inside%20parentheses.%20Give%20as%20many%20details%20to%20the%20feature%20or%20enhancement%20as%20you%20can%2C%20and%20why%20it%20should%20be%20included.%20Think%20of%20it%20as%20trying%20to%20persuade%20someone%20to%20include%2C%20or%20do%20something.%0A%0AIf%20you%20are%20willing%20to%20submit%20a%20pull%20request%20to%20add%20the%20feature%20or%20enhancement%2C%20include%20this%20as%20well%20but%20do%20not%20start%20working%20on%20a%20pull%20request%20until%20a%20repository%20maintainer%20has%20approved%20the%20inclusion%20%28by%20creating%20an%20issue%20with%20a%20reference%20to%20this%20discussion%29.%20Remember%20to%20remove%20this%20comment%20once%20you%20are%20done.%0A%0AREMEMBER%20TO%20REMOVE%20THIS%20COMMENT%20BEFORE%20CONTINUING%20--%3E
+    url: https://github.com/chocolatey-community/chocolatey-packages/discussions/new?category=ideas
     about: Open a discussion to request a feature or enhancement be implemented for a specific package.
   - name: Request a new package being migrated to this repository.
     # This same annoying url is used here as well to pre-fill some parts of the new discussion that needs to be created.


### PR DESCRIPTION
## Description

This pull request adds a very basic template requesting the information we want the user to have verified before they request adding features, or enhancing packages.

## Motivation and Context

Some leg work is needed when requesting features, and we want the user to confirm that they have done this before creating the discussion.
As well as give them information about what we expect.

## How Has this Been Tested?

1. Go to https://github.com/AdmiringWorm/chocolatey-coreteampackages/discussions/new/choose
2. Select `Ideas`
3. Play around

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).