### PR TITLE
(datagrip) Strip `.0` suffix from installation directory

### DIFF
--- a/automatic/datagrip/tools/ChocolateyInstall.ps1
+++ b/automatic/datagrip/tools/ChocolateyInstall.ps1
@@ -6,7 +6,9 @@ $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $programFiles = (${env:ProgramFiles(x86)}, ${env:ProgramFiles} -ne $null)[0]
 $pp = Get-PackageParameters
 
-$installDir = "$programFiles\JetBrains\DataGrip $env:ChocolateyPackageVersion"
+# If the release version ends in '.0', remove this since JetBrains don't
+# use this part of the version number when creating the installation directory.
+$installDir = "$programFiles\JetBrains\DataGrip $($env:ChocolateyPackageVersion -replace '.0$', '')"
 if ($pp.InstallDir) {
     $installDir = $pp.InstallDir
 }


### PR DESCRIPTION
## Description

When determining the installation directory for Datagrip, remove any `.0` suffix that might be present in the version number. Jetbrains doesn't use this part of the release version number when installing, so this causes Chocolatey to create an empty directory that never gets used or cleaned up.

## Motivation and Context
Fixes: https://github.com/chocolatey-community/chocolatey-packages/issues/2257

## How Has this Been Tested?
`choco install -s . datagrip` with these changes; observe that spurious `.0` directory is no longer created.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).

