### PR TITLE
(tixati) Overhauled AHK script for v2

### DIFF
--- a/automatic/tixati/tixati.nuspec
+++ b/automatic/tixati/tixati.nuspec
@@ -35,14 +35,14 @@ __Tixati__ is one of the most advanced and flexible BitTorrent clients available
 * **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 ]]></description>
         <projectUrl>http://www.tixati.com/</projectUrl>
-        <tags>internet network download torrent p2p share admin freeware</tags>
+        <tags>tixati bittorrent network download torrent p2p share freeware notsilent</tags>
         <copyright></copyright>
         <licenseUrl>http://www.tixati.com/tixati_eula.txt</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@bee4bc391df114723011dbd5b8a8af2a17c6bf2e/icons/tixati.png</iconUrl>
         <dependencies>
             <dependency id="chocolatey-core.extension" version="1.3.3" />
-            <dependency id="autohotkey.portable" version="1.1.26.01" />
+            <dependency id="autohotkey.portable" version="2.0" />
         </dependencies>
         <releaseNotes></releaseNotes>
         <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/tixati</packageSourceUrl>

--- a/automatic/tixati/tools/chocolateyInstall.ps1
+++ b/automatic/tixati/tools/chocolateyInstall.ps1
@@ -1,29 +1,32 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$packageName = 'tixati'
-$fileName = 'tixati-3.19-1.install.exe'
-$download_dir = "$Env:TEMP\chocolatey\$packageName\$Env:ChocolateyPackageVersion"
+$toolsDir   = Split-Path -parent $MyInvocation.MyCommand.Definition
+$DLFileName = 'tixati-3.19-1.install.exe'
+$DLdir = "$Env:TEMP\chocolatey\$Env:ChocolateyPackageName\$Env:ChocolateyPackageVersion"
 
 $packageArgs = @{
-  packageName    = $packageName
-  fileFullPath   = "$download_dir\$fileName"
+  packageName    = $Env:ChocolateyPackageName
+  fileFullPath   = Join-path $DLdir $DLFileName
   url            = 'https://download1.tixati.com/download/tixati-3.19-1.win32-install.exe'
   url64bit       = 'https://download1.tixati.com/download/tixati-3.19-1.win64-install.exe'
   checksum       = 'aba530275d136a63e927807d75a3d5ceb30990d15eedf00a12f5bd247f79b5e0'
   checksum64     = 'c696960f8bdade39e3a73d6a7626dbd9ecb79f8c9335c8ea1220015a55627692'
   checksumType   = 'sha256'
-  checksumType64 = 'sha256'
 }
 Get-ChocolateyWebFile @packageArgs
 
-Write-Output "Running Autohotkey installer"
-$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
-Autohotkey.exe $toolsPath\$packageName.ahk $packageArgs.fileFullPath
+# silent install requires AutoHotKey
+$ahkFile = Join-Path $toolsDir "$Env:ChocolateyPackageName.ahk"
+$ahkProc = Start-Process -FilePath AutoHotkey.exe -ArgumentList "$ahkFile" -PassThru
+Write-Debug "AutoHotKey start time:`t$($ahkProc.StartTime.ToShortTimeString())"
+Write-Debug "AutoHotKey Process ID:`t$($ahkProc.Id)"
 
-$installLocation = Get-AppInstallLocation $packageName
+Start-ChocolateyProcessAsAdmin -ExeToRun $packageArgs.fileFullPath
+
+$installLocation = Get-AppInstallLocation $Env:ChocolateyPackageName
 if ($installLocation)  {
-    Write-Host "$packageName installed to '$installLocation'"
-    Register-Application "$installLocation\$packageName.exe"
-    Write-Host "$packageName registered as $packageName"
+    Write-Host "$Env:ChocolateyPackageName installed to '$installLocation'"
+    Register-Application "$installLocation\$Env:ChocolateyPackageName.exe"
+    Write-Host "$Env:ChocolateyPackageName registered as $Env:ChocolateyPackageName"
 }
-else { Write-Warning "Can't find $PackageName install location" }
+else { Write-Warning "Can't find $Env:ChocolateyPackageName install location" }

--- a/automatic/tixati/tools/chocolateyInstall.ps1
+++ b/automatic/tixati/tools/chocolateyInstall.ps1
@@ -1,12 +1,12 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsDir   = Split-Path -parent $MyInvocation.MyCommand.Definition
-$DLFileName = 'tixati-3.19-1.install.exe'
+$fileName = 'tixati-3.19-1.install.exe'
 $DLdir = "$Env:TEMP\chocolatey\$Env:ChocolateyPackageName\$Env:ChocolateyPackageVersion"
 
 $packageArgs = @{
   packageName    = $Env:ChocolateyPackageName
-  fileFullPath   = Join-path $DLdir $DLFileName
+  fileFullPath   = Join-path $DLdir $fileName
   url            = 'https://download1.tixati.com/download/tixati-3.19-1.win32-install.exe'
   url64bit       = 'https://download1.tixati.com/download/tixati-3.19-1.win64-install.exe'
   checksum       = 'aba530275d136a63e927807d75a3d5ceb30990d15eedf00a12f5bd247f79b5e0'

--- a/automatic/tixati/tools/tixati.ahk
+++ b/automatic/tixati/tools/tixati.ahk
@@ -1,20 +1,25 @@
-SetTitleMatchMode, RegEx
-exe_re = tixati-.+install.exe
+SetTitleMatchMode "RegEx"
+exe_re := "tixati-.+install.exe"
 
-Run %1%
-WinWait, ahk_exe %exe_re%,,20
-IfNotEqual, ErrorLevel, 0, exit 1
-ControlSend,, {ENTER}, ahk_exe %exe_re%
+If WinWait("ahk_exe " exe_re, , 20)
+   ControlSend "{ENTER}",, "ahk_exe " exe_re
+Else
+   exit 1
 
-WinWait, ahk_exe %exe_re%, YES`, continue installation, 20
-IfNotEqual, ErrorLevel, 0, exit 1
-ControlSend,, {ENTER}, ahk_exe %exe_re%
+If WinWait("ahk_exe " exe_re, "YES`, continue installation", 20)
+   ControlSend "{ENTER}",, "ahk_exe " exe_re
+Else
+   exit 1
 
-WinWait, ahk_exe %exe_re%, Install, 20
-IfNotEqual, ErrorLevel, 0, exit 1
-ControlSend,, {ENTER}, ahk_exe %exe_re%
+If WinWait("ahk_exe " exe_re, "Install", 20)
+   ControlSend "{ENTER}",, "ahk_exe " exe_re
+Else
+   exit 1
 
-WinWait, ahk_exe %exe_re%, Installation is complete!, 20
-IfNotEqual, ErrorLevel, 0, exit 1
-WinActivate
-Send, {TAB}{ENTER}
+if WinWait("ahk_exe " exe_re, "Installation is complete!", 20)
+{
+   WinActivate
+   Send "{TAB}{ENTER}"
+}
+Else
+   exit 1


### PR DESCRIPTION
This requires AHK v2 now, but it seems to be working.

## Description
Rewrote the AutoHotKey script to be compatible with AHKv2.

## Motivation and Context
The Tixoti package has an "open" dependency on AutoHotKey.  When V2 of AHK was realeased, it had significantly different syntax, and it broke this package (and many others).  The AHK script had to be rewritten.  Also, launching the installer from the ChocolateyInstall.ps1 script rather than from AHK seems more "proper".

## How Has this Been Tested?
`choco pack` and `choco install tixoti -s . -y` and `choco uninstall tixoti -y`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

