### PR TITLE
(libreoffice-streams) Add NoDesktopIcon package parameter

### DIFF
--- a/automatic/libreoffice-streams/README.fresh.md
+++ b/automatic/libreoffice-streams/README.fresh.md
@@ -2,6 +2,10 @@
 
 LibreOffice is the free power-packed Open Source personal productivity suite for Windows, macOS and Linux, that gives you six feature-rich applications for all your document production and data processing needs.
 
+## Package parameters
+* `/NoDesktopIcon` - Don't add a desktop icon.
+Example: `choco install libreoffice-fresh --params "/NoDesktopIcon"`
+
 ## Notes
 
 - This package relies on the update service provided by The Document Foundation to determine new updates. As their policy is to distribute to their website immediately and to the update service after 1 to 2 weeks, there will be a delay between a new software update and a new version release of the package.

--- a/automatic/libreoffice-streams/README.md
+++ b/automatic/libreoffice-streams/README.md
@@ -4,7 +4,7 @@ LibreOffice is the free power-packed Open Source personal productivity suite for
 
 ## Package parameters
 * `/NoDesktopIcon` - Don't add a desktop icon.
-Example: `choco install libreoffice-fresh --params "/NoDesktopIcon"`
+Example: `choco install libreoffice-streams --params "/NoDesktopIcon"`
 
 ## Notes
 

--- a/automatic/libreoffice-streams/README.md
+++ b/automatic/libreoffice-streams/README.md
@@ -2,6 +2,10 @@
 
 LibreOffice is the free power-packed Open Source personal productivity suite for Windows, macOS and Linux, that gives you six feature-rich applications for all your document production and data processing needs.
 
+## Package parameters
+* `/NoDesktopIcon` - Don't add a desktop icon.
+Example: `choco install libreoffice-fresh --params "/NoDesktopIcon"`
+
 ## Notes
 
 - This package relies on the update service provided by The Document Foundation to determine new updates. As their policy is to distribute to their website immediately and to the update service after 1 to 2 weeks, there will be a delay between a new software update and a new version release of the package.

--- a/automatic/libreoffice-streams/README.still.md
+++ b/automatic/libreoffice-streams/README.still.md
@@ -2,6 +2,10 @@
 
 LibreOffice is the free power-packed Open Source personal productivity suite for Windows, macOS and Linux, that gives you six feature-rich applications for all your document production and data processing needs.
 
+## Package parameters
+* `/NoDesktopIcon` - Don't add a desktop icon.
+Example: `choco install libreoffish-still --params "/NoDesktopIcon"`
+
 ## Notes
 
 - This package relies on the update service provided by The Document Foundation to determine new updates. As their policy is to distribute to their website immediately and to the update service after 1 to 2 weeks, there will be a delay between a new software update and a new version release of the package.

--- a/automatic/libreoffice-streams/libreoffice-streams.nuspec
+++ b/automatic/libreoffice-streams/libreoffice-streams.nuspec
@@ -10,6 +10,10 @@
     <summary>LibreOffice is the free power-packed Open Source personal productivity suite for Windows, Macintosh and Linux, that gives you six feature-rich applications for all your document production and data processing needs.</summary>
     <description><![CDATA[LibreOffice is the free power-packed Open Source personal productivity suite for Windows, macOS and Linux, that gives you six feature-rich applications for all your document production and data processing needs.
 
+## Package parameters
+* `/NoDesktopIcon` - Don't add a desktop icon.
+Example: `choco install libreoffice-streams --params "/NoDesktopIcon"`
+
 ## Notes
 
 - This package relies on the update service provided by The Document Foundation to determine new updates. As their policy is to distribute to their website immediately and to the update service after 1 to 2 weeks, there will be a delay between a new software update and a new version release of the package.

--- a/automatic/libreoffice-streams/tools/chocolateyInstall.ps1
+++ b/automatic/libreoffice-streams/tools/chocolateyInstall.ps1
@@ -23,5 +23,7 @@ if (-not (IsUrlValid $packageArgs.url)) {
   $packageArgs.url = $exactVersion.Url32
   $packageArgs.url64bit = $exactVersion.Url64
 }
+$pp = Get-PackageParameters
+if ($pp['NoDesktopIcon']) { $packageArgs.silentArgs += 'CREATEDESKTOPLINK=0' }
 
 Install-ChocolateyPackage @packageArgs

--- a/automatic/libreoffice-streams/tools/chocolateyInstall.ps1
+++ b/automatic/libreoffice-streams/tools/chocolateyInstall.ps1
@@ -24,6 +24,6 @@ if (-not (IsUrlValid $packageArgs.url)) {
   $packageArgs.url64bit = $exactVersion.Url64
 }
 $pp = Get-PackageParameters
-if ($pp['NoDesktopIcon']) { $packageArgs.silentArgs += 'CREATEDESKTOPLINK=0' }
+if ($pp['NoDesktopIcon']) { $packageArgs.silentArgs += ' CREATEDESKTOPLINK=0' }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
## Description
Add '/NoDesktopIcon' package parameter to package
Setting --params '/NoDesktopIcon' appends 'CREATEDESKTOPLINK=0' to the end of the package's silentArgs variable.
When the parameter is unset, nothing happens because CREATEDESKTOPLINK=1 is set by default in libreoffice MSI installers.

## Motivation and Context
Allows user to disable the creation of the Desktop Icon / Desktop Shortcut.

## How Has this Been Tested?
I installed and uninstalled libreoffice-fresh and libreoffice-still packages with the --params '/NoDesktopIcon' set and unset, both in a running system and in the chocolatey-community test environment.

With '/NoDesktopIcon' unset, the packages installed with a desktop icon added, as expected.
With '/NoDesktopIcon' set, they installed with no desktop icon.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [X] My change requires a change to documentation (this usually means the notes in the description of a package).
- [X] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [X] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [X] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
