### PR TITLE
(inkscape) Create start menu entries for all users

### DIFF
--- a/automatic/inkscape/tools/chocolateyInstall.ps1
+++ b/automatic/inkscape/tools/chocolateyInstall.ps1
@@ -10,7 +10,7 @@ $packageArgs = @{
   checksumType   = 'sha256'
   file64         = "$toolsPath\inkscape-1.3_2023-07-21_0e150ed6c4-x64_31XBEKV.msi"
   softwareName   = 'InkScape*'
-  silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
+  silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).MsiInstall.log`" ALLUSERS=1"
   validExitCodes = @(0)
 }
 


### PR DESCRIPTION
Make start menu entries visible for all users.
Workaround for upstream bug https://gitlab.com/inkscape/inkscape/-/issues/1618

## Description
Apply the workaround suggested in the upstream bug: Pass ALLUSERS=1 to the MSI installer.
Then, the start menu entries are visible for all users and not just for the one user that runs choco.

## Motivation and Context
Fixes #2328 

## How Has this Been Tested?
- official choco test env 
- and also in custom VM
- You can see that it works by right-clicking on the Inkscape start menu entry --> More --> Open File Location. Check that it is NOT in C:\Users\...\AppData\... but somewhere system-wide

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
