### PR TITLE
(spotify) fix timeout error

### DIFF
--- a/automatic/spotify/tools/ChocolateyInstall.ps1
+++ b/automatic/spotify/tools/ChocolateyInstall.ps1
@@ -17,7 +17,7 @@ $arguments['file'] = Get-ChocolateyWebFile @arguments
 
 # It doesn't matter what time we choose, we need to start it manually
 schtasks.exe /Create /SC Once /st (Get-Date -Format 'HH:mm') /TN $arguments['packageName'] /TR "'$($arguments['file'])' $($arguments['silentArgs'])" /F 2>$null
-schtasks.exe /Run /TN $arguments['packageName']
+schtasks.exe /Run /TN $arguments['packageName'] /I
 Start-Sleep -s 1
 schtasks.exe /Delete /TN $arguments['packageName'] /F
 


### PR DESCRIPTION
## Description
I created a possible fix for a timeout issue when installing spotify. The script waits for Spotify to run as an check for successful installation, which sometimes fails.

I've added the `/I` argument to the `schtasks.exe`-command:
>     /I                   Runs the task immediately by ignoring any constraint.

## Motivation and Context
The "wait for Spotify to start" gives a timeout error.
Spotify is never started using the `schtasks /Run`, so the `Get-Process` will never evaluate to true.

Resulting in the following output:
> SUCCESS: The scheduled task "spotify" has successfully been created.
SUCCESS: Attempted to run the scheduled task "spotify".
SUCCESS: The scheduled task "spotify" was successfully deleted.
Chocolatey timed out waiting for the command to finish. The timeout specified (or the default value) was '2700' seconds. Perhaps try a higher `--execution-timeout`? See `choco -h` for  details.

## How Has this Been Tested?
- When I manually started Spotify during `choco upgrade spotify`, the script continues and exits. Suggesting the `schtasks /Run` isn't working as expected.
- The script deletes the task to quick to manually start the task from the Task Scheduler UI.
- I was able to replicate the issue with a local PS1-script, with hardcoded arguments.
- After adding `/I`, Spotify is started and the script continues.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).

## Original Location
N/A