### PR TITLE
(vscode) Updated version check API call

### DIFF
--- a/automatic/vscode-insiders.install/update.ps1
+++ b/automatic/vscode-insiders.install/update.ps1
@@ -1,8 +1,8 @@
 ﻿import-module au
 import-module "$PSScriptRoot\..\..\extensions\chocolatey-core.extension\extensions\chocolatey-core.psm1"
 
-$releases32 = 'https://update.code.visualstudio.com/api/update/win32/insider/VERSION'
-$releases64 = 'https://update.code.visualstudio.com/api/update/win32-x64/insider/VERSION'
+$releases32 = 'https://update.code.visualstudio.com/api/update/win32/insider/0000000000000000000000000000000000000000'
+$releases64 = 'https://update.code.visualstudio.com/api/update/win32-x64/insider/0000000000000000000000000000000000000000'
 
 if ($MyInvocation.InvocationName -ne '.') {
   function global:au_BeforeUpdate {

--- a/automatic/vscode.install/update.ps1
+++ b/automatic/vscode.install/update.ps1
@@ -1,8 +1,8 @@
 import-module au
 import-module "$PSScriptRoot\..\..\extensions\chocolatey-core.extension\extensions\chocolatey-core.psm1"
 
-$releases32 = 'https://update.code.visualstudio.com/api/update/win32/stable/VERSION'
-$releases64 = 'https://update.code.visualstudio.com/api/update/win32-x64/stable/VERSION'
+$releases32 = 'https://update.code.visualstudio.com/api/update/win32/stable/0000000000000000000000000000000000000000'
+$releases64 = 'https://update.code.visualstudio.com/api/update/win32-x64/stable/0000000000000000000000000000000000000000'
 
 if ($MyInvocation.InvocationName -ne '.') {
   function global:au_BeforeUpdate {


### PR DESCRIPTION
## Description
Updated version check API call. API was updated to require 40 characters for version input.

- vscode.install
- vscode-insiders.install

## Motivation and Context
Version check URL is no longer working stopping the automatic package upgrades.

## How Has this Been Tested?
Ran update.ps1 and choco pack locally. Tested package in a sandboxed environment.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to change)
* [ ]  Migrated package (a package has been migrated from another repository)

## Checklist:
* [x]  My code follows the code style of this repository.
* [x]  My change requires a change to documentation (this usually means the notes in the description of a package).
* [ ]  I have updated the documentation accordingly (this usually means the notes in the description of a package).
* [ ]  I have updated the package description and it is less than 4000 characters.
* [x]  All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
* [x]  The added/modified package passed install/uninstall in the chocolatey test environment.
* [ ]  The changes only affect a single package (not including meta package).

