### PR TITLE
(autohotkey.install)(#1710) Add AutoHotkey v2 with v1 compatibility

### DIFF
--- a/automatic/autohotkey.install/tools/VERIFICATION.txt
+++ b/automatic/autohotkey.install/tools/VERIFICATION.txt
@@ -1,4 +1,4 @@
-VERIFICATION
+﻿VERIFICATION
 
 Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
@@ -7,8 +7,8 @@ Package can be verified like this:
 
 1. Go to
 
-   x32: https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.37.02/AutoHotkey_1.1.37.02_setup.exe
-   x64: https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.37.02/AutoHotkey_1.1.37.02_setup.exe
+   v1 x32: https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.36.02/AutoHotkey_1.1.36.02_setup.exe
+   v2 x32: https://github.com/Lexikos/AutoHotkey_L/releases/download/v2.0.11/AutoHotkey_2.0.11_setup.exe
 
    to download the installer.
 
@@ -16,12 +16,12 @@ Package can be verified like this:
    - Use powershell function 'Get-FileHash'
    - Use Chocolatey utility 'checksum.exe'
 
-   checksum32: 49A48E879F7480238D2FE17520AC19AFE83685AAC0B886719F9E1EAC818B75CC
-   checksum64: 49A48E879F7480238D2FE17520AC19AFE83685AAC0B886719F9E1EAC818B75CC
+   v1 checksum32: AF7B8E60B4B54F5F85E6B207AC51926CB076AA4319B8E4C72E59B98C85818CAE
+   v2 checksum32: 510A833BDD0F896CC398EAAE4FF475F5B7CFE37649EFBF647B50D21E442394B9
 
 Using Chocolatey AU:
 
-   Get-RemoteChecksum https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.37.02/AutoHotkey_1.1.37.02_setup.exe
+   Get-RemoteChecksum https://github.com/Lexikos/AutoHotkey_L/releases/download/v2.0.11/AutoHotkey_2.0.11_setup.exe
 
 File 'license.txt' is obtained from:
    https://github.com/AutoHotkey/AutoHotkey/blob/df84a3e902b522db0756a7366bd9884c80fa17b6/license.txt

--- a/automatic/autohotkey.install/tools/chocolateyInstall.ps1
+++ b/automatic/autohotkey.install/tools/chocolateyInstall.ps1
@@ -1,29 +1,53 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsDir = Split-Path $MyInvocation.MyCommand.Definition
+$installerv1File = 'AutoHotkey_1.1.36.02_setup.exe'
+$installerv2File = 'AutoHotkey_2.0.11_setup.exe'
 
 $pp = Get-PackageParameters
 if (!$pp.DefaultVer){
   $pp.DefaultVer = if ((Get-OSArchitectureWidth 64) -and ($Env:chocolateyForceX86 -ne 'true')) { 'U64' } else { 'U32' }
 }
 
-$packageArgs = @{
+$packageArgsv2 = @{
   packageName    = 'autohotkey.install'
   fileType       = 'exe'
-  file           = Get-Item "$toolsDir\*.exe"
-  silentArgs     = "/S /$($pp.DefaultVer)"
+  file           = Join-Path -Path $toolsDir -ChildPath $installerv2File
+  silentArgs     = "/silent"
   softwareName   = 'AutoHotkey*'
   validExitCodes = @(0, 1223)
 }
-Install-ChocolateyInstallPackage @packageArgs
-Remove-Item $toolsDir\*.exe
 
-$installLocation = Get-AppInstallLocation $packageArgs.softwareName
-$packageName = $packageArgs.softwareName
-if ($installLocation)  {
-    $installName = 'AutoHotkey'
-    Write-Host "$packageName installed to '$installLocation'"
-    Register-Application "$installLocation\$installName.exe"
-    Write-Host "$packageName registered as $installName"
+Install-ChocolateyInstallPackage @packageArgsv2
+
+$installLocation = Get-AppInstallLocation $packageArgsv2.softwareName
+$packageName = $packageArgsv2.softwareName
+$installName = 'AutoHotkey'
+$exePath = Join-Path -Path $installLocation -ChildPath "v2\$installName.exe"
+if ($installLocation) {
+  Write-Host "$packageName installed to '$installLocation'"
+  Register-Application -ExePath $exePath
+  Write-Host "$packageName registered as $installName"
 }
-else { Write-Warning "Can't find $packageName install location" }
+else {
+  Write-Warning "Can't find $packageName install location"
+}
+
+$packageArgsv1 = @{
+  packageName    = 'autohotkey.install'
+  fileType       = 'exe'
+  file           = Join-Path -Path $toolsDir -ChildPath $installerv1File
+  silentArgs     = "/S /$($pp.DefaultVer) /install"
+  softwareName   = 'AutoHotkey*'
+  validExitCodes = @(0, 1223)
+}
+
+Install-ChocolateyInstallPackage @packageArgsv1
+
+# This is run to ensure that version 2.x is shown in Programs and Features and registered with the system.
+# See https://www.autohotkey.com/docs/v2/Program.htm#install_v1
+# The /silent switch was found by looking at the ux\install.ahk script
+$ahkInstall = Join-Path -Path $installLocation -ChildPath 'ux\install.ahk'
+Start-ChocolateyProcessAsAdmin -ExeToRun $exePath -Statements """$ahkInstall"" /silent"
+
+Remove-Item $toolsDir\*.exe

--- a/automatic/autohotkey.install/update.ps1
+++ b/automatic/autohotkey.install/update.ps1
@@ -1,20 +1,24 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = 'https://autohotkey.com/download/1.1'
+$releases = 'https://autohotkey.com/download/2.0'
+$v1Version = '1.1.36.02'
+$v1Filename = "AutoHotkey_$($v1Version)_setup.exe"
 
 function global:au_SearchReplace {
-   @{
+    @{
         ".\tools\chocolateyInstall.ps1" = @{
-            "(?i)(^\s*packageName\s*=\s*)('.*')"  = "`$1'$($Latest.PackageName)'"
-            "(?i)(^\s*fileType\s*=\s*)('.*')"     = "`$1'$($Latest.FileType)'"
+            '(?i)(^\s*\$installerv1File\s*=\s*)(''.*'')' = "`$1'$($Latest.v1FileName)'"
+            '(?i)(^\s*\$installerv2File\s*=\s*)(''.*'')' = "`$1'$($Latest.FileName)'"
+            "(?i)(^\s*packageName\s*=\s*)('.*')"      = "`$1'$($Latest.PackageName)'"
+            "(?i)(^\s*fileType\s*=\s*)('.*')"         = "`$1'$($Latest.FileType)'"
         }
 
         ".\tools\verification.txt" = @{
-          "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL)"
-          "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL)"
-          "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum)"
-          "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum)"
-          "(?i)(Get-RemoteChecksum).*" = "`${1} $($Latest.URL)"
+          "(?i)(\s+v1 x32:).*"            = "`${1} $($Latest.v1URL)"
+          "(?i)(v1 checksum32:).*"        = "`${1} $($Latest.v1Checksum)"
+          "(?i)(\s+v2 x32:).*"            = "`${1} $($Latest.URL)"
+          "(?i)(v2 checksum32:).*"        = "`${1} $($Latest.Checksum)"
+          "(?i)(Get-RemoteChecksum).*"    = "`${1} $($Latest.URL)"
         }
     }
 }
@@ -23,21 +27,31 @@ function global:au_BeforeUpdate {
     Remove-Item "$PSScriptRoot\tools\*.exe"
 
     $client = New-Object System.Net.WebClient
-        $filePath = "$PSScriptRoot\tools\$($Latest.FileName)"
-        $client.DownloadFile($Latest.URL, $filePath)
+    $filePath = "$PSScriptRoot\tools\$($Latest.FileName)"
+    $client.DownloadFile($Latest.URL, $filePath)
     $client.Dispose()
 
     $Latest.ChecksumType = 'sha256'
-    $Latest.Checksum = Get-FileHash -Algorithm $Latest.ChecksumType -Path $filePath | ForEach-Object Hash
+    $Latest.Checksum = (Get-FileHash -Algorithm $Latest.ChecksumType -Path $filePath).Hash
+
+    $client = New-Object System.Net.WebClient
+    $filePath = "$PSScriptRoot\tools\$($Latest.v1FileName)"
+    $client.DownloadFile($Latest.v1URL, $filePath)
+    $client.Dispose()
+
+    $Latest.v1ChecksumType = 'sha256'
+    $Latest.v1Checksum = (Get-FileHash -Algorithm $Latest.ChecksumType -Path $filePath).Hash
 }
 
 function global:au_GetLatest {
-    $version = Invoke-WebRequest -Uri "$releases\version.txt" -UseBasicParsing | ForEach-Object Content
-    $url     = "https://github.com/Lexikos/AutoHotkey_L/releases/download/v${version}/AutoHotkey_${version}_setup.exe"
+    $version = Invoke-WebRequest -Uri "$releases\version.txt" -UseBasicParsing | % Content
+    $url     = "https://github.com/Lexikos/AutoHotkey_L/releases/download/v$($version)/AutoHotkey_$($version)_setup.exe"
     @{
         Version  = $version
         URL      = $url
-        FileName = $url -split '/' | Select-Object -Last 1
+        FileName = "AutoHotkey_$($version)_setup.exe"
+        v1Url    = "https://github.com/Lexikos/AutoHotkey_L/releases/download/v$($v1Version)/$v1Filename"
+        v1FileName = $v1Filename
     }
 }
 


### PR DESCRIPTION
## Description
Adds AutoHotkey v2 with v1 compatibility.

## Motivation and Context
AutoHotkey v1.1 has been deprecated and v2 has been out for some time. There is concern around upgrading to v2 and v1 scripts failing. There are a lot of v1 script still on CCR.

I don't feel this is a breaking change (as functionality has not changed) so have not ticked that below.

Closes #1710 

## How Has this Been Tested?
It was tested in the Chocolatey Test Environment with the [Logitech Presentation](https://community.chocolatey.org/packages/logitech-presentation) package that has an AutohotKey v1 uninstall script. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).