### PR TITLE
(datagrip) Fix installation folder

### DIFF
--- a/automatic/datagrip/tools/ChocolateyInstall.ps1
+++ b/automatic/datagrip/tools/ChocolateyInstall.ps1
@@ -2,19 +2,16 @@
 
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-# Workaround for https://youtrack.jetbrains.com/issue/IDEA-202935
-$programFiles = (${env:ProgramFiles(x86)}, ${env:ProgramFiles} -ne $null)[0]
 $pp = Get-PackageParameters
 
-$installDir = "$programFiles\JetBrains\DataGrip $env:ChocolateyPackageVersion"
-if ($pp.InstallDir) {
-    $installDir = $pp.InstallDir
-}
-
 $silentArgs   = "/S /CONFIG=$toolsDir\silent.config "
-$silentArgs   += "/D=`"$installDir`""
-
-New-Item -ItemType Directory -Force -Path $installDir
+if ($pp.InstallDir) {
+    # note there are no quotes around the installDir
+    # (taken from https://www.jetbrains.com/help/datagrip/2023.1/installation-guide.html#silent):
+    # /D: Specify the path to the installation directory
+    # This parameter must be the last in the command line, and it should not contain any quotes even if the path contains blank spaces.
+    $silentArgs   += "/D=$($pp.InstallDir)"
+}
 
 $arguments              = @{
     packageName         = $env:ChocolateyPackageName


### PR DESCRIPTION
## Description
The workaround, and folder having to be created before the installer is run, can be removed as the issue has been fixed in the installer. The installer argument, specifying the installer, should not be wrapped in quotes.

Fixes #2257

## Motivation and Context
The package was creating two folders on install and installing to a custom location did not work.

## How Has this Been Tested?
Installing  in Windows Server 2019.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).