### PR TITLE
(maint) Update stale messages

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,10 +27,13 @@ jobs:
           close-pr-label: 'Unresolved'
           exempt-issue-labels: 'Security / CVE,0 - Backlog,1 - Ready for work,2 - Working, 3 - Review, 5 - Push required'
           exempt-pr-labels: 'Security / CVE'
-          labels-to-remove-when-unstale: '0 - Wating on User,Pending closure'
+          labels-to-remove-when-unstale: '0 - Waiting on User,Pending closure'
           stale-issue-message: |
             Is this still relevant? If so, what is blocking it? Is there anything you can do to help move it forward?
             This issue will be closed in 14 days if it continues to be inactive.
+
+            Please do not add a comment to circumvent automatic closure unless **you** plan to help move it forward.
+            Doing this may lead to the issue being closed immediately instead.
           close-issue-message: |
             Dear contributor,
 


### PR DESCRIPTION
## Description

Update the stale messages used by the GitHub Action.

## Motivation and Context

On the Contributing.md file, we include a note about not commenting just to try to circumvent the automatic closure. This adds a similar note directly to the comments left by the GitHub Action.

## How Has this Been Tested?

This is an update to the wording of the action, no testing has been done.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).