### PR TITLE
(nexus-repository) Removes Unnecessary Dependency

### DIFF
--- a/automatic/nexus-repository/nexus-repository.nuspec
+++ b/automatic/nexus-repository/nexus-repository.nuspec
@@ -53,9 +53,6 @@ You can pass parameters as follows:
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@f459e946d7b1926ee89c2b415ec8507dffe99218/icons/nexus-repository.png</iconUrl>
     <releaseNotes>https://help.sonatype.com/repomanager3/release-notes</releaseNotes>
-    <dependencies>
-      <dependency id="temurinjre" version="11.0.12.7" />
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
## Description
Removes the dependency for `TermurinJRE` from the `Nexus-Repository` package.

## Motivation and Context
Nexus, it turns out, packs a version of [Azul Zulu](https://www.azul.com/) with the install. This means that the dependency is unrequired.

## How Has this Been Tested?
- Removed dependency from package, packed it
- Installed clean on a Windows Sandbox container
- Observed Nexus working nicely without any installed JRE package

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

I would argue this is not a breaking change, though folk may end up with an unrequired package installed after updating their Nexus package.

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
