### PR TITLE
(nomacs) Fixes Update.ps1 (HTML Parsing)

### DIFF
--- a/automatic/nomacs/update.ps1
+++ b/automatic/nomacs/update.ps1
@@ -1,6 +1,4 @@
-import-module au
-
-$releases = 'https://github.com/nomacs/nomacs/releases'
+﻿Import-Module AU
 
 function global:au_SearchReplace {
    @{
@@ -15,16 +13,16 @@ function global:au_SearchReplace {
     }
 }
 
-function global:au_BeforeUpdate  { Get-RemoteFiles -NoSuffix -Purge }
+function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-    $url     = $download_page.links | ? href -like '*/nomacs-*x64.msi' | % href | select -First 1
-    $version = $url -split '\/' | select -Last 1 -Skip 1
+    $latestRelease = Get-GitHubRelease -Owner nomacs -Name nomacs
+    $url     = $latestRelease.assets.Where{$_.name -like 'nomacs-*x64.msi'}[0].browser_download_url
+    $version = $latestRelease.tag_name.TrimStart('v')
     @{
         Version      = $version
-        URL64        = "https://github.com/${url}"
-        ReleaseNotes = "https://github.com/nomacs/nomacs/releases/tag/${version}"
+        URL64        = $url
+        ReleaseNotes = $latestRelease.html_url
     }
 }
 


### PR DESCRIPTION
## Description
Updates the `Update.ps1` script to use the GitHub release API rather than parsing the (now unparsable) HTML pages.

Note: It seems that we've been publishing beta versions as full releases. Should we change that?

## Motivation and Context
The build was broken.

## How Has this Been Tested?
- Ran `upgrade_all.ps1 -Name nomacs` before and after changes were made (with force, as there's no currently newer non-prerelease version available)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).