### PR TITLE
Selenium chromium edge driver 114

### DIFF
--- a/automatic/selenium-chromium-edge-driver/selenium-chromium-edge-driver.nuspec
+++ b/automatic/selenium-chromium-edge-driver/selenium-chromium-edge-driver.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>selenium-chromium-edge-driver</id>
     <!-- Do not touch the version, it will be updated automatically during the update check -->
-    <version>112.0.1722.39</version>
+    <version>114.0.1823.18</version>
     <title>Selenium Chromium Edge Driver</title>
     <authors>Chromium and Microsoft teams</authors>
     <owners>chocolatey-community,agabrys,laurin1,AdmiringWorm</owners>

--- a/automatic/selenium-chromium-edge-driver/tools/chocolateyinstall.ps1
+++ b/automatic/selenium-chromium-edge-driver/tools/chocolateyinstall.ps1
@@ -7,10 +7,10 @@ $parameters = Get-PackageParameters
 
 $packageArgs = @{
   packageName    = 'selenium-chromium-edge-driver'
-  url            = 'https://msedgedriver.azureedge.net/112.0.1722.39/edgedriver_win32.zip'
-  url64          = 'https://msedgedriver.azureedge.net/112.0.1722.39/edgedriver_win64.zip'
-  checksum       = 'b17cfb0165b34e89d175e55f1358915edf4c23624a76b1d118034b241ad7d881'
-  checksum64     = '0d68705e8258567dc4fe1160eb0b066e988e641de99e87e6c06380b15cedb180'
+  url            = 'https://msedgedriver.azureedge.net/114.0.1823.18/edgedriver_win32.zip'
+  url64          = 'https://msedgedriver.azureedge.net/114.0.1823.18/edgedriver_win64.zip'
+  checksum       = 'b02827509473bd351ced31b1e3a70e9094c42b945327543d3f3592ee0b7aa407'
+  checksum64     = '44a0383745813c295ba0ebc9faf94cbf60a966ba460b5f4629d3a1293a6eaf3f'
   checksumType   = 'sha256'
   checksumType64 = 'sha256'
   unzipLocation  = $seleniumDir


### PR DESCRIPTION
Update Selenium chromium edge driver to version 114

## Description
Changed the version and hashes to use the latest 114 drivers

fix #2241 

## Motivation and Context
Edge browser 114 has been available for some time and for testing we require the corresponding webdriver 114.

## How Has this Been Tested?
Checked against previouse versions.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
