### PR TITLE
(chromium) Only Internalizes x64 Binary

### DIFF
--- a/automatic/chromium/tools/chocolateyInstall.ps1
+++ b/automatic/chromium/tools/chocolateyInstall.ps1
@@ -15,7 +15,7 @@ if (Test-Path $Chromium) {
 
 $packageArgs = @{
   packageName   = 'chromium'
-  file          = "$toolsdir\chromium_x32.exe"
+  url           = 'https://chromium_x32.exe'
   file64        = "$toolsdir\chromium_x64.exe"
   fileType      = 'exe'
   silentArgs    = $silentArgs

--- a/automatic/chromium/update.ps1
+++ b/automatic/chromium/update.ps1
@@ -1,74 +1,74 @@
+Import-Module au
 
-import-module au
-    $releases = 'https://chromium.woolyss.com/api/v5/?os=win<bit>&type=<type>&out=json'
-    $ChecksumType = 'sha256'
+$checksumType = 'sha256'
 
 function global:au_SearchReplace {
   @{
     ".\legal\verification.txt" = @{
-    "(?i)(\s*32\-Bit Software.*)\<.*\>"        = "`${1}<$($Latest.URL32)>"
-    "(?i)(\s*64\-Bit Software.*)\<.*\>"        = "`${1}<$($Latest.URL64)>"
-    "(?i)(^\s*checksum\s*type\:).*"            = "`${1} $($Latest.ChecksumType32)"
-    "(?i)(^\s*checksum32\:).*"                 = "`${1} $($Latest.Checksum32)"
-    "(?i)(^\s*checksum64\:).*"                 = "`${1} $($Latest.Checksum64)"
+      "(?i)(\s*32\-Bit Software.*)\<.*\>"        = "`${1}<$($Latest.URL32)>"
+      "(?i)(\s*64\-Bit Software.*)\<.*\>"        = "`${1}<$($Latest.URL64)>"
+      "(?i)(^\s*checksum\s*type\:).*"            = "`${1} $($Latest.ChecksumType32)"
+      "(?i)(^\s*checksum32\:).*"                 = "`${1} $($Latest.Checksum32)"
+      "(?i)(^\s*checksum64\:).*"                 = "`${1} $($Latest.Checksum64)"
     }
     ".\tools\chocolateyInstall.ps1" = @{
-    '(^[$]version\s*=\s*)(".*")'               = "`$1""$($Latest.Version)"""
-	  "(?i)(^\s*file\s*=\s*`"[$]toolsdir\\).*"   = "`${1}$($Latest.FileName32)`""
-	  "(?i)(^\s*file64\s*=\s*`"[$]toolsdir\\).*" = "`${1}$($Latest.FileName64)`""
+      '(^[$]version\s*=\s*)(["''].*["''])'       = "`$1'$($Latest.Version)'"
+      "(?i)(^\s*url\s*=\s*').*"                  = "`${1}$($Latest.URL32)'"
+      "(?i)(^\s*file64\s*=\s*`"[$]toolsdir\\).*" = "`${1}$($Latest.FileName64)`""
     }
     ".\chromium.nuspec" = @{
-    "(?i)(^\s*\<title\>).*(\<\/title\>)"       = "`${1}$($Latest.Title)`${2}"
+      "(?i)(^\s*\<title\>).*(\<\/title\>)"       = "`${1}$($Latest.Title)`${2}"
     }
   }
 }
 
 function global:au_BeforeUpdate {
     Get-RemoteFiles -Purge -FileNameBase "$($Latest.PackageName)"
+
+    # This should be reworked when Get-RemoteFiles can get _only_ x64 URLs
+    Remove-Item $PSScriptRoot\tools\chromium_x32.exe
 }
 
 function Get-Chromium {
-param(
-	[string]$releases,
-	[string]$Title,
+  param(
+    [string]$ReleasesBaseUrl = 'https://chromium.woolyss.com/api/v5/?os=win<bit>&type=<type>&out=json',
+
+    [Parameter(Mandatory)]
+    [string]$Title,
+
     [Parameter()]
     [ValidateNotNullOrEmpty()]
     [ValidateSet('dev-official','stable-sync','stable-nosync-arm')]
-    [string]$type = 'dev-official'
-)
- # Change the URI for the specific type and bit
-    $releases = $releases -replace('<type>', $type )
-    $releases_x32 = $releases -replace('<bit>','32')
-    $releases_x64 = $releases -replace('<bit>','64')
-    $download_page32 = Invoke-WebRequest -Uri $releases_x32
-    $download_page64 = Invoke-WebRequest -Uri $releases_x64
- # Convert Respose from Json
-    $chromium32 = $download_page32 | ConvertFrom-Json
-    $chromium64 = $download_page64 | ConvertFrom-Json
- # Get values from the hashtable
-    $url32 = $chromium32.chromium.windows.download
-    $url64 = $chromium64.chromium.windows.download
-    $version32 = $chromium32.chromium.windows.version
-    $version64 = $chromium64.chromium.windows.version
- # Compare versions default to 64bit version for any variance
-    if ($version32 -ne $version64) { $version = $version64 } else { $version = $version32 }
- # Build Version for Snapshots or Stable
-    $build = @{$true="-snapshots";$false=""}[ $type -eq 'dev-official' ]
-    
+    [string]$Type = 'dev-official'
+  )
+  # Change the URI for the specific type and bit and get the information
+  $chromium32 = Invoke-RestMethod -Uri ($ReleasesBaseUrl -replace '<type>', $type -replace '<bit>', '32') -UseBasicParsing
+  $chromium64 = Invoke-RestMethod -Uri ($ReleasesBaseUrl -replace '<type>', $type -replace '<bit>', '64') -UseBasicParsing
+
+  # Compare versions default to 64bit version for any variance
+  $version = if ($chromium32.chromium.windows.version -ne $chromium64.chromium.windows.version) {
+    $chromium64.chromium.windows.version
+  } else {
+    $chromium32.chromium.windows.version
+  }
+
+  # Update Version for Snapshots or Stable
+  $version += @{$true="-snapshots";$false=""}[ $Type -eq 'dev-official' ]
+
 	@{
 		Title = $Title
-		URL32 = $url32
-		URL64 = $url64
-		Version = "$version$build"
-		ChecksumType32 = $ChecksumType
-		ChecksumType64 = $ChecksumType
+		URL32 = $chromium32.chromium.windows.download
+		URL64 = $chromium64.chromium.windows.download
+		Version = $version
+		ChecksumType32 = $checksumType
+		ChecksumType64 = $checksumType
 	}
 }
 
 function global:au_GetLatest {
   $streams = [ordered] @{
-    stable = Get-Chromium -releases $releases -Title "Chromium" -type "stable-sync"
-    snapshots = Get-Chromium -releases $releases -Title "Chromium Snapshots" -type "dev-official"
+    stable = Get-Chromium -Title "Chromium" -Type "stable-sync"
+    snapshots = Get-Chromium -Title "Chromium Snapshots" -Type "dev-official"
   }
 
   return @{ Streams = $streams }


### PR DESCRIPTION
## Description
This change removes the x86 binary from the package, leaving a link to it.

## Motivation and Context
The final nupkg was too large to push to CCR, so we needed to cut space.

This change should serve many users, while still enabling x86 usage. As it happens, it seems that the maintainer of the Chromium binaries we are using here has stopped building x86 versions as of January. We could consider dropping them entirely from future packages, and directing x86 users to the last-updated-version (as in at least one other package I've seen).

I'm happy to merge this as is, or to remove the x86 entirely before continuing, as people prefer - am putting this in draft for that reason.

Fixes #2295

## How Has this Been Tested?
- Built using `update_all.ps1`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).