### PR TITLE
(youtube-dl) Fixes Update.ps1 and adds Nightly stream

### DIFF
--- a/automatic/youtube-dl/update.ps1
+++ b/automatic/youtube-dl/update.ps1
@@ -1,8 +1,5 @@
-import-module au
-import-module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
-
-$domain   = 'https://youtube-dl.org'
-$releases = "$domain/"
+Import-Module AU
+Import-Module "$env:ChocolateyInstall\helpers\chocolateyInstaller.psm1"
 
 function global:au_BeforeUpdate {
   if (Test-Path "$PSScriptRoot\tools") {
@@ -18,7 +15,7 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt" = @{
-      "(?i)(listed on\s*)\<.*\>" = "`${1}<$releases>"
+      "(?i)(listed on\s*)\<.*\>" = "`${1}<$($Latest.ReleaseUrl)>"
       "(?i)(1\..+)\<.*\>"          = "`${1}<$($Latest.URL32)>"
       "(?i)(checksum type:).*"   = "`${1} $($Latest.ChecksumType32)"
       "(?i)(checksum:).*"       = "`${1} $($Latest.Checksum32)"
@@ -27,22 +24,48 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $streams = [ordered]@{}
+  foreach ($repository in 'youtube-dl','ytdl-nightly') {
+    $latestRelease = Get-GitHubRelease -Owner ytdl-org -Name $repository
+    $url = $latestRelease.assets.Where{$_.name -eq 'youtube-dl.exe'}.browser_download_url
 
-  $re    = '\.exe$'
-  $url   = $domain + "/" + ($download_page.Links | ? href -match $re | select -First 1 -expand href)
-  $filename = $url.Substring($url.LastIndexOf('/') + 1)
-  ($download_page.Content -match "\(v(2[0-9]{3}[.].*)\)")
-  $version  = $Matches[1]
-  
-  #Update checksum automatically from self-contained executable
-  $checksum = Get-RemoteChecksum -Algorithm "sha512" $url
-  
-  return @{
-    Version = $version
-    URL32 = $url
-    Checksum32 = $checksum
-    ChecksumType32 = "sha512"
+    $version = $latestRelease.tag_name.TrimStart('v')
+    if ($repository.EndsWith('nightly')) {
+      $version += '-nightly'
+    }
+
+    # Look for a checksum asset for SHA512
+    $checksumFile = $latestRelease.assets.Where{$_.name -eq 'SHA2-512SUMS'}
+
+    # If it exists
+    $checksum = if ($checksumFile) {
+      # Get the content of the file
+      $checksumFileContent = (-join [char[]](Invoke-WebRequest -Uri $ChecksumFile.browser_download_url -UseBasicParsing).content).Split("`n")
+
+      # Find the line for youtube-dl.exe
+      $youtubeDlExeChecksumLine = $checksumFileContent -match "^(?<checksum>.+)(?=\s+youtube-dl\.exe)"
+
+      # And output the checksum portion, which is the first part of the line
+      $youtubeDlExeChecksumLine.Split(' ')[0]
+    } else {
+      # Otherwise, use Get-RemoteChecksum to output a SHA512 checksum for the asset URL
+      Get-RemoteChecksum -Url $Url -Algorithm "sha512"
+    }
+
+    $streams.Add(
+      $repository,
+      @{
+        Version        = $version
+        URL32          = $url
+        Checksum32     = $checksum
+        ChecksumType32 = "sha512"
+        ReleaseUrl     = $latestRelease.html_url
+      }
+    )
+  }
+
+  @{
+    streams = $streams
   }
 }
 


### PR DESCRIPTION
## Description
This commit both switches to using the GitHub releases for sourcing update information, but also adds nightly builds to the streams to build.

## Motivation and Context
The build was broken due to the update-target being a site that has been taken down. This moves the target to the GitHub release page, and adds a nightly versions to the repository when found (with a `-nightly` addition to the version to ensure they track as pre-release).

## How Has this Been Tested?
- Ran `upgrade_all.ps1 -Name youtube-dl -force youtube-dl` before and after changes were made

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
