### PR TITLE
(freecad) Increases Maintainability of Update Helper

### DIFF
--- a/automatic/freecad/freecad.nuspec
+++ b/automatic/freecad/freecad.nuspec
@@ -51,6 +51,7 @@ Example: `choco install freecad --params "/InstallDir:'C:\FreeCAD' /NoShortcut"`
     <tags>freecad 3d cad modeling engineering admin</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/freecad</packageSourceUrl>
     <dependencies>
+      <dependency id="chocolatey" version="1.0.0" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
     </dependencies>
   </metadata>

--- a/automatic/freecad/update.ps1
+++ b/automatic/freecad/update.ps1
@@ -22,6 +22,7 @@ function global:au_SearchReplace {
       "(?i)(^\s*\<id\>).*(\<\/id\>)"                     = "`${1}$($Latest.PackageName)`${2}"
       "(?i)(^\s*\<title\>).*(\<\/title\>)"               = "`${1}$($Latest.Title)`${2}"
       "(?i)(^\s*\<releaseNotes\>).*(\<\/releaseNotes\>)" = "`${1}$($Latest.ReleaseNotes)`${2}"
+      '(?i)(^\s*\<dependency id="chocolatey" version=").*(" \/\>)' = "`${1}$(if ($Latest.FileType -eq '7z') {'2.2.2'} else {'1.0.0'})`${2}"
     }
     ".\tools\chocolateyUninstall.ps1" = @{
       "(?i)(^\s*packageName\s*=\s*)'.*'"  = "`$1'$($Latest.PackageName)'"

--- a/automatic/freecad/update.ps1
+++ b/automatic/freecad/update.ps1
@@ -3,9 +3,6 @@
 if (!$PSScriptRoot) { $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent }
 . "$PSScriptRoot\update_helper.ps1"
 
-$PreUrl = 'https://github.com'
-$releases = "$PreUrl/FreeCAD/FreeCAD/releases"
-$dev_releases = "$PreUrl/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds"
 $softwareName = 'FreeCAD'
 
 function global:au_SearchReplace {
@@ -44,9 +41,9 @@ function global:au_BeforeUpdate {
 
 function global:au_GetLatest {
   $streams = [ordered] @{
-    dev      = Get-FreeCad -Title "${softwareName}" -uri $dev_releases -kind "dev"
-    stable   = Get-FreeCad -Title "${softwareName}"
-    portable = Get-FreeCad -Title "${softwareName}" -kind "portable"
+    dev      = Get-FreeCad -Kind "dev"
+    stable   = Get-FreeCad -Kind "stable"
+    portable = Get-FreeCad -Kind "portable"
   }
   return @{ Streams = $streams }
 }


### PR DESCRIPTION
## Description
Increases legibility / maintainability of the update helper function for FreeCAD, which was hard to grok.

This should also "fix" a portable asset not being available failing the build.

## Motivation and Context
This is a bit of a rewrite of the helper function that I'd done previously for the GitHub Release changes, plus a change to ensure that the build doesn't fail when the portable artifact isn't published as the portable zip hasn't been pushed to the release in a few versions.

I am unsure if the portable artifact is being published going forward (can't find any context / intent around the change), and we should address that separately if >22.x doesn't appear.

## How Has this Been Tested?
- `update_all.ps1 -Name FreeCAD` run with a non-existant portable release, should still "work" for other streams
- Import the helpers with `. .\update_helpers.ps1` and then test the output of the new and old versions of `Get-FreeCAD`. They should be identical (roughly speaking).
- Tested installing the generated packages in a test environment
    - Note: Uninstall doesn't appear to be fully silent, but not due to any changes I have made. I may need to address this as part of this PR, but as this PR was to fix the build I haven't yet.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

Note: I do not count this as a breaking change, despite the Get-FreeCAD signature completely changing, as it's only used here (internally, without any exposure to actual users) and is essentially a private function.

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- ~[ ] The changes only affect a single package (not including meta package).~ Affects three streams of package / two actual package IDs.
