### PR TITLE
(musescore) Cleanup update.ps1 links

### DIFF
--- a/automatic/musescore/legal/VERIFICATION.txt
+++ b/automatic/musescore/legal/VERIFICATION.txt
@@ -3,7 +3,7 @@ Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
 The embedded software have been downloaded from the listed download
-location on <https://musescore.org/en/download/musescore.msi>
+location on <https://musescore.org/en/download>
 and can be verified by doing the following:
 
 1. Download the following <https://cdn.jsdelivr.net/musescore/v4.2.0/MuseScore-4.2.0.233521124-x86_64.msi>

--- a/automatic/musescore/update.ps1
+++ b/automatic/musescore/update.ps1
@@ -1,4 +1,4 @@
-﻿﻿Import-Module AU
+﻿Import-Module AU
 
 $releases = 'https://musescore.org/en/download/musescore.msi'
 
@@ -7,7 +7,6 @@ function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt"      = @{
-      "(?i)(^\s*location on\:?\s*)\<.*\>" = "`${1}<$releases>"
       "(?i)(\s*1\..+)\<.*\>"              = "`${1}<$($Latest.URL32)>"
       "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType32)"
       "(?i)(^\s*checksum(32)?\:).*"       = "`${1} $($Latest.Checksum32)"

--- a/automatic/musescore/update.ps1
+++ b/automatic/musescore/update.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module AU
+﻿﻿Import-Module AU
 
 $releases = 'https://musescore.org/en/download/musescore.msi'
 


### PR DESCRIPTION
## Description
The changed hard-coded link is not necessary in the old format and the way it is worded suggests that the download location is sufficient. There is already a valid download-link generated and pushed to the VERIFICATION.txt, so there is no need for a second one.

## Motivation and Context
In the VERIFICATION.txt were two msi-links included. As the first one is not necessary and suggests that the download location is sufficient, it would be great if it could be changed, because of some automations we are using.

## How Has this Been Tested?
This change does not harm or interrupt the update-module and its process at all as the link is only there for informational purpose.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).