### PR TITLE
(python3-streams) Also lockdown sub-folders

### DIFF
--- a/automatic/python3-streams/tools/helpers.ps1
+++ b/automatic/python3-streams/tools/helpers.ps1
@@ -93,7 +93,7 @@ function Protect-InstallFolder {
   $ErrorActionPreference = 'Stop'
   try {
     # get current acl
-    $acl = (Get-Item $folder).GetAccessControl('Access,Owner')
+    $acl = Get-Acl -Path $folder
 
     Write-Debug "Removing existing permissions."
     $acl.Access | ForEach-Object { $acl.RemoveAccessRuleAll($_) }
@@ -139,7 +139,7 @@ function Protect-InstallFolder {
     $acl.SetAccessRuleProtection($true, $false)
 
     # enact the changes against the actual
-    (Get-Item $folder).SetAccessControl($acl)
+    Set-Acl -Path $folder -AclObject $acl
   }
   catch {
     Write-Warning "Not able to set permissions for $folder."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->

Fixes https://github.com/chocolatey-community/chocolatey-packages/issues/1840

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

Close the security hole; make permissions consistent

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

All sub-folders are limited to administrators, so pip installs to user site-packages as expected if it's run as a normal user. I tested Python 3.9 and 3.12.
```
PS> python3.9.exe -m pip install pyreadline3
Defaulting to user installation because normal site-packages is not writeable
Collecting pyreadline3
  Using cached pyreadline3-3.4.1-py3-none-any.whl (95 kB)
Installing collected packages: pyreadline3
Successfully installed pyreadline3-3.4.1
PS> python3.12.exe -m pip install pyreadline3
Defaulting to user installation because normal site-packages is not writeable
Collecting pyreadline3
  Using cached pyreadline3-3.4.1-py3-none-any.whl (95 kB)
Installing collected packages: pyreadline3
Successfully installed pyreadline3-3.4.1
```

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment. - I got several issues during setting up the test environment, and I prefer not investing time into those issues
- [x] The changes only affect a single package (not including meta package).
