### PR TITLE
(filezilla) Fix - verification URL pointing to download page

### DIFF
--- a/automatic/filezilla/update.ps1
+++ b/automatic/filezilla/update.ps1
@@ -9,8 +9,8 @@ function global:au_SearchReplace {
         }
 
         ".\legal\VERIFICATION.txt" = @{
-          "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL32)"
-          "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
+          "(?i)(\s+x32:).*"            = "`${1} $($releases)"
+          "(?i)(\s+x64:).*"            = "`${1} $($releases)"
           "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
           "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
Modified update.ps1 to use the URL in the releases variable to modify VERIFICATION.txt
Fixes #1881
See request in PR: #2166 

## Motivation and Context
The download links for Filezilla use a unique value that is timed. Putting them into the VERIFCATION.txt file means that after the time has run out, the links don't work. Using the download page links instead.

## How Has this Been Tested?
This is a simple text file change so hasn't been tested.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
