### PR TITLE
(codelite) Fix version scraping

### DIFF
--- a/automatic/codelite/update.ps1
+++ b/automatic/codelite/update.ps1
@@ -28,7 +28,7 @@ function global:au_GetLatest {
 
   $re64 = 'windows_64$'
   $url64 = $download_page.links | ? href -match $re64 | select -First 1 -Expand href { % Get-RedirectedUrl $_  3>$null }
-  $version = $download_page.content -match "CodeLite ([\d\.]+) - Stable Release" | select -first 1 | % { $Matches[1] }
+  $version = $download_page.content -match "CodeLite ([\d\.]+) - Stable" | select -first 1 | % { $Matches[1] }
 
   @{
     URL64        = $url64


### PR DESCRIPTION
## Description
This changeset adjusts the regex pattern used in scraping the latest stable version info from the [CodeLite download page](https://downloads.codelite.org/), to enable `codelite`'s update script to work correctly.

## Motivation and Context
Fixes #2176.

As of v17.0.0's release, the website no longer contains the word "Release" in the table header that we scrape to determine the latest stable version. This causes `$version` to be set to `$null`, as there are no valid string matches against the current regex pattern.

Resolved by adjusting the regex pattern to reflect this change.

## How Has this Been Tested?

### Environments

#### Dev

* OS Build: Windows 11 Pro v10.0.22621.0 (64-bit)
* PowerShell version: 7.3.3
* Chocolatey version: 1.3.1

#### Chocolatey Test Environment
* Vagrant Box Version: 3.0.0
* VM Provider: Virtualbox (although practically Hyper-V, since I manually converted the resulting virtual disk)
* OS Build: Windows Server 2019 Datacenter v10.0.17763.0 (64-bit)
* PowerShell version: 5.1.17763.3770
* Chocolatey version: 1.3.1

### Steps

1. Executed `.\update.ps1` locally to confirm that the modified regex pattern behaves as expected, and that the update script completes without errors.
2. Within my local Chocolatey Testing Environment instance, installed the resulting `codelite` v17.0.0 test package with dependencies sourced from the Community Repository (i.e. `choco install codelite --source="'.;https://community.chocolatey.org/api/v2'"`), and confirmed the package installation completes without errors.
3. Uninstalled `codelite` (i.e. `choco uninstall codelite`), answered the uninstaller's dialog prompt, and confirmed the package uninstallation completes without errors.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
