### PR TITLE
(simplewall) Fixes Update.ps1 Overenthusiastic Match

### DIFF
--- a/automatic/simplewall/update.ps1
+++ b/automatic/simplewall/update.ps1
@@ -6,7 +6,7 @@ function global:au_GetLatest {
     @{
         Version = $LatestRelease.tag_name.TrimStart("v.")  # Tags have a "v." prefix, not a typo
         URL32_i = $LatestRelease.assets | Where-Object {$_.name.EndsWith(".exe")} | Select-Object -ExpandProperty browser_download_url
-        URL32_p = $LatestRelease.assets | Where-Object {$_.name.EndsWith(".zip")} | Select-Object -ExpandProperty browser_download_url
+        URL32_p = $LatestRelease.assets | Where-Object {$_.name.EndsWith("bin.zip")} | Select-Object -ExpandProperty browser_download_url
     }
 }
 


### PR DESCRIPTION
## Description
Simplewall have added another zip file to their releases containing pdbs. This was causing the build to fail. This addition to the EndsWith string results in only a single URL matching.

## Motivation and Context
Builds for Simplewall, .install, and .portable were failing due to the update.ps1 for simplewall failing.
This fixes that.

## How Has this Been Tested?
- Ran `upgrade_all.ps1 -Name simplewall` before and after changes were made

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

