### PR TITLE
(encfs4win) Use new API helper to get GitHub releases

### DIFF
--- a/update_all.ps1
+++ b/update_all.ps1
@@ -107,7 +107,7 @@ $Options = [ordered]@{
         $Options.ModulePaths | % { Import-Module $_ }
         . $Options.UpdateIconScript $PackageName.ToLowerInvariant() -Quiet -ThrowErrorOnIconNotFound
         . $Options.UpdatePackageSourceScript $PackageName.ToLowerInvariant() -Quiet
-        if (Test-Path tools) { Expand-Aliases -Directory tools }
+        Expand-Aliases -Directory "$PWD"
 
         $pattern = "^${PackageName}(?:\\(?<stream>[^:]+))?(?:\:(?<version>.+))?$"
         $p = $Options.ForcedPackages | ? { $_ -match $pattern }


### PR DESCRIPTION
## Description

This pull request updates the automated updater to make use of the new API helper when getting releases from GitHub.
This change was needed as the old way of doing things does no longer work as these are populated using JavaScript on the website.

Additionally, the call to expanding aliases has also been updated to expand all aliases in a package directory so it will expand any aliases in `update.ps1` as well.

fixes #2192

## Motivation and Context

To get the automated updater working again

## How Has this Been Tested?

1. Run `.\update_all.ps1 encfs4win`
2. Verify there are no failures, and the package update was ignored.
3. Run `.\update_all.ps1 encfs4win -ForcedPackages encfs4win\1.10`.
4. Verify a the package was updated with a new fix version for the latest `1.1.x` version.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment (_No changes to the install script, only to the updater. No need to test this_).
- [x] The changes only affect a single package (not including meta package).
