### PR TITLE
(opera) Add Opera /NoAutostart param

### DIFF
--- a/automatic/opera/README.md
+++ b/automatic/opera/README.md
@@ -4,11 +4,12 @@ The Opera web browser makes the Web fast and fun, giving you a better web browse
 
 ## Parameters
 
+- `/NoAutostart` - Do not add Opera autostart entry
 - `/NoDesktopShortcut` - Do not create desktop shortcut for Opera
 - `/NoTaskbarShortcut` - Do not pin Opera to taskbar
 
 These parameters can be passed to the installer with the use of `--params`.
-For example: `--params '"/NoDesktopShortcut /NoTaskbarShortcut"'`
+For example: `--params '"/NoAutostart /NoDesktopShortcut /NoTaskbarShortcut"'`
 
 ## Notes
 

--- a/automatic/opera/tools/chocolateyInstall.ps1
+++ b/automatic/opera/tools/chocolateyInstall.ps1
@@ -4,6 +4,7 @@ $toolsPath = (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 
 $pp = Get-PackageParameters
 
+$parameters += if ($pp.NoAutostart) { " /run-at-startup=0"; Write-Host "Autorun entry won't be added" }
 $parameters += if ($pp.NoDesktopShortcut) { " /desktopshortcut=0"; Write-Host "Desktop shortcut won't be created" }
 $parameters += if ($pp.NoTaskbarShortcut) { " /pintotaskbar=0"; Write-Host "Opera won't be pinned to taskbar" }
 


### PR DESCRIPTION
Add `/NoAutostart` param for opera since newer versions annoyingly add an autorun entry to registry by default. https://www.reddit.com/r/operabrowser/wiki/opera/installer_commands/

## Description
The param got added where params seem to be normally added.

## Motivation and Context
As above, upgrading/installing Opera makes it autostart with Windows.

## How Has this Been Tested?
I hope this is enough as testing is stopping me from submitting PRs, need to learn how to test such changes and I don't have quite time for that. Filling this template already took longer than the small changes themselves.

Anyways, I ran:
- `choco pack` in the `opera` folder in git repository
- ` choco install Opera --debug --verbose --source . --params "'/NoAutostart'" -f`
- Installation completed, no autorun entry was found

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

Fixes #2285 
