### PR TITLE
(selenium-chromium-edge-driver) Get stable driver version directly from MS

### DIFF
--- a/automatic/selenium-chromium-edge-driver/update.ps1
+++ b/automatic/selenium-chromium-edge-driver/update.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module AU
 
-$releases = "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/"
+$releases = "https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/LATEST_STABLE"
 
 function global:au_BeforeUpdate {
   $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32 -Algorithm $Latest.ChecksumType32
@@ -8,14 +8,6 @@ function global:au_BeforeUpdate {
 
   $Latest.FileName32 = Split-Path -Leaf $Latest.URL32
   $Latest.FileName64 = Split-Path -Leaf $Latest.URL64
-}
-
-function Get-EdgePackageVersion {
-  param($PackageName = 'microsoft-edge')
-
-  $scrape_content = Invoke-RestMethod -Uri "https://community.chocolatey.org/api/v2/package-versions/$PackageName" -UseBasicParsing
-
-  $scrape_content | Select-Object -Last 1
 }
 
 function global:au_SearchReplace {
@@ -36,18 +28,13 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  # We use the available package on CCR as the source of truth
-  $packageVersion = Get-EdgePackageVersion -PackageName 'microsoft-edge'
-  $escapedVersion = [regex]::Escape($packageVersion)
+  $stableVersionFile = "$env:TEMP\EdgeDriverLatestStable.txt"
 
-  $downloadPage = Invoke-WebRequest $releases -UseBasicParsing
+  Invoke-WebRequest -URI $releases -OutFile $stableVersionFile -UseBasicParsing
+  $packageVersion = Get-Content $stableVersionFile
 
-  $url32 = $downloadPage.Links | Where-Object { $_.href -match "$escapedVersion.*win32" } | Select-Object -First 1 -ExpandProperty href
-  $url64 = $downloadPage.Links | Where-Object { $_.href -match "$escapedVersion.*win64" } | Select-Object -First 1 -ExpandProperty href
-
-  if (!$url32 -or !$url64) {
-    throw "The 32bit or 64bit URL is missing"
-  }
+  $url32 = "https://msedgedriver.azureedge.net/$packageVersion/edgedriver_win32.zip"
+  $url64 = "https://msedgedriver.azureedge.net/$packageVersion/edgedriver_win64.zip"
 
   @{
     Version        = $packageVersion


### PR DESCRIPTION
## Description

Changed the automatic update script to fetch the latest stable driver version directly from MS.

## Motivation and Context

Currently the package is only updated if the edge driver download page has a driver link with the version matching the current version of the microsoft-edge package.

The versions of the selenium driver and browser don't necessarily match up and this caused the update script to be broken for quite a long time. Because of this now quite a few versions of the selenium drivers are missing on chocolatey.

Loading the latest stable driver version from MS and using that for the download links is a more stable approach for the update script. 

Fixes #2241 

## How Has this Been Tested?

Run locally
Had the almost identical PS script in use for the last ~ 1.5 years because for quite some time there was no up-to-date edge driver package.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
