### PR TITLE
Remove dotnet4.5.2 dependency

### DIFF
--- a/automatic/vscode.install/vscode.install.nuspec
+++ b/automatic/vscode.install/vscode.install.nuspec
@@ -47,7 +47,6 @@ Example: `choco install vscode.install --params "/NoDesktopIcon /DontAddToPath"`
     <tags>microsoft visualstudiocode vscode development editor ide javascript typescript admin foss cross-platform</tags>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="dotnet4.5.2" version="4.5.2.20140902" />
     </dependencies>
     <releaseNotes>https://code.visualstudio.com/Updates</releaseNotes>
   </metadata>


### PR DESCRIPTION
Remove dotnet4.5.2 dependency from VSCode.Install package.

## Description
Removed the dotnet4.5.2 dependency from VSCode.Install package.

## Motivation and Context
The dotnet4.5.2 package is out of support, and it not required anymore from VSCode ever since Windows 7 went out of support.
This commit will fix https://github.com/chocolatey-community/chocolatey-packages/issues/2224

## How Has this Been Tested?
Tested both vscode.install and vscode.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [] The changes only affect a single package (not including meta package).