### PR TITLE
(notepadplusplus.install) Add /NoStop install parameter to avoid killing the process

### DIFF
--- a/automatic/notepadplusplus.install/README.md
+++ b/automatic/notepadplusplus.install/README.md
@@ -4,6 +4,10 @@ Notepad++ is a free (as in "free speech" and also as in "free beer") source code
 
 Based on the powerful editing component Scintilla, Notepad++ is written in C++ and uses pure Win32 API and STL which ensures a higher execution speed and smaller program size. By optimizing as many routines as possible without losing user friendliness, Notepad++ is trying to reduce the world carbon dioxide emissions. When using less CPU power, the PC can throttle down and reduce power consumption, resulting in a greener environment.
 
+## Package Parameters
+
+- `/NoStop` - Do not stop Notepad++ before running the install if it is running or attempt to restart it after install.
+
 ## Features
 
 * Syntax Highlighting and Syntax Folding
@@ -21,6 +25,11 @@ Based on the powerful editing component Scintilla, Notepad++ is written in C++ a
 * Macro recording and playback
 * Launch with different [arguments](https://notepad-plus-plus.org/assets/images/scsh/scsh_cmdlineArguments.png)
 
+### Examples
+
+`choco install notepadplusplus.install --params "/NoStop"`
+
+## Notes
 ## Notes
 
 * To force the installation of x32 version, use the `--x86` argument with `choco install`.

--- a/automatic/notepadplusplus.install/notepadplusplus.install.nuspec
+++ b/automatic/notepadplusplus.install/notepadplusplus.install.nuspec
@@ -13,6 +13,10 @@
 
 Based on the powerful editing component Scintilla, Notepad++ is written in C++ and uses pure Win32 API and STL which ensures a higher execution speed and smaller program size. By optimizing as many routines as possible without losing user friendliness, Notepad++ is trying to reduce the world carbon dioxide emissions. When using less CPU power, the PC can throttle down and reduce power consumption, resulting in a greener environment.
 
+## Package Parameters
+
+- `/NoStop` - Do not stop Notepad++ before running the install if it is running or attempt to restart it after install.
+
 ## Features
 
 * Syntax Highlighting and Syntax Folding
@@ -30,10 +34,14 @@ Based on the powerful editing component Scintilla, Notepad++ is written in C++ a
 * Macro recording and playback
 * Launch with different [arguments](https://notepad-plus-plus.org/assets/images/scsh/scsh_cmdlineArguments.png)
 
+### Examples
+
+`choco install notepadplusplus.install --params "/NoStop"`
+
 ## Notes
 
 * To force the installation of x32 version, use the `--x86` argument with `choco install`.
-* Starting in v8.3.3.20220321 and above the Notepad++ process will be closed during install, upgrade and uninstalls.
+* Starting in v8.3.3.20220321 and above the Notepad++ process will be closed during install, upgrade and uninstalls, unless the `/NoStop` parameter is passed to the install.
   This may in rare cases result in data loss if there are unsaved text files open. Make sure all files are
   saved before installing, upgrading or uninstalling this package.
 * **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**

--- a/automatic/notepadplusplus.install/tools/chocolateyBeforeModify.ps1
+++ b/automatic/notepadplusplus.install/tools/chocolateyBeforeModify.ps1
@@ -1,10 +1,16 @@
-﻿$process = Get-Process "Notepad++*" -ea 0
+﻿$pp = Get-PackageParameters
+
+$process = Get-Process "Notepad++*" -ea 0
 
 if ($process) {
   $runningFile = "$env:TEMP\npp.running"
   $processPath = $process | Where-Object { $_.Path } | Select-Object -First 1 -ExpandProperty Path
   Set-Content -Value "$processPath" -Path $runningFile
 
-  Write-Host "Found Running instance of Notepad++. Stopping processes..."
-  $process | Stop-Process
+  if ($pp.NoStop) {
+    Write-Warning "Not stopping running Notepad++ process"  
+  } else {
+    Write-Host "Found Running instance of Notepad++. Stopping processes..."
+    $process | Stop-Process
+  }
 }

--- a/automatic/notepadplusplus.install/tools/chocolateyInstall.ps1
+++ b/automatic/notepadplusplus.install/tools/chocolateyInstall.ps1
@@ -1,5 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+$pp = Get-PackageParameters
+
 if (Test-Path "$env:TEMP\npp.running") {
   $programRunning = Get-Content -Path "$env:TEMP\npp.running"
   Remove-Item "$env:TEMP\npp.running"
@@ -8,7 +10,7 @@ if (Test-Path "$env:TEMP\npp.running") {
 # Temporary code until we have at least one version with the before modify script
 $process = Get-Process "Notepad++*" -ea 0
 
-if ($process) {
+if ($process -and !$pp.NoStop) {
   $processPath = $process | Where-Object { $_.Path } | Select-Object -First 1 -ExpandProperty Path
   Write-Host "Found Running instance of Notepad++. Stopping processes..."
   $process | Stop-Process
@@ -38,7 +40,7 @@ if (!$installLocation)  {  Write-Warning "Can't find $PackageName install locati
 Write-Host "$packageName installed to '$installLocation'"
 Install-BinFile -Path "$installLocation\notepad++.exe" -Name 'notepad++'
 
-if ($programRunning -and (Test-Path $programRunning)) {
+if ($programRunning -and (Test-Path $programRunning) -and !$pp.NoStop) {
   Write-Host "Running stopped program"
   Start-Process $programRunning
 }


### PR DESCRIPTION
…ing notepad++ processes

## Description
We would like to update packages automatically on peoples machines, but having the notepad++ processes killed is terribly disruptive.  This adds a `\NoStop` install parameter to allow admins to avoid this.

This is similar to #1919 

## How Has this Been Tested?
Built package locally and installed with:
`choco install notepadplusplus.install --debug --verbose --source . --params "/NoStop"`
and verified that a running notepad++ process was not killed.  Ran again without `--params "/NoStop"` and verified that notepad++ was killed and restarted.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).