### PR TITLE
(spotify) Remove Windows Store version

### DIFF
--- a/automatic/spotify/tools/ChocolateyInstall.ps1
+++ b/automatic/spotify/tools/ChocolateyInstall.ps1
@@ -12,6 +12,24 @@ $arguments          = @{
     validExitCodes  = @(0, 1641, 3010)
 }
 
+# check we can use Get-AppxPackage
+if (Get-Command 'Get-AppxPackage' -ErrorAction SilentlyContinue) {
+    # there is likely going to be two packages returned for x86 and x64.
+    # we don't care about the architecture, just the version and they will both be the same.
+    $allAppxPackages = Get-AppxPackage
+    $installedAppXPackage = @($allAppxPackages | Where-Object -Property Name -eq 'SpotifyAB.SpotifyMusic')
+    if ($installedAppXPackage.Count -gt 0) {
+        if ($env:ChocolateyForce) {
+            #when you remove a package, you don't remove it per architecture. You just remove it for all architectures.
+            Write-Warning 'Attempting to remove Spotify installed from the Microsoft Store.'
+            Remove-AppxPackage -Package $installedAppXPackage[0].PackageFullName
+        }
+        else {
+            throw "Cannot install the Spotify package because the Microsft Store version is installed. Please uninstall this manually or add the '--force' option to the command line."
+        }
+    }
+}
+
 # Download the installer
 $arguments['file'] = Get-ChocolateyWebFile @arguments
 
@@ -24,10 +42,10 @@ schtasks.exe /Delete /TN $arguments['packageName'] /F
 # Wait for Spotify to start, then kill it
 $done = $false
 do {
-  if (Get-Process Spotify -ErrorAction SilentlyContinue) {
-    Stop-Process -name Spotify
-    $done = $true
-  }
+    if (Get-Process Spotify -ErrorAction SilentlyContinue) {
+        Stop-Process -name Spotify
+        $done = $true
+    }
 
-  Start-Sleep -s 10
+    Start-Sleep -s 10
 } until ($done)


### PR DESCRIPTION
## Description
Detects and removes the Windows Store version of Spotify if it's already installed and the `--force` option is used. Warn otherwise.

## Motivation and Context
If the Windows Store version is installed, the package will not install.

## How Has this Been Tested?
Run in Windows 10 with the Microsoft Store version of Spotify installed.

## Screenshot (if appropriate, usually isn't needed):

Run without the `--force` option.

![image](https://github.com/chocolatey-community/chocolatey-packages/assets/12760779/b6355076-8f26-417a-834d-cdbd33ca7103)

Run with the `--force` option:

![image](https://github.com/chocolatey-community/chocolatey-packages/assets/12760779/ad355a9d-73bb-4f99-9958-ed560b11639e)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).