### PR TITLE
(maint) Bump Chocolatey Version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,8 +48,8 @@ environment:
     secure: zPuYvdxGda6DUGRCwTJL5FQCWF3U+1bSLE2mEr+VfpfV08NXlXX2uFLizkhQuJYW
 
   #Chocolatey version we want to use when checking for updates (usually latest).
-  choco_version: '1.3.1'
-  choco_version_pr: '1.0.1' # Should be kept to the version available one year ago
+  choco_version: '2.0.0'
+  choco_version_pr: '1.1.0' # Should be kept to the version available one year ago
   nupkg_cache_path: C:\packages
 
 init:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -25,7 +25,6 @@ body:
         - 1.2.1
         - 1.2.0
         - 1.1.0
-        - 1.0.1
         - Other (note in the comments)
     validations:
       required: true


### PR DESCRIPTION
## Description

This updates the Chocolatey version used when building pull requests,
when pushing and running normal updates and removes an unsupported
version of Chocolatey CLI.

## Motivation and Context

We always want to use the latest stable version of Chocolatey CLI when updating and pushing packages, the latest supported version when building pull request and to not list any versions of Chocolatey CLI that is too old for us to support.

## How Has this Been Tested?

N/A

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
