### PR TITLE
(prey) Fixes Update.ps1 (HTML parsing)

### DIFF
--- a/automatic/prey/update.ps1
+++ b/automatic/prey/update.ps1
@@ -2,8 +2,6 @@
 param($IncludeStream, [switch]$Force)
 Import-Module AU
 
-$releases = 'https://github.com/prey/prey-node-client/releases'
-
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
 function global:au_SearchReplace {
@@ -26,20 +24,18 @@ function global:au_SearchReplace {
 function global:au_AfterUpdate { Update-Metadata -key 'releaseNotes' -value $Latest.ReleaseNotes }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $latestRelease = Get-GitHubRelease -Owner "Prey" -Name "Prey-Node-Client"
 
   $re = 'x86\.msi$'
-  $urls32 = $download_page.Links | ? href -match $re | select -expand href | % { 'https://github.com' + $_ }
+  $urls32 = $latestRelease.assets.Where{$_.name -match $re}.browser_download_url
 
   $re = 'x64\.msi$'
-  $urls64 = $download_page.links | ? href -match $re | select -expand href | % { 'https://github.com' + $_ }
+  $urls64 = $latestRelease.assets.Where{$_.name -match $re}.browser_download_url
 
   $streams = @{}
-  $urls32 | % {
-    $verRe = '\/[v\.]{0,2}'
-    $version = $_ -split "$verRe" | select -last 1 -skip 1
-    $version = Get-Version $version
-    $url64 = $urls64 | ? { $_ -match "${verRe}$version" } | select -First 1
+  $urls32 | ForEach-Object {
+    $version = Get-Version $latestRelease.tag_name.TrimStart('v')
+    $url64 = $urls64 | Where-Object { $_ -match "\/[v\.]{0,2}$version" } | Select-Object -First 1
     if (!($url64)) { throw "URL64 was not found for version $version" }
 
     if (!($streams.ContainsKey($version.ToString(2)))) {
@@ -47,7 +43,7 @@ function global:au_GetLatest {
         Version = $version.ToString()
         URL32   = $_
         URL64   = $url64
-        ReleaseNotes = "${releases}/tag/v${version}"
+        ReleaseNotes = $latestRelease.html_url
       })
     }
   }


### PR DESCRIPTION
## Description
This package was relying on parsing the HTML for one of GitHub's release pages. I thought we'd caught all of these, but it seems not.

## Motivation and Context
The build was broken due to there being a lack of matching links to parse on the returned site for GitHub, what with everything moving to rendering in delightful alternate technologies.

## How Has this Been Tested?
- Ran `upgrade_all.ps1 -Name prey` before and after changes were made

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
