### PR TITLE
(ghostscript.app) Use AHK for installation after silent install flag removal

### DIFF
--- a/automatic/ghostscript.app/ghostscript.app.nuspec
+++ b/automatic/ghostscript.app/ghostscript.app.nuspec
@@ -36,6 +36,7 @@ Ghostscript has been under active development for over 20 years, and offers an e
     <releaseNotes>https://ghostscript.readthedocs.io/en/latest/News.html</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
+      <dependency id="autohotkey.portable" version="2.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/ghostscript.app/tools/ChocolateyInstall.ps1
+++ b/automatic/ghostscript.app/tools/ChocolateyInstall.ps1
@@ -18,6 +18,12 @@ $packageArgs = @{
   validExitCodes = @(0)
 }
 
+# silent install requires AutoHotKey after installer removed silent flag
+$ahkFile = Join-Path $toolsPath "ghostscript.ahk"
+$ahkProc = Start-Process -FilePath AutoHotkey.exe -ArgumentList "$ahkFile" -PassThru
+Write-Debug "AutoHotKey start time:`t$($ahkProc.StartTime.ToShortTimeString())"
+Write-Debug "AutoHotKey Process ID:`t$($ahkProc.Id)"
+
 Install-ChocolateyInstallPackage @packageArgs
 
 Remove-Item -Force -ea 0 "$toolsPath\*.$($packageArgs.fileType)*"

--- a/automatic/ghostscript.app/tools/ghostscript.ahk
+++ b/automatic/ghostscript.app/tools/ghostscript.ahk
@@ -1,0 +1,33 @@
+#Requires AutoHotkey v2.0
+#NoTrayIcon
+#SingleInstance Force
+#Warn
+SetTitleMatchMode "RegEx"
+exe_re := "gs.+.exe"
+
+If WinWait("ahk_exe " exe_re, "Next >", 20)
+   ControlSend "{ENTER}",, "ahk_exe " exe_re
+Else
+   exit 1
+
+If WinWait("ahk_exe " exe_re, "I Agree", 20)
+   ControlSend "{ENTER}",, "ahk_exe " exe_re
+Else
+   exit 1
+
+If WinWait("ahk_exe " exe_re, "Install", 20)
+   ControlSend "{ENTER}",, "ahk_exe " exe_re
+Else
+   exit 1
+
+If WinWait("ahk_exe " exe_re, "Finish", 20)
+   ControlSend "{ENTER}",, "ahk_exe " exe_re
+Else
+   exit 1
+
+if WinWait("ahk_exe " exe_re, "OK", 20)
+   ControlSend "{ENTER}",, "ahk_exe " exe_re
+Else
+   exit 1
+
+ExitApp


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
Add AHK install script after Artifex disabled the silent flag in the GhostScript installer.
Fixes #2221 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
Artifex disabled the option to install GhostScript with the silent flag (it's get's always overridden).
Installing Ghostscript with Chocolatey is only possible by using AHK.
Uninstaller does not need adjustments as it still can be run with silent flag.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
Tested successfully on latest Windows 11 fully patched.
Edit: Also tested successfully with with the latest chocolatey test environment.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
