### PR TITLE
(universal-usb-installer) Treat trailing character as a additional version number

### DIFF
--- a/automatic/universal-usb-installer/update.ps1
+++ b/automatic/universal-usb-installer/update.ps1
@@ -16,6 +16,18 @@ function global:au_SearchReplace {
     }
   }
 }
+
+function Convert-CharacterToNumber {
+  param(
+    [Parameter(Mandatory)]
+    [char] $character
+  )
+
+  $newNum = ([int]$character) + 1
+
+  $newNum - [int]([char]'a')
+}
+
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
@@ -27,6 +39,13 @@ function global:au_GetLatest {
 
   $verRe = '[-]|\.exe$'
   $version32 = $url32 -split "$verRe" | Select-Object -Last 1 -Skip 1
+
+  if ($version32 -match "^([\d\.]+)([a-z])$") {
+    $m1 = $Matches[1]
+    $num = Convert-CharacterToNumber $Matches[2]
+    $version32 = "${m1}$num"
+  }
+
   @{
     URL32   = $url32
     Version = Get-FixVersion $version32 -OnlyFixBelowVersion $padVersionUnder


### PR DESCRIPTION
## Description

This pull request updates the automatic updater to treat any trailing character
as its own number to be appended to the last version part, this allows us to
create a new package version even when the software developer has created
a new version without using a pure version number.

ref #2187


## Motivation and Context

To have a working automatic updater

## How Has this Been Tested?

1. Run `.\update_all.ps1 universal-usb-installer`
2. Verify it updated to `2.0.1.4100` (those last zeros are the fix version part)

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment (Not changing any package scripts).
- [x] The changes only affect a single package (not including meta package).