### PR TITLE
(ant-renamer) Fixes Update Script (No Scheme)

### DIFF
--- a/automatic/ant-renamer/update.ps1
+++ b/automatic/ant-renamer/update.ps1
@@ -22,7 +22,10 @@ function global:au_GetLatest {
     $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
 
     $re    = 'install\.exe'
-    $url   = $download_page.links | ? href -match $re | select -First 1 -expand href
+    $url   = $download_page.links | Where-Object href -match $re | Select-Object -First 1 -ExpandProperty href
+    if (-not ([uri]$url).Scheme) {
+      $url = "$(([uri]$releases).Scheme)://$($url.TrimStart('https://'))"
+    }
 
     $version  = [regex]::Match($download_page.Content, "Version\s+([0-9\.]+)").Groups[1].Value;
 


### PR DESCRIPTION
## Description
This change ensures a scheme matching the one used by the releases URL is added to the download URL if no other is present.

## Motivation and Context
The download URLs on the page are missing a scheme. Though this may work in browsers, it doesn't play nicely with our update scripts / PowerShell.

![image](https://github.com/chocolatey-community/chocolatey-packages/assets/1975761/5a614080-5813-4464-a1a7-dabb479c8fce)

## How Has this Been Tested?
- Ran `update_all.ps1 -Name ant-renamer` before and after the changes, note no failure on new version
- Tested the (forcibly) generated package ran on a test environment

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).