### PR TITLE
(chromium) Get Rid of Choco Dependency on Chromium Pkg

### DIFF
--- a/automatic/chromium/chromium.nuspec
+++ b/automatic/chromium/chromium.nuspec
@@ -28,7 +28,6 @@
     <tags>chromium admin google cross-platform foss chrome browser</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/chromium</packageSourceUrl>
     <dependencies>
-      <dependency id="chocolatey" version="0.10.5" />
     </dependencies>
 
   </metadata>


### PR DESCRIPTION
## Description
With the newer NuGet framework in Chocolatey V 2.x dependency resolution matters more. Hence I have gone and removed this dependency.

## Motivation and Context
Having a dependency of a version of Chocolatey that is no longer supported in this repository doesn't make sense.

## How Has this Been Tested?
Manually compiled package and tested installation on local VM

## Screenshot (if appropriate, usually isn't needed):
NA

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [X] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).
