### PR TITLE
(vscode.install) fix vscode.install after 1.83

### DIFF
--- a/automatic/vscode.install/README.md
+++ b/automatic/vscode.install/README.md
@@ -14,8 +14,8 @@ Build and debug modern web and cloud applications. Code is free and available on
 * `/NoDesktopIcon` - Don't add a desktop icon.
 * `/NoQuicklaunchIcon` - Don't add an icon to the QuickLaunch area.
 * `/NoContextMenuFiles` - Don't add an _Open with Code_ entry to the context menu for files.
-* `/NoContextMenuFolders` - Dont't add an _Open with Code_ entry to the context menu for folders.
-* `/DontAssociateWithFiles` - Dont't associate Visual Studio Code with supported files.
+* `/NoContextMenuFolders` - Don't add an _Open with Code_ entry to the context menu for folders.
+* `/DontAssociateWithFiles` - Don't associate Visual Studio Code with supported files.
 * `/DontAddToPath` - Don't add Visual Studio Code to the system PATH.
 
 Example: `choco install vscode.install --params "/NoDesktopIcon /DontAddToPath"`

--- a/automatic/vscode.install/README.md
+++ b/automatic/vscode.install/README.md
@@ -24,6 +24,7 @@ Example: `choco install vscode.install --params "/NoDesktopIcon /DontAddToPath"`
 
 * The package uses default install options except that it adds context menu entries and Visual Studio Code isn't started after installation.
 * For disabling the auto-update functionality see the [Visual Studio Code Auto Update Deactivation package](https://chocolatey.org/packages/visualstudiocode-disableautoupdate).
+* Version 1.83.1 is the last version which is available in 32-bit and 64-bit. All later versions are 64-bit only.
 * **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 
 ![screenshot](https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@6dc510f16b69a2134e901f2576e991c462a18e9b/automatic/vscode/screenshot.png)

--- a/automatic/vscode.install/tools/ChocolateyInstall.ps1
+++ b/automatic/vscode.install/tools/ChocolateyInstall.ps1
@@ -16,13 +16,10 @@ Close-VSCode
 $packageArgs = @{
   packageName    = 'vscode.install'
   fileType       = 'exe'
-  url            = 'https://update.code.visualstudio.com/1.83.1/win32/stable'
   url64bit       = 'https://update.code.visualstudio.com/1.83.1/win32-x64/stable'
 
   softwareName   = "$softwareName"
 
-  checksum       = '6b5830991395299b59d1d8f4ecb3a9d752ef64b9b39c5dd4be848851c87f3126'
-  checksumType   = 'sha256'
   checksum64     = '4ce748cdd111d88e1b7990641912a0e55904709a2cc85a72895ee6d7aa1801fd'
   checksumType64 = 'sha256'
 

--- a/automatic/vscode.install/update.ps1
+++ b/automatic/vscode.install/update.ps1
@@ -4,7 +4,6 @@ Import-Module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
 if ($MyInvocation.InvocationName -ne '.') {
   function global:au_BeforeUpdate {
-    $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32
     $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64
   }
 }
@@ -13,9 +12,7 @@ function global:au_SearchReplace {
   @{
     'tools\chocolateyInstall.ps1' = @{
       "(?i)(^\s*packageName\s*=\s*)('.*')" = "`$1'$($Latest.PackageName)'"
-      "(?i)(^\s*url\s*=\s*)('.*')"         = "`$1'$($Latest.URL32)'"
       "(?i)(^\s*url64bit\s*=\s*)('.*')"    = "`$1'$($Latest.URL64)'"
-      "(?i)(^\s*checksum\s*=\s*)('.*')"    = "`$1'$($Latest.Checksum32)'"
       "(?i)(^\s*checksum64\s*=\s*)('.*')"  = "`$1'$($Latest.Checksum64)'"
       "(?i)(^[$]version\s*=\s*)('.*')"     = "`$1'$($Latest.RemoteVersion)'"
     }
@@ -26,13 +23,11 @@ function global:au_GetLatest {
   $latestRelease = Get-GitHubRelease microsoft vscode
   $version = $latestRelease.tag_name
   # URLs are documented here: https://code.visualstudio.com/docs/supporting/faq#_previous-release-versions
-  $url32 = "https://update.code.visualstudio.com/$version/win32/stable"
   $url64 = "https://update.code.visualstudio.com/$version/win32-x64/stable"
 
   @{
     Version       = $version
     RemoteVersion = $version
-    URL32         = $url32
     URL64         = $url64
   }
 }

--- a/automatic/vscode/vscode.nuspec
+++ b/automatic/vscode/vscode.nuspec
@@ -30,7 +30,8 @@
 * `/NoDesktopIcon` - Don't add a desktop icon.
 * `/NoQuicklaunchIcon` - Don't add an icon to the QuickLaunch area.
 * `/NoContextMenuFiles` - Don't add an _Open with Code_ entry to the context menu for files.
-* `/NoContextMenuFolders` - Dont't add an _Open with Code_ entry to the context menu for folders.
+* `/NoContextMenuFolders` - Don't add an _Open with Code_ entry to the context menu for folders.
+* `/DontAssociateWithFiles` - Don't associate Visual Studio Code with supported files.
 * `/DontAddToPath` - Don't add Visual Studio Code to the system PATH.
 
 Example: `choco install vscode --params "/NoDesktopIcon /DontAddToPath"`

--- a/automatic/vscode/vscode.nuspec
+++ b/automatic/vscode/vscode.nuspec
@@ -39,6 +39,7 @@ Example: `choco install vscode --params "/NoDesktopIcon /DontAddToPath"`
 
 * The package uses default install options except that it adds context menu entries and Visual Studio Code isn't started after installation.
 * For disabling the auto-update functionality see the [Visual Studio Code Auto Update Deactivation package](https://chocolatey.org/packages/visualstudiocode-disableautoupdate).
+* Version 1.83.1 is the last version which is available in 32-bit and 64-bit. All later versions are 64-bit only.
 * **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 
 ![screenshot](https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@6dc510f16b69a2134e901f2576e991c462a18e9b/automatic/vscode/screenshot.png)


### PR DESCRIPTION
Remove 32-bit checks.

## Description

vscode does not provide a 32-bit version anymore after 1.83, so the automatic update checks fail.

## Motivation and Context

#2344

## How Has this Been Tested?

I wan't able to get the update checks running locally. Since I only removed the 32-bit URLs, I hope this is ok.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).