### PR TITLE
(vscode.install) Switch vscode to github release check

### DIFF
--- a/automatic/vscode.install/update.ps1
+++ b/automatic/vscode.install/update.ps1
@@ -1,8 +1,6 @@
 import-module au
 import-module "$PSScriptRoot\..\..\extensions\chocolatey-core.extension\extensions\chocolatey-core.psm1"
-
-$releases32 = 'https://update.code.visualstudio.com/api/update/win32/stable/VERSION'
-$releases64 = 'https://update.code.visualstudio.com/api/update/win32-x64/stable/VERSION'
+Import-Module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
 if ($MyInvocation.InvocationName -ne '.') {
   function global:au_BeforeUpdate {
@@ -25,18 +23,17 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $json32 = Invoke-WebRequest -UseBasicParsing -Uri $releases32 | ConvertFrom-Json
-  $json64 = Invoke-WebRequest -UseBasicParsing -Uri $releases64 | ConvertFrom-Json
-
-  if ($json32.productVersion -ne $json64.productVersion) {
-    throw "Different versions for 32-Bit and 64-Bit detected."
-  }
+  $latestRelease = Get-GitHubRelease microsoft vscode
+  $version = $latestRelease.tag_name
+  # URLs are documented here: https://code.visualstudio.com/docs/supporting/faq#_previous-release-versions
+  $url32 = "https://update.code.visualstudio.com/$version/win32/stable"
+  $url64 = "https://update.code.visualstudio.com/$version/win32-x64/stable"
 
   @{
-    Version       = $json32.productVersion
-    RemoteVersion = $json32.productVersion
-    URL32         = $json32.Url
-    URL64         = $json64.Url
+    Version       = $version
+    RemoteVersion = $version
+    URL32         = $url32
+    URL64         = $url64
   }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
Change the check to use github releases instead of the undocumented api.

This will fix issue https://github.com/chocolatey-community/chocolatey-packages/issues/2269

Note: This only fixes `vscode` and not `vscode insiders` as the insiders version is not in GitHub releases.

## Motivation and Context
Version check URL is no longer working stopping the automatic package upgrades.

## How Has this Been Tested?
Ran update.ps1 to generate the new packages, installed the new version locally.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
