### PR TITLE
(nexus-repository) Fix docsUrl in nuspec

### DIFF
--- a/automatic/nexus-repository/nexus-repository.nuspec
+++ b/automatic/nexus-repository/nexus-repository.nuspec
@@ -46,7 +46,7 @@ You can pass parameters as follows:
 ]]></description>
     <projectUrl>http://www.sonatype.com/nexus-repository-oss</projectUrl>
     <projectSourceUrl>https://github.com/sonatype/nexus-public</projectSourceUrl>
-    <docsUrl>http://books.sonatype.com/nexus-book/3.0/reference/index.html</docsUrl>
+    <docsUrl>https://help.sonatype.com/repomanager3</docsUrl>
     <tags>nexus-repository server freeware cross-platform maven nuget npm java rubygems docker eclipse p2 osgi obr apt yum rpm artifact bower ssl respository sonatype nexus admin</tags>
     <copyright>Sonatype</copyright>
     <licenseUrl>http://www.eclipse.org/legal/epl-v10.html</licenseUrl>


### PR DESCRIPTION


## Description

Fix the docsUrl for nexus-repository so it passes verification.

## Motivation and Context

Bad links fail the verifier

## How Has this Been Tested?

N/A

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

<
## Original Location
- [Original Repository](add_link_to_original_repository_location)
- [Open Issues](link_to_the_generic_location_of_open_issues) *Add the different issues underneath, and tick those that are fixed in this PR*
  - [ ] Issue 1 link
  - [ ] Issue 2 Link
- [ ] *Include the link to the opened PR that removes the package from the original location*
- [ ] The [migration guidelines](https://github.com/chocolatey-community/chocolatey-packages/wiki/Package-migration-process) have been followed
