### PR TITLE
(apache-httpd) Migrated Apache httpd from Apache Haus to Apache Lounge

### DIFF
--- a/automatic/apache-httpd/apache-httpd.nuspec
+++ b/automatic/apache-httpd/apache-httpd.nuspec
@@ -3,7 +3,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>apache-httpd</id>
-    <version>2.4.55</version>
+    <version>2.4.58</version>
     <title>Apache HTTP Server Project</title>
      <authors>Apache Software Foundation</authors>
     <owners>chocolatey-community</owners>
@@ -35,7 +35,7 @@ Example: `choco install apache-httpd --params '"/installLocation:C:\HTTPD /port:
 
 ## Notes
 
-- This package will install the latest Apache binaries provided at Apache Haus (http://www.apachehaus.com/) with OpenSSL 1.1.1p, brotli 1.0.9, nghttp 1.47.0, Zlib 1.2.12, PCRE2 10.40.
+- This package will install the latest Apache binaries provided at Apache Lounge (https://www.apachelounge.com/) with OpenSSL, brotli, nghttp, Zlib, PCRE2.
 - The complete path of the package will be `$Env:AppData\Apache*`
 - Apache will be installed as a service under the default name 'Apache' (can be disabled with the `/noService` install parameter)
 ]]></description>

--- a/automatic/apache-httpd/legal/VERIFICATION.txt
+++ b/automatic/apache-httpd/legal/VERIFICATION.txt
@@ -2,18 +2,18 @@ VERIFICATION
 Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
-The installer has been downloaded from their official download link listed on <https://www.apachehaus.com/cgi-bin/download.plx>
+The installer has been downloaded from their official download link listed on <https://www.apachelounge.com/download/>
 and can be verified like this:
 
 1. Download the following installers:
-  32-Bit: <https://www.apachehaus.com/downloads/httpd-2.4.55-o111s-x86-vs17.zip>
-  64-Bit: <https://www.apachehaus.com/downloads/httpd-2.4.55-o111s-x64-vs17.zip>
+  32-Bit: <https://www.apachelounge.com/download/VS17/binaries/httpd-2.4.58-win32-vs17.zip>
+  64-Bit: <https://www.apachelounge.com/download/VS17/binaries/httpd-2.4.58-win64-VS17.zip>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum32: 34E94E6CFB23B0AB6658A0EE06DB53460CC907B80851F7EA325EF482224D12B8
-  checksum64: 33E5D2C657583F2AB5D9D52D9C626E4BF369B18965491EF75BEF121388EE34E3
+  checksum32: 5C79B779475777534F0C8E93CE6E662B4226700511B92571F75BA0441DAF9C0B
+  checksum64: E9A179AD4767C595BE55024EE0415A96AE522F492DECA4B0D54CF136FF2B092C
 
 File 'LICENSE.txt' is obtained from <https://www.apache.org/licenses/LICENSE-2.0.txt>

--- a/automatic/apache-httpd/readme.md
+++ b/automatic/apache-httpd/readme.md
@@ -19,6 +19,6 @@ Example: `choco install apache-httpd --params '"/installLocation:C:\HTTPD /port:
 
 ## Notes
 
-- This package will install the latest Apache binaries provided at Apache Haus (http://www.apachehaus.com/) with OpenSSL 1.1.1p, brotli 1.0.9, nghttp 1.47.0, Zlib 1.2.12, PCRE2 10.40.
+- This package will install the latest Apache binaries provided at Apache Lounge (http://www.apachelounge.com/) with OpenSSL, brotli, nghttp, Zlib, PCRE2.
 - The complete path of the package will be `$Env:AppData\Apache*`
 - Apache will be installed as a service under the default name 'Apache' (can be disabled with the `/noService` install parameter)

--- a/automatic/apache-httpd/tools/chocolateyInstall.ps1
+++ b/automatic/apache-httpd/tools/chocolateyInstall.ps1
@@ -5,8 +5,8 @@ $pp = Get-PackageParameters
 
 $arguments = @{
     packageName = $env:chocolateyPackageName
-    file        = "$toolsDir\httpd-2.4.55-o111s-x86-vs17.zip"
-    file64      = "$toolsDir\httpd-2.4.55-o111s-x64-vs17.zip"
+    file        = "$toolsDir\httpd-2.4.58-win32-vs17.zip"
+    file64      = "$toolsDir\httpd-2.4.58-win64-VS17.zip"
     destination = if ($pp.installLocation) { $pp.installLocation } else { $env:APPDATA }
     port        = if ($pp.Port) { $pp.Port } else { 8080 }
     serviceName = if ($pp.NoService) { $null } elseif ($pp.serviceName) { $pp.serviceName } else { 'Apache' }

--- a/automatic/apache-httpd/update.ps1
+++ b/automatic/apache-httpd/update.ps1
@@ -1,21 +1,21 @@
 ﻿Import-Module au
 
-$releases = 'https://www.apachehaus.com/cgi-bin/download.plx'
+$releases = 'https://www.apachelounge.com/download/'
 
 function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix }
 
 function global:au_GetLatest {
-  $versionRegEx = 'httpd\-([\d\.]+).*\-x86\-(vs17).*\.zip'
+  $versionRegEx = 'httpd\-([\d\.]+).*?\-win32\-([vV][sS]17).*?\.zip'
 
-  $downloadPage = Invoke-WebRequest $releases -UseBasicParsing
+  $downloadPage = Invoke-WebRequest $releases -UseBasicParsing -UserAgent Chocolatey
   $matches = [regex]::match($downloadPage.Content, $versionRegEx)
   $version32 = $matches.Groups[1].Value
-  $url32 = "https://www.apachehaus.com/downloads/$($matches.Groups[0].Value)"
+  $url32 = "https://www.apachelounge.com/download/VS17/binaries/$($matches.Groups[0].Value)"
 
-  $versionRegEx = $versionRegEx -replace 'x86', 'x64'
+  $versionRegEx = $versionRegEx -replace 'win32', 'win64'
   $matches = [regex]::match($downloadPage.Content, $versionRegEx)
   $version64 = [version]$matches.Groups[1].Value
-  $url64 = "https://www.apachehaus.com/downloads/$($matches.Groups[0].Value)"
+  $url64 = "https://www.apachelounge.com/download/VS17/binaries/$($matches.Groups[0].Value)"
 
   if ($version32 -ne $version64) {
     throw "32bit and 64bit version do not match. Please check the update script."


### PR DESCRIPTION
Migrated Apache httpd from Apache Haus to Apache Lounge.

## Description
Changed download URL from apachehaus.com to apachelounge.com.
Modified regex to match the new Apache Lounge naming convention.

## Motivation and Context
Apache Haus has been on hold since 27 Feb 2023 and has not received updates. Switching to a maintained version on Apache Lounge.

## How Has this Been Tested?
Performed local install, checked the site responded in a browser, and performed local uninstall.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ x] I have updated the package description and it is less than 4000 characters.
- [ x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ x] The changes only affect a single package (not including meta package).