### PR TITLE
(googlechromebeta) fix update script

### DIFF
--- a/automatic/googlechromebeta/update.ps1
+++ b/automatic/googlechromebeta/update.ps1
@@ -1,7 +1,7 @@
 ﻿import-module au
 import-module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
-$releases = 'https://omahaproxy.appspot.com/all?os=win&channel=beta'
+$versionsApi = 'https://versionhistory.googleapis.com/v1/chrome/platforms/win/channels/beta/versions'
 $paddedUnderVersion = '57.0.2988'
 
 function global:au_BeforeUpdate {
@@ -22,8 +22,8 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $release_info = Invoke-WebRequest -Uri $releases -UseBasicParsing
-  $version = $release_info | ForEach-Object Content | ConvertFrom-Csv | ForEach-Object current_version
+  $versions_info = Invoke-RestMethod -Method Get -UseBasicParsing -Uri $versionsApi
+  $version = $versions_info.versions | Select-Object -First 1 -ExpandProperty version
   $version = "$version-beta"
 
   @{


### PR DESCRIPTION
## Description


As omahaproxy has shut down, the update script broke. This switches to using the official google version history api for google chrome.

## Motivation and Context


Fixes #2398

## How Has this Been Tested?

Tested update script on Windows 10, tested package in chocolatey test env.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).


