### PR TITLE
update checksum

### DIFF
--- a/manual/lockhunter/lockhunter.nuspec
+++ b/manual/lockhunter/lockhunter.nuspec
@@ -5,7 +5,7 @@
     <id>lockhunter</id>
     <title>LockHunter</title>
     <!-- They had rolled back the actual version, so we use a date fix version to allow updating the package -->
-    <version>3.4.3.20220526</version>
+    <version>3.4.3.20230609</version>
     <authors>Igor Tkachenko, Nikolay Duylovskiy, Crystal Rich Ltd</authors>
     <owners>chocolatey-community, Rob Reynolds</owners>
     <copyright>2016 Crystal Rich Ltd</copyright>

--- a/manual/lockhunter/tools/chocolateyInstall.ps1
+++ b/manual/lockhunter/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $packageArgs = @{
   packageName    = $env:chocolateyPackageName
   fileType       = 'EXE'
   url            = 'https://lockhunter.com/assets/exe/lockhuntersetup_3-4-3.exe'
-  checksum       = '982dda5eec52dd54ff6b0b04fd9ba8f4c566534b78f6a46dada624af0316044e'
+  checksum       = '2C0D52DCA3E5CE9CFC8062CB72C7235E3C6FF650242FCB7D46A892D602DD3DD1'
   checksumType   = 'sha256'
   silentArgs     = "/VERYSILENT /NORESTART /SUPPRESSMSGBOXES /SP- /LOG=`"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).InnoInstall.log`""
   validExitCodes = @(0)


### PR DESCRIPTION
Updated checksum for lockhunter

Attempted to run choco install lockhunter and ran into this error message:
> Error - hashes do not match. Actual value was 'CE9A8B33BC156E00F7FEA7EF40049A7DA0D4531243E7511A29B36D416B904914'.

I set the new checksum here

From [Issue](https://github.com/chocolatey-community/chocolatey-packages/issues/2223)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

