### PR TITLE
(docs) Add discussion template for package migrations

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/migrations.yml
+++ b/.github/DISCUSSION_TEMPLATE/migrations.yml
@@ -1,0 +1,44 @@
+title: "(packageName) Request for migration"
+body:
+  - type: markdown
+    attributes:
+      value: We appreciate your interest in migrating a package to the Chocolatey Packages Repository.
+        Before we can start handling your request, there are a few questions we need you to answer.
+
+        Please also verify that you have looked to see if any existing migration requests have opened.
+
+        Please understand that it may take some time before we decide whether to accept or reject any package migration request.
+        A discussion between team repository maintainers will happen before making the decision.
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why should the package be migrated to this Chocolatey Packages Repository?
+      description: Please describe in detail why you believe the package should be migrated to this repository. The reason must include why the package can not be in your source repository.
+    validations:
+      required: true
+  - type: input
+    id: ccr-link
+    attributes:
+      label: What is the link to the package hosted on Chocolatey Community Repository?
+    validations:
+      required: true
+  - type: input
+    id: source-link
+    attributes:
+      label: Where are the sources located?
+      description: Please provide a link to where we can see the package source outside the Chocolatey Community Repository.
+  - type: checkboxes
+    attributes:
+label: I will be responsible for creating a PR to migrate the package.
+          required: true
+label: I will be available to fix any issues with the package or the automatic updater!
+  - type: input
+    id: responsible
+    attributes:
+      label: Who will fix any issues with the package or the automatic updater?
+      description: If you have already marked the previous check box, feel free to ignore this one. Any other person or community mentioned here must confirm through a comment that they agreed. We will not reach out to the user or community!
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Is there any other context you believe is relevant that we need to consider when deciding whether to accept or reject this package migration request?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,7 +8,7 @@ contact_links:
   - name: Request a new package being migrated to this repository.
     # This same annoying url is used here as well to pre-fill some parts of the new discussion that needs to be created.
     # Follow the link to see what will be displayed.
-    url: https://github.com/chocolatey-community/chocolatey-packages/discussions/new?category=ideas&title=(packageName)%20Migrate%20package&body=%3C%21--%20DO%20NOT%20OPEN%20A%20DISCUSSION%20ABOUT%20MIGRATING%20A%20PACKAGE%20WITHOUT%20HAVING%20PERMISSIONS%20FROM%20THE%20MAINTAINER%20OF%20THE%20PACKAGE.%20IF%20THE%20PACKAGE%20MAINTAINER%20IS%20UNRESPONSIVE%2C%20FOLLOW%20THE%20NORMAL%20PACKAGE%20TRIAGE%20DOCUMENTATION.%0A%0AInclude%20details%20of%20why%20it%20should%20be%20migrated%20to%20this%20repository%2C%20who%20will%20be%20responsible%20for%20keeping%20it%20up%20to%20date%20and%20who%20will%20fix%20any%20issues%20that%20get%20reported%20%28either%20by%20users%2C%20or%20the%20automated%20checks%20on%20the%20Community%20Repository%29%20--%3E
+    url: https://github.com/chocolatey-community/chocolatey-packages/discussions/new?category=migrations
     about: Open a discussion about moving a package you own, or have permission to move over to this repository.
   - name: Ask a Question
     url: https://github.com/chocolatey-community/chocolatey-packages/discussions/categories/q-a


### PR DESCRIPTION
## Description

This pull request adds a new template people can use when they request migrating a package to this repository.

## Motivation and Context

To make it a bit easier to find, and request new migrations.

## How Has this Been Tested?

N/A

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)
- [x] Repository Maintenance

## Checklist:

- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
