### PR TITLE
(k9s) Update to checksum extension to sha256 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@
 */transifex*          @chocolatey-community/chocolatey-team-maintainers
 */waterfox*           @AdmiringWorm
 */composer*           @johnstevenson
+*/k9s*                @danielkoek
 */krew*               @jetersen
 */kubelogin*          @jetersen
 */ffmpeg-full*        @VuiMuich

--- a/automatic/k9s/update.ps1
+++ b/automatic/k9s/update.ps1
@@ -24,7 +24,7 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
   $LatestRelease = Get-GitHubRelease derailed k9s
 
-  $checksumAsset = $LatestRelease.assets | Where-Object { $_.name -eq 'checksums.txt' } | Select-Object -ExpandProperty browser_download_url
+  $checksumAsset = $LatestRelease.assets | Where-Object { $_.name -eq 'checksums.sha256' } | Select-Object -ExpandProperty browser_download_url
   $checksum_page = Invoke-WebRequest -Uri $checksumAsset -UseBasicParsing
   $checksum64 = [regex]::Match($checksum_page, "([a-f\d]+)\s*$([regex]::Escape($filename64))").Groups[1].Value
 


### PR DESCRIPTION
## Description
In pr https://github.com/derailed/k9s/pull/2153 they have changed the extension from txt to sha256, this change will make it possible to update k9s 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

