### PR TITLE
(wixtoolset) Change to only track GitHub v3 releases

### DIFF
--- a/automatic/wixtoolset/wixtoolset.nuspec
+++ b/automatic/wixtoolset/wixtoolset.nuspec
@@ -32,6 +32,7 @@ With Burn, the WiX bootstrapper, you can create setup bundles that install prere
 The WiX SDK includes managed and native libraries that make it easier to write code that works with Windows Installer, including custom actions in both C# and C++.
 
 ]]></description>
+    <releaseNotes>Will be replaced by updater</releaseNotes>
     <dependencies>
       <dependency id="dotnet3.5" version="3.5.20160716" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />

--- a/automatic/wixtoolset/wixtoolset.nuspec
+++ b/automatic/wixtoolset/wixtoolset.nuspec
@@ -35,7 +35,6 @@ The WiX SDK includes managed and native libraries that make it easier to write c
     <releaseNotes>Will be replaced by updater</releaseNotes>
     <dependencies>
       <dependency id="dotnet3.5" version="3.5.20160716" />
-      <dependency id="chocolatey-core.extension" version="1.3.3" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
## Description

The website looks have changed, which makes it harder to parse the website. With this in mind this pull request changes to track the v3 releases available on GitHub through our custom API helper instead.
We need to keep an eye on the development in v4 for this, in case they decide to release a full installer for it but as of right now that isn't available.

Ref #2187 (remember to tick the task for `wixtoolset` when merging)

## Motivation and Context

To get the automatic updater fixed.

## How Has this Been Tested?

1. Run `.\update_all.ps1 wixtoolset -ForcedPackages wixtoolset`
2. Verify it created a new fix version successfully.
3. Restore a snapshot of chocolatey-test-environment
4. Run `choco install wixtoolset --source "C:\packages;chocolatey"` (change C:\packages to where you have the wixtoolset package)
5. Verify it successfully installed
6. Run `choco uninstall wixtoolset`
7. Verify it successfully uninstalled

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).