### PR TITLE
(googlechrome) Migrate version detection to ChromiumDash

### DIFF
--- a/automatic/googlechrome/update.ps1
+++ b/automatic/googlechrome/update.ps1
@@ -23,7 +23,7 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $release_info = Invoke-WebRequest -Uri $releases -UseBasicParsing
-  $version = ($release_info | % Content | ConvertFrom-Json)[0].version
+  $version = ($release_info | ConvertFrom-Json)[0].version
 
   @{
     URL32 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi'

--- a/automatic/googlechrome/update.ps1
+++ b/automatic/googlechrome/update.ps1
@@ -1,7 +1,7 @@
 ﻿import-module au
 import-module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
-$releases = 'http://omahaproxy.appspot.com/all?os=win&amp;channel=stable'
+$releases = 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Windows&num=1&offset=0'
 $paddedUnderVersion = '57.0.2988'
 
 function global:au_BeforeUpdate {
@@ -23,7 +23,7 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $release_info = Invoke-WebRequest -Uri $releases -UseBasicParsing
-  $version = $release_info | ForEach-Object Content | ConvertFrom-Csv | ForEach-Object current_version
+  $version = ($release_info | % Content | ConvertFrom-Json)[0].version
 
   @{
     URL32 = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi'


### PR DESCRIPTION
## Description

Changes version detection from Omaha to ChromiumDash

## Motivation and Context
OmahaProxy has been deprecated, it now returns the message below.

This small change moves version detection to the new service.

```
*** Service Permanently Offline ***

OmahaProxy has been turned down.
Please migrate to <https://chromiumdash.appspot.com>.
```

## How Has this Been Tested?

Run AU locally, the version is correctly extracted.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).