### PR TITLE
(opera) Add unattended uninstallation support

### DIFF
--- a/automatic/opera/README.md
+++ b/automatic/opera/README.md
@@ -7,6 +7,7 @@ The Opera web browser makes the Web fast and fun, giving you a better web browse
 - `/NoAutostart` - Do not add Opera autostart entry
 - `/NoDesktopShortcut` - Do not create desktop shortcut for Opera
 - `/NoTaskbarShortcut` - Do not pin Opera to taskbar
+- `/RemoveUserData` - Remove Opera's user data during uninstallation.
 
 These parameters can be passed to the installer with the use of `--params`.
 For example: `--params '"/NoAutostart /NoDesktopShortcut /NoTaskbarShortcut"'`

--- a/automatic/opera/opera.nuspec
+++ b/automatic/opera/opera.nuspec
@@ -30,6 +30,10 @@ For example: `--params '"/NoAutostart /NoDesktopShortcut /NoTaskbarShortcut"'`
     <releaseNotes>https://blogs.opera.com/desktop/changelog-for-102/#b4880.40</releaseNotes>
     <tags>browser opera cross-platform internet admin</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/opera</packageSourceUrl>
+    <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.3.4" />
+      <dependency id="autohotkey.portable" version="2.0.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/opera/opera.nuspec
+++ b/automatic/opera/opera.nuspec
@@ -31,7 +31,7 @@ For example: `--params '"/NoAutostart /NoDesktopShortcut /NoTaskbarShortcut"'`
     <tags>browser opera cross-platform internet admin</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/opera</packageSourceUrl>
     <dependencies>
-      <dependency id="chocolatey-core.extension" version="1.3.4" />
+      <dependency id="chocolatey-core.extension" version="1.4.0" />
       <dependency id="autohotkey.portable" version="2.0.0" />
     </dependencies>
   </metadata>

--- a/automatic/opera/tools/chocolateyUninstall.ps1
+++ b/automatic/opera/tools/chocolateyUninstall.ps1
@@ -2,17 +2,32 @@
 
 $packageName         = $env:chocolateyPackageName
 $softwareNamePattern = 'Opera*'
+$toolsDir            = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
 
 [array] $key = Get-UninstallRegistryKey $softwareNamePattern
 if ($key.Count -eq 1) {
   $key | ForEach-Object {
     $packageArgs = @{
       packageName    = $packageName
-      silentArgs     = "/uninstall /silent"
+      silentArgs     = "/uninstall"
       fileType       = 'EXE'
       validExitCodes = @(0)
       file           = $_.UninstallString.replace(' /uninstall', '').trim('"')
     }
+
+    $installLocation = Get-AppInstallLocation -AppNamePattern $softwareNamePattern
+    if ($null -ne $installLocation) {
+      Remove-Process -PathFilter "$([regex]::Escape($installLocation)).*" | Out-Null
+    }
+
+    $pp = Get-PackageParameters
+    $ahkArgList = New-Object Collections.Generic.List[string]
+    $ahkArgList.Add($(Join-Path -Path $toolsDir -ChildPath 'uninstall.ahk'))
+    if ($pp.RemoveUserData) {
+      $ahkArgList.Add('/RemoveUserData')
+    }
+
+    Start-Process -FilePath 'AutoHotKey.exe' -ArgumentList $ahkArgList
     Uninstall-ChocolateyPackage @packageArgs
   }
 }

--- a/automatic/opera/tools/uninstall.ahk
+++ b/automatic/opera/tools/uninstall.ahk
@@ -1,0 +1,67 @@
+#Requires AutoHotkey v2.0
+#NoTrayIcon
+#SingleInstance Force
+#Warn
+DetectHiddenText "Off"
+DetectHiddenWindows "Off"
+SetControlDelay 20
+SendMode "Input"
+SetTitleMatchMode 3 ;Exact
+SetWinDelay 100
+
+ShouldRemoveUserData := False
+for i, param in A_Args
+{
+  if (!StrCompare("/RemoveUserData", param))
+  {
+    ShouldRemoveUserData := True
+    break
+  }
+}
+
+UninstallerProcessName := "installer.exe"
+MainWindowClass := "InstallerMainWindow"
+MainWindowTitle := "ahk_class " MainWindowClass " ahk_exe " UninstallerProcessName
+WinWait MainWindowTitle
+
+if (ShouldRemoveUserData)
+{
+  RemoveUserDataCheckbox := "Button12"
+  ;For some reason, neither ControlClick nor ControlSetChecked will tick the checkbox
+  ControlSend "{Space}", RemoveUserDataCheckbox, MainWindowTitle
+}
+
+UninstallButton := "Button3"
+;This window's buttons may not work reliably with ControlClick if mouse-up events are delayed.
+;Send spaces with ControlSend instead for increased reliability.
+ControlSend "{Space}", UninstallButton, MainWindowTitle
+
+;If the user has launched Opera at least once, a survey page may show up.
+Sleep 200
+FirstRadioButton := "Button13" ;The positioning of each option is randomized and may vary
+SurveyPageVisible := ControlGetVisible(FirstRadioButton, MainWindowTitle)
+if (SurveyPageVisible) {
+  ;Skip over the survey
+  ControlSend "{Space}", UninstallButton, MainWindowTitle
+}
+
+DialogWindowClass := "#32770"
+DialogWindowTitle := "ahk_class " DialogWindowClass " ahk_exe " UninstallerProcessName
+WinWait DialogWindowTitle
+
+YesButton := "Button1"
+ControlClick YesButton, DialogWindowTitle,,,, "NA"
+
+TryAgainButton := "Button6"
+while !WinWaitClose(MainWindowTitle,, 1) {
+  try {
+    TryAgainButtonVisible := ControlGetVisible(TryAgainButton, MainWindowTitle)
+    if (TryAgainButtonVisible) {
+      ;Allow the user an opportunity to see the uninstaller has failed, then try again
+      Sleep 2000
+      ControlSend "{Space}", TryAgainButton, MainWindowTitle
+    }
+  }
+}
+
+ExitApp


### PR DESCRIPTION
## Description

This changeset modifies `opera`'s uninstallation process to close any running instances of Opera, then runs an AutoHotkey script, to work around Opera's decision to disable the `/silent` switch in its uninstaller.

## Motivation and Context

Fixes #2249.

This should enable the package to complete uninstallation in an automated fashion.

I've added a new dependency on `chocolatey-core.extension` v1.3.4+ and `autohotkey.portable` v2.0.0+, as well as a new package parameter (`/RemoveUserData`) to facilitate the process and ensure possibly desired functionality is exposed for user consumption.

The uninstaller's workflow may change slightly if existing user data is detected. After initially pressing the Uninstall button, a survey page may appear in the uninstaller for the user to optionally provide feedback as to why it's being uninstalled. The AutoHotkey script should detect when this happens, and will press the Uninstall button again to skip the survey and progress the uninstallation as expected.

>**Warning**
>The AutoHotkey script could potentially stall if an error is encountered during the uninstallation. As the uninstaller itself recommends closing Opera before trying again, `opera`'s uninstall script will also close all processes originating from the install location (if detected) prior to executing the uninstaller, in an effort to avoid this.
>
>If another error condition is encountered, the AutoHotkey script will continue pressing the Try Again button until the window closes (due to it either succeeding or closing by other means).

## How Has this Been Tested?

### Environment

#### Dev

- OS Build: Windows 11 Pro v10.0.22621.0 (64-bit)
- PowerShell version: 7.3.6
- Chocolatey version: 2.2.2

#### Chocolatey Test Environment

- Vagrant Box Version: 3.0.0
- VM Provider: Virtualbox (although practically Hyper-V, since I manually converted the resulting virtual disk)
- OS Build: Windows Server 2019 Datacenter v10.0.17763.0 (64-bit)
- PowerShell version: 5.1.17763.3770
- Chocolatey version: 2.2.2

### Steps

#### Uninstall without User Data

>**Important**
>Opera (both the package and software) is assumed to have never been installed previously.

1. Create a test package with the proposed changes from my dev environment (i.e. `choco pack`).
2. In the Chocolatey Testing Environment, install the test package version (i.e. `choco install opera --source="'.;https://community.chocolatey.org/api/v2/'"` [to prioritize local packages while sourcing dependencies from the Community Repository]).
3. Uninstall the test package version (i.e. `choco uninstall opera`).
4. Confirm that both the software and package's uninstallation completes without issues.

>**Note**
>As a post-uninstall step, this case will open a browser instance (either Google Chrome, Mozilla Firefox, or Microsoft Edge, in descending order, regardless of the user's browser preference) pointed to a page that redirects to <https://www.opera.com/client/uninstall>. As far as I know, this behavior cannot be suppressed. Closing the browser was deliberately avoided in the interest of preventing possibly unexpected closures.

#### Uninstall with User Data Creation and Preservation

1. Reinstall the test package version (i.e. `choco install opera --source="'.'"`).
2. Launch Opera after installation (it should show a splash screen upon first launch), then close it to trigger creation of user data.
3. Uninstall the test package version (i.e. `choco uninstall opera`).
4. Confirm that both the software and package's uninstallation completes without issues.
5. Reinstall the test package version (i.e. `choco install opera --source="'.'"`).
6. Launch Opera after installation, and confirm that no splash screen appears.

#### Uninstall while Opera is Running

1. Uninstall the test package version (i.e. `choco uninstall opera`).
2. Confirm that Opera is closed prior to the uninstaller launching.
3. Confirm that both the software and package's uninstallation completes without issues.

#### Uninstall with User Data Removal

1. Reinstall the test package version (i.e. `choco install opera --source="'.'"`).
2. Uninstall the test package version with the `/RemoveUserData` package parameter (i.e. `choco uninstall opera --package-parameters="'/RemoveUserData'"`).
3. Confirm that both the software and package's uninstallation completes without issues.
4. Reinstall the test package version (i.e. `choco install opera --source="'.'"`).
5. Launch Opera after installation, and confirm a splash screen appears upon first launch (which should signal no detected user data).

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
