### PR TITLE
(sysinternals) fix minor cosmetic typo

### DIFF
--- a/automatic/sysinternals/tools/chocolateyBeforeModify.ps1
+++ b/automatic/sysinternals/tools/chocolateyBeforeModify.ps1
@@ -1,3 +1,3 @@
 ﻿$toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-Write-Host "Closing processes from sysinternals  package installation directory"
+Write-Host "Closing processes from sysinternals package installation directory"
 Remove-Process -PathFilter ([regex]::escape('C:\ProgramData\chocolatey\lib\sysinternals\tools') + ".*") | Out-Null


### PR DESCRIPTION
## Description
Minor fix for trailing space after "sysinternals" string in Write-Host call.

## Motivation and Context
General clean-up, nothing fancy.

## How Has this Been Tested?
It hasn't, but it's a single-byte cosmetic change, so...

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
