### PR TITLE
(juju) Fixes Update.ps1 to handle missing release notes

### DIFF
--- a/automatic/juju/update.ps1
+++ b/automatic/juju/update.ps1
@@ -26,7 +26,14 @@ function global:au_AfterUpdate() {
 
   $release_notes = $release_page.Links | Where-Object href -match "release-notes|roadmap-releases" | Select-Object -First 1 -expand href
 
-  Update-Metadata -key "releaseNotes" -value $release_notes
+  if ($release_page -and -not $release_notes) {
+    Write-Warning "Release notes not found within body of the GitHub release. Linking directly to release."
+    $release_notes = $ghReleasesFmt -f $($Latest.RemoteVersion)
+  }
+
+  if ($release_notes) {
+    Update-Metadata -key "releaseNotes" -value $release_notes
+  }
 }
 
 function global:au_GetLatest {


### PR DESCRIPTION
## Description
This fixes the update script so it doesn't choke if it can't find release notes within the GitHub release body.

## Motivation and Context
The build was failing due to passing an empty string to `Update-Metadata`. This should fix that issue.

Please note that though I added a fallback method ("if the GitHub release exists but there is no link found, link to the GitHub release") in theory if the release page doesn't exist the releasenotes may point to an older version. We might consider updating `Update-Metadata` to accept blank strings and handle itself appropriately in that situation.

The example of the failing release is 'https://github.com/juju/juju/releases/tag/juju-3.3-beta1'

## How Has this Been Tested?
- Ran `upgrade_all.ps1 -Name juju` before and after changes were made

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
