### PR TITLE
(kubernetes-cli) Fixes Update.ps1 (HTML parsing)

### DIFF
--- a/automatic/kubernetes-cli/update.ps1
+++ b/automatic/kubernetes-cli/update.ps1
@@ -3,7 +3,7 @@ param($IncludeStream, [switch] $Force)
 
 Import-Module AU
 
-$changelogs = 'https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md'
+$changelogs = 'https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/README.md'
 
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
@@ -27,44 +27,52 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
     # Only report the supported Kubernetes streams.
 
-    $changelog_page = Invoke-WebRequest -Uri $changelogs -UseBasicParsing
+    $changelogs = (Invoke-WebRequest -Uri $changelogs -UseBasicParsing).content
 
     # There is quite a few versions that do not exist on chocolatey.org
     # and since the limit of pushed packages is 10, we need to limit the amount
     # of streams that we parse. Once packages are approved we can increase/remove
     # the limit.
-    $minor_version_changelogs = $changelog_page.links `
-      | Where-Object href -match "CHANGELOG-(?<version>\d+\.\d+)\.md`$" `
-      | Select-Object -Expand href -First 10
+    $minor_version_changelogs = $changelogs `
+      | Select-String -Pattern "- \[CHANGELOG-(?<version>\d\.\d+)\.md\]" -AllMatches `
+      | ForEach-Object {$_.Matches.Groups.Where{$_.Name -eq 'version'}.value} `
+      | Select-Object -First 10
 
     $streams = @{}
 
-    $minor_version_changelogs | ForEach-Object {
-        if ($_ -notmatch "CHANGELOG-(?<version>\d+\.\d+)\.md`$") {
-          return
-        }
-        $minor_version = $matches.version
+    foreach ($minor_version in $minor_version_changelogs) {
         if ($streams.ContainsKey($minor_version)) {
           return
         }
-        $minor_changelog_page = Invoke-WebRequest -UseBasicParsing -Uri "https://github.com$_"
-        $url64 = $minor_changelog_page.links `
-          | Where-Object href -match "/v(?<version>\d+(\.\d+)+)/kubernetes-client-windows-amd64.tar.gz" `
-          | Select-Object -First 1 -Expand href
-        $patch_version = $matches.version
+
+        $minor_changelog_page = Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/CHANGELOG-$($minor_version).md"
+        $url64 = $minor_changelog_page.content `
+          | Select-String -Pattern "(?<=\[.+\]\()(?<href>.+/v(?<version>\d+(\.\d+)+)/kubernetes-client-windows-amd64\.tar\.gz)\)" `
+          | ForEach-Object {$_.Matches.Groups.Where{$_.Name -eq 'href'}.value} `
+          | Select-Object -First 1
+
         if (!$url64) {
           return
         }
-        $url32 = $minor_changelog_page.links `
-          | Where-Object href -match "/v(?<version>\d+(\.\d+)+)/kubernetes-client-windows-386.tar.gz" `
-          | Select-Object -First 1 -Expand href
 
-        $streams.Add($minor_version, @{
-            Version     = $patch_version
-            URL32       = $url32
-            URL64       = $url64
-            ReleaseNotes= "https://github.com$_"
-        })
+        if ($url64 -match "/v(?<version>\d+(\.\d+)+)/kubernetes-client-windows-amd64.tar.gz") {
+          $patch_version = $matches.version
+        }
+
+        $url32 = $minor_changelog_page.content `
+          | Select-String -Pattern "(?<=\[.+\]\()(?<href>.+/v(?<version>\d+(\.\d+)+)/kubernetes-client-windows-386\.tar\.gz)\)" `
+          | ForEach-Object {$_.Matches.Groups.Where{$_.Name -eq 'href'}.value} `
+          | Select-Object -First 1
+
+        $streams.Add(
+          $minor_version,
+          @{
+            Version      = $patch_version
+            URL32        = $url32
+            URL64        = $url64
+            ReleaseNotes = "https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-$($minor_version).md"
+          }
+        )
     }
 
   return @{ Streams = $streams }


### PR DESCRIPTION
## Description
Fixes a GitHub page-parse that no longer works / has been restricted by GitHub. This now uses the raw markdown file and parses that for the required links.

## Motivation and Context
It seems we have a few more places where we were parsing GitHub pages - I thought we'd caught them all. The build was broken, and now should work.

## How Has this Been Tested?
- Ran `upgrade_all.ps1 -Name kubernetes-cli` before and after changes were made

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
