### PR TITLE
(selenium-chrome-driver) Update selenium-chrome-driver to use Chrome for Testing

### DIFF
--- a/automatic/selenium-chrome-driver/tools/chocolateyInstall.ps1
+++ b/automatic/selenium-chrome-driver/tools/chocolateyInstall.ps1
@@ -7,11 +7,12 @@ $driverPath = "$seleniumDir\chromedriver.exe"
 $parameters = Get-PackageParameters
 
 $packageArgs = @{
-  packageName  = 'selenium-chrome-driver'
-  file         = "$toolsDir\chromedriver_win32.zip"
-  checksum     = '53c2e1f1b9f2a7571483284ea156958674501e8571cfe34be01282b4152e0770138d9aaef12876f109db9d77c1216362d0576aa40b4f19f039d4b97a15054c98'
-  checksumType = 'sha512'
-  destination  = $seleniumDir
+  packageName     = 'selenium-chrome-driver'
+  file            = "$toolsDir\chromedriver_win32.zip"
+  checksum        = '53c2e1f1b9f2a7571483284ea156958674501e8571cfe34be01282b4152e0770138d9aaef12876f109db9d77c1216362d0576aa40b4f19f039d4b97a15054c98'
+  checksumType    = 'sha512'
+  destination     = $seleniumDir
+  specificFolder  = 'chromedriver-win32'
 }
 
 Get-ChocolateyUnzip @packageArgs

--- a/automatic/selenium-chrome-driver/tools/chocolateyInstall.ps1
+++ b/automatic/selenium-chrome-driver/tools/chocolateyInstall.ps1
@@ -12,10 +12,12 @@ $packageArgs = @{
   checksum        = '53c2e1f1b9f2a7571483284ea156958674501e8571cfe34be01282b4152e0770138d9aaef12876f109db9d77c1216362d0576aa40b4f19f039d4b97a15054c98'
   checksumType    = 'sha512'
   destination     = $seleniumDir
-  specificFolder  = 'chromedriver-win32/chromedriver.exe'
 }
 
 Get-ChocolateyUnzip @packageArgs
+Move-Item -Path $seleniumDir\chromedriver-win32\chromedriver.exe -Destination $driverPath
+Move-Item -Path $seleniumDir\chromedriver-win32\license.chromedriver -Destination $seleniumDir\license.chromedriver
+Remove-Item $seleniumDir\chromedriver-win32
 Get-ChildItem $toolsDir\*.zip | ForEach-Object { Remove-Item $_ -ea 0 }
 
 Uninstall-BinFile -Name 'chromedriver'

--- a/automatic/selenium-chrome-driver/tools/chocolateyInstall.ps1
+++ b/automatic/selenium-chrome-driver/tools/chocolateyInstall.ps1
@@ -12,7 +12,7 @@ $packageArgs = @{
   checksum        = '53c2e1f1b9f2a7571483284ea156958674501e8571cfe34be01282b4152e0770138d9aaef12876f109db9d77c1216362d0576aa40b4f19f039d4b97a15054c98'
   checksumType    = 'sha512'
   destination     = $seleniumDir
-  specificFolder  = 'chromedriver-win32'
+  specificFolder  = 'chromedriver-win32/chromedriver.exe'
 }
 
 Get-ChocolateyUnzip @packageArgs

--- a/automatic/selenium-chrome-driver/update.ps1
+++ b/automatic/selenium-chrome-driver/update.ps1
@@ -20,10 +20,6 @@ function global:au_SearchReplace {
   }
 }
 
-function global:au_AfterUpdate {
-  Update-Metadata -key 'releaseNotes' -value (Invoke-WebRequest -Uri $Latest.UrlReleaseNotes -UseBasicParsing -ContentType "text/plain" | ForEach-Object Content)
-}
-
 function global:au_GetLatest {
   $releases_object = Invoke-RestMethod -Uri $releases_by_channel
 
@@ -35,7 +31,7 @@ function global:au_GetLatest {
   $win32url = $releases_object.channels.Stable.downloads.chromedriver.url.Get($win32index)
   $win64url = $releases_object.channels.Stable.downloads.chromedriver.url.Get($win64index)
 
-  $chrome_for_testing_dashboard = 'https://googlechromelabs.github.io/chrome-for-testing/'
+  $chrome_for_testing_dashboard = "https://googlechromelabs.github.io/chrome-for-testing/"
 
   $streams = @{}
 
@@ -43,7 +39,6 @@ function global:au_GetLatest {
     URL32           = $win32url
     URL64           = $win64url
     Version         = $stable_version
-    UrlReleaseNotes = $chrome_for_testing_dashboard
     ReleasesUrl     = $chrome_for_testing_dashboard
     FileType        = 'zip'
   }

--- a/automatic/selenium-chrome-driver/update.ps1
+++ b/automatic/selenium-chrome-driver/update.ps1
@@ -35,14 +35,17 @@ function global:au_GetLatest {
   $win32url = $releases_object.channels.Stable.downloads.chromedriver.url.Get($win32index)
   $win64url = $releases_object.channels.Stable.downloads.chromedriver.url.Get($win64index)
 
+  $chrome_for_testing_dashboard = 'https://googlechromelabs.github.io/chrome-for-testing/'
+
   $streams = @{}
 
   $streams[[string]"$stable_version.Version.Major"] = @{
-    URL32       = $win32url
-    URL64       = $win64url
-    Version     = $stable_version
-    ReleasesUrl = 'https://googlechromelabs.github.io/chrome-for-testing/'
-    FileType    = 'zip'
+    URL32           = $win32url
+    URL64           = $win64url
+    Version         = $stable_version
+    UrlReleaseNotes = $chrome_for_testing_dashboard
+    ReleasesUrl     = $chrome_for_testing_dashboard
+    FileType        = 'zip'
   }
 
   return @{ Streams = $streams }


### PR DESCRIPTION
## Description
Update to use the new Chrome for Testing sources for selenium-chrome-driver. Release notes no longer provided by google.

## Motivation and Context
The old method doesn't update past chromedriver 114, change is required to keep package up to date

## How Has this Been Tested?
Ran locally

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
