### PR TITLE
(cmake) Fix AU version detection

### DIFF
--- a/automatic/cmake/update.ps1
+++ b/automatic/cmake/update.ps1
@@ -31,13 +31,27 @@ function global:au_GetLatest {
     $url32_portable = $allZips | Where-Object { $_ -match "$version-$re32" }
     $url64_portable = $allZips | Where-Object { $_ -match "$version-$re64" }
 
-    $streams.Add($versionTwopart, @{
-        Version = $version
-        URL32_i = [uri]$_
-        URL64_i = [uri]$url64
-        URL32_p = [uri]$url32_portable
-        URL64_p = [uri]$url64_portable
-      })
+    if ($streams.ContainsKey($versionTwoPart)) {
+        $previousKeyVersion = Get-Version $streams[$versionTwoPart].Version
+        $currentKeyVersion = Get-Version $version
+        if ($currentKeyVersion -gt $previousKeyVersion) {
+            $streams[$versionTwopart] = @{
+                Version = $version
+                URL32_i = [uri]$_
+                URL64_i = [uri]$url64
+                URL32_p = [uri]$url32_portable
+                URL64_p = [uri]$url64_portable
+            }
+        }
+    } else {
+        $streams.Add($versionTwopart, @{
+            Version = $version
+            URL32_i = [uri]$_
+            URL64_i = [uri]$url64
+            URL32_p = [uri]$url32_portable
+            URL64_p = [uri]$url64_portable
+          })
+    }
   }
 
   return @{ Streams = $streams }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The cmake download page was changed to have both old prerelease versions still available for download after the stable minor version is released. This causes the AU script to error, as the streams variable already has the key, so the stable version is not added. This adds a check to fix that.


## Motivation and Context

Fixes #2394
As the `.install` and `.portable` packages reference this AU script, this change fixes both of them as well.

## How Has this Been Tested?

AU script ran on Windows 10. Package tested in Chocolatey test environment. 

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

