### PR TITLE
(googlechrome) Fixed the Google Chrome Download Links

### DIFF
--- a/automatic/googlechrome/update.ps1
+++ b/automatic/googlechrome/update.ps1
@@ -2,6 +2,7 @@
 import-module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
 $releases = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json"
+$paddedUnderVersion = '57.0.2988'
 
 function global:au_BeforeUpdate {
   $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32

--- a/automatic/googlechrome/update.ps1
+++ b/automatic/googlechrome/update.ps1
@@ -22,7 +22,7 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $releasesData = Invoke-RestMethod -UseBasicParsing -Method Get -Uri $releases
-  $version = $data.channels.Stable.version
+  $version = $releasesData.channels.Stable.version
   
   @{
     URL32 = 'https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise.msi'

--- a/automatic/googlechrome/update.ps1
+++ b/automatic/googlechrome/update.ps1
@@ -1,8 +1,7 @@
 ﻿import-module au
 import-module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
-$releases = 'http://omahaproxy.appspot.com/all?os=win&amp;channel=stable'
-$paddedUnderVersion = '57.0.2988'
+$releases = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json"
 
 function global:au_BeforeUpdate {
   $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32
@@ -22,9 +21,9 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $release_info = Invoke-WebRequest -Uri $releases -UseBasicParsing
-  $version = $release_info | ForEach-Object Content | ConvertFrom-Csv | ForEach-Object current_version
-
+  $releasesData = Invoke-RestMethod -UseBasicParsing -Method Get -Uri $releases
+  $version = $data.channels.Stable.version
+  
   @{
     URL32 = 'https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise.msi'
     URL64 = 'https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi'

--- a/automatic/googlechrome/update.ps1
+++ b/automatic/googlechrome/update.ps1
@@ -26,8 +26,8 @@ function global:au_GetLatest {
   $version = $release_info | ForEach-Object Content | ConvertFrom-Csv | ForEach-Object current_version
 
   @{
-    URL32 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi'
-    URL64 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi'
+    URL32 = 'https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise.msi'
+    URL64 = 'https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi'
     Version = Get-FixVersion $version -OnlyFixBelowVersion $paddedUnderVersion
     RemoteVersion = $version
     PackageName = 'GoogleChrome'


### PR DESCRIPTION
Fix Google Chrome Download Link

The google chrome download link has changed slightly, I fixed it so it will download reliably now.

## Description
I changed `https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi` to `https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise.msi` removing the `tag/s/` part, as that has apparently changed.

## Motivation and Context
This fixes the chrome installer, as that is failing for my PCs I manage.

## How Has this Been Tested?
I don't fully know how to test this script, if someone can let me know, I will happily do whatever I need to.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).
