### PR TITLE
(jenkins) Fixes the Validation File Update

### DIFF
--- a/automatic/jenkins/legal/VERIFICATION.txt
+++ b/automatic/jenkins/legal/VERIFICATION.txt
@@ -5,7 +5,7 @@ in verifying that this package's contents are trustworthy.
 The installer has been downloaded from their official download link from <https://www.jenkins.io/download/>
 
 1. Download the file via:
-  64-Bit: 2.387.2/jenkins.msi>
+  64-Bit: <http://mirrors.jenkins-ci.org/windows-stable/2.387.2/jenkins.msi>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'

--- a/automatic/jenkins/update.ps1
+++ b/automatic/jenkins/update.ps1
@@ -7,9 +7,9 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
     @{
         ".\legal\VERIFICATION.txt" = @{
-            "(?i)(64-Bit.+)\<.*\>"   = "`${1}$($Latest.Version)/jenkins.msi>"
-            "(?i)(checksum type:).*" = "`${1} $($Latest.ChecksumType64)"
-            "(?i)(checksum64:).*"    = "`${1} $($Latest.Checksum64)"
+            "(?i)(64-Bit.+\<.+/)[\d\.]+/jenkins.msi\>" = "`${1}$($Latest.Version)/jenkins.msi>"
+            "(?i)(checksum type:).*"                   = "`${1} $($Latest.ChecksumType64)"
+            "(?i)(checksum64:).*"                      = "`${1} $($Latest.Checksum64)"
         }
         ".\tools\chocolateyInstall.ps1" = @{
             "(?i)(^\s*file\s*=\s*`"[$]ToolsDir\\).+`"" = "`${1}$($Latest.FileName64)`""


### PR DESCRIPTION
## Description
The update script was swallowing too much on a match, and invalidating the match on the next run. This fixes the validation file, and fixes the update script.

This should fix the Jenkins package update.

## Motivation and Context
The Jenkins package was failing to update. This should solve that issue!

## How Has this Been Tested?
- Checkout fix branch
- `.\update_all.ps1 jenkins`
- Observe changed files to ensure
    - Jenkins package is updated successfully
    - Verification.txt is still going to match the appropriate regex

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
