### PR TITLE
(brave) Change package to be partially embedded

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,6 +39,7 @@
 */freecad*            @redbaron2
 */selenium-chromium-edge-driver* @chocolatey-community/chocolatey-team-maintainers @AdmiringWorm
 */jenkins*            @chocolatey-community/chocolatey-team-maintainers
+*/brave*              @AdmiringWorm
 
 # Other
 # This can be any file other that won't be matched as a package

--- a/automatic/brave/legal/VERIFICATION.txt
+++ b/automatic/brave/legal/VERIFICATION.txt
@@ -6,7 +6,6 @@ The installer has been downloaded from the GitHub mirror and can be verified lik
 
 1. Download the following installer(s):
 
-x86: https://github.com/brave/brave-browser/releases/download/v1.45.123/BraveBrowserStandaloneSilentSetup32.exe
 x86_64: https://github.com/brave/brave-browser/releases/download/v1.45.123/BraveBrowserStandaloneSilentSetup.exe
 
 2. You can use one of the following methods to obtain the checksum(s):
@@ -14,7 +13,6 @@ x86_64: https://github.com/brave/brave-browser/releases/download/v1.45.123/Brave
   - Use chocolatey utility 'checksum.exe'
 
 checksum type: sha256
-checksum32: 562AB11ED624C696E994AC2DF285A8E8DF1896E889BD1A70ADF0D691E536D22D
 checksum64: CAB870C03F03AE43DA9DDEE9F26BE2F841F60134CA86E83CC6B252E3FBBEB3B3
 
 The included 'LICENSE.txt' file have been obtained from:

--- a/automatic/brave/tools/chocolateyInstall.ps1
+++ b/automatic/brave/tools/chocolateyInstall.ps1
@@ -1,9 +1,11 @@
-﻿$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 . $toolsPath\helpers.ps1
 
 $packageArgs = @{
   packageName = $env:ChocolateyPackageName
-  file        = "$toolsPath\BraveBrowserStandaloneSilentSetup32.exe"
+  url         = ''
+  checksum    = ''
+  checksumType= ''
   file64      = "$toolsPath\BraveBrowserStandaloneSilentSetup.exe"
 }
 
@@ -18,7 +20,9 @@ if ($installedVersion -and ($softwareVersion -lt $installedVersion)) {
 elseif ($installedVersion -and ($softwareVersion -eq $installedVersion)) {
   Write-Warning "Skipping installation because version $softwareVersion is already installed."
 }
-else {
+elseif ((Get-OSArchitectureWidth -compare 32) -or ($env:ChocolateyForceX86 -eq $true)) {
+  Install-ChocolateyPackage @packageArgs
+} else {
   Install-ChocolateyInstallPackage @packageArgs
 }
 

--- a/automatic/brave/update.ps1
+++ b/automatic/brave/update.ps1
@@ -72,19 +72,20 @@ function global:au_BeforeUpdate {
   $stream_readme = if ($Latest.Title -like '*Beta*') { 'README-beta.md' } else { 'README-release.md' }
   cp $stream_readme $PSScriptRoot\README.md -Force
   Get-RemoteFiles -Purge -NoSuffix
+  rm "$PSScriptRoot\tools\$($Latest.FileName32)"
 }
 
 function global:au_SearchReplace {
   @{
     "tools\chocolateyInstall.ps1" = @{
-      "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\).*"   = "`${1}$($Latest.FileName32)`""
+      "(?i)(^\s*url\s*=\s*)('.*')"                = "`$1'$($Latest.URL32)'"
+      "(?i)(^\s*checksum\s*=\s*)('.*')"           = "`$1'$($Latest.Checksum32)'"
+      "(?i)(^\s*checksumType\s*=\s*)('.*')"       = "`$1'$($Latest.ChecksumType32)'"
       "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName64)`""
       "(?i)([$]softwareVersion\s*=\s*)'.*'"       = "`${1}'$($Latest.RemoteVersion)'"
     }
     "legal\VERIFICATION.txt"      = @{
-      "(?i)(x86:).*"        = "`${1} $($Latest.URL32)"
       "(?i)(x86_64:).*"     = "`${1} $($Latest.URL64)"
-      "(?i)(checksum32:).*" = "`${1} $($Latest.Checksum32)"
       "(?i)(checksum64:).*" = "`${1} $($Latest.Checksum64)"
     }
     "brave.nuspec"                = @{


### PR DESCRIPTION
## Description

The changes in this pull request updates the brave package to continue embedding the 64bit installers, while the 32bit installer is now being downloaded during runtime if the running computer is a 32bit system, or the user has requested to install the 32bit version of bave.

This pull request fixes #2158

## Motivation and Context

The package has gotten too large to be able to embed both the 32bit and 64bit executables, as such we need to move to the next best thing which is to only partially embedd executables.

## How Has this Been Tested?

As a first step we need to create the expected package.

1. Run the script in the root directory with the following command: `.\update_all.ps1 brave`
2. Verify it created both a stable and beta versions (at the time of writing, these were version `1.49.128` and `1.50.101-beta`)
3. Verify the Chocolatey Install script updated the following items:
   - `$softwareVersion` was updated to one of the created package versions
   - `url` was updated to the location of the remote 32bit binary
   - `checksum` was updated to a checksum of the binary
   - `checksumType` was updated to SHA256
   - `file64` was updated to the embedded file location
4. Verify the Verification.txt textfile was updated
   - x86_64 download location was updated to the remote location of the 64bit installer
   - checksum64 was updated to the checksum of the embedded binary
5. Copy the stable package to a snapshotted version of the chocolatey-test-environment (can use the shared directory, I will say `C:\packages` as the source).
   **DO NOT TEST USING VAGRANT UP, OR THROUGH WINRM. Installing brave through winrm does not function.**
6. Inside the VM run `choco install brave --source C:\packages
7. Verify no mention of downloading any remote binaries
8. Open Brave, go to `About Brave` and verify it installed 64bit version
9. Restore snapshot
10. Run `choco install brave --source C:\packages --x86`
11. Verify it mentions downloading remote binary
12. Open Brave, got to `About Brave` and verify it installed 32bit version.
13. Repeat steps 5-12 using the beta package (and an additional `--pre` on the choco install calls)

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment (WinRM install will also succeed, but it is not functional).
- [x] The changes only affect a single package (not including meta package).
