### PR TITLE
(freecad) Fix portable regex and remove 32 bit references

### DIFF
--- a/automatic/freecad/tools/chocolateyInstall.ps1
+++ b/automatic/freecad/tools/chocolateyInstall.ps1
@@ -6,11 +6,8 @@ if (!$PSScriptRoot) { $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -P
 $packageArgs = @{
   packageName    = 'freecad'
   fileType       = '7z'
-  url            = ''
   url64          = 'https://github.com/FreeCAD/FreeCAD-Bundle/releases/download/weekly-builds/FreeCAD_weekly-builds-33658-2023-07-30-conda-Windows-x86_64-py310.7z'
   softwareName   = 'FreeCAD'
-  checksum       = ''
-  checksumType   = ''
   checksum64     = '4E61B5E4176CB93EDC23EB71A53D2ACAA840C88AEE9BFAA63AB2CA48F8300726'
   checksumType64 = 'sha256'
   silentArgs     = '/S'
@@ -20,7 +17,6 @@ $packageArgs = @{
 if (( $packageArgs.filetype -eq '7z' ) -or ( $packageArgs.filetype -eq 'zip' )) {
   # Checking for Package Parameters
   $pp = ( Get-UserPackageParams -scrawl )
-  if ($packageArgs.url64 -match "Conda") { $packageArgs.Remove("url"); $packageArgs.Remove("checksum"); $packageArgs.Remove("checksumType"); }
   if ($pp.InstallDir) { $packageArgs.Add( "UnzipLocation", $pp.InstallDir ) }
   Install-ChocolateyZipPackage @packageArgs
   if ($pp.Shortcut) { $pp.Remove("Shortcut"); Install-ChocolateyShortcut @pp }

--- a/automatic/freecad/update.ps1
+++ b/automatic/freecad/update.ps1
@@ -13,11 +13,8 @@ function global:au_SearchReplace {
     ".\tools\chocolateyInstall.ps1"   = @{
       "(?i)(^\s*packageName\s*=\s*)'.*'"      = "`$1'$($Latest.PackageName)'"
       "(?i)(^\s*fileType\s*=\s*)('.*')"       = "`$1'$($Latest.fileType)'"
-      "(?i)(^\s*url\s*=\s*)('.*')"            = "`$1'$($Latest.URL32)'"
       "(?i)(^\s*url64\s*=\s*)('.*')"          = "`$1'$($Latest.URL64)'"
-      "(?i)(^\s*checksum\s*=\s*)('.*')"       = "`$1'$($Latest.Checksum32)'"
       "(?i)(^\s*checksum64\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum64)'"
-      "(?i)(^\s*checksumType\s*=\s*)('.*')"   = "`$1'$($Latest.ChecksumType32)'"
       "(?i)(^\s*checksumType64\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType64)'"
       "(?i)(^\s*softwareName\s*=\s*)'.*'"     = "`$1'$($softwareName)'"
     }

--- a/automatic/freecad/update_helper.ps1
+++ b/automatic/freecad/update_helper.ps1
@@ -31,8 +31,8 @@ param(
     'portable' {
       $download_page = (Get-GitHubRelease -Owner "Freecad" -Name "Freecad" -Verbose).assets
       $mobile = "portable"
-      $ext = "zip"
-      $re64 = "(FreeCAD\-)((\d+)?(\.))+?(\d)?(\-)(WIN)(\-)?(x\d{2})\-(${mobile})(\-|.)?(\d+)?(\.${ext})$"
+      $ext = "7z"
+      $re64 = "(FreeCAD\-)((\d+)?(\.))+?(\d)?(\-)(Windows)(\-)?(x\d{2})(\-|.)?(\d+)?(\.${ext})$"
 #      $url64 = ( $download_page.Links | ? href -match $re64 | Sort-Object -Property 'href' -Descending | Select-Object -First 1 -ExpandProperty 'href' )
       $url64 = ( $download_page | Where-Object Name -match $re64 | Select-Object -First 1 -ExpandProperty 'browser_download_url' )
       $vert = "$version"

--- a/automatic/freecad/update_helper.ps1
+++ b/automatic/freecad/update_helper.ps1
@@ -16,16 +16,18 @@ param(
       $ext = "7z"
       $re64 = "(FreeCAD_weekly-builds)?((\-\d{2,6})+)?(\-conda)?(\-${mobile})(\-|.)?(x\d{2}_\d{2}\-)?(py\d{2,5})?(\.$ext)$"
 #      $url64 = ( $download_page.Links | ? href -match $re64 | Select-Object -First 1 -ExpandProperty 'href' )
-      $url64 = ( $download_page | Where-Object Name -match $re64 | Select-Object -First 1 -ExpandProperty 'browser_download_url' )
+      $asset64 = ( $download_page | Where-Object Name -match $re64 | Select-Object -First 1 )
+      $url64 = $asset64.browser_download_url
       "url64 -$url64-" | Write-Warning
       $PackageName  = "$Title"
       $Title        = "$Title"
-      # Now to get the newest Revision from url64
+      # Now to get the newest Revision with date from asset64
+      $dateCreated = Get-Date -Date $asset64.created_at -UFormat "%Y.%m.%d"
       $veri = ((($url64 -split('\/'))[-1]) -replace( "(x\d{2})|(_\d{2}\-py\d{2,5})|(\-)?([A-z])+?(\-)|(\.$ext)", ''))
       "veri -$veri-" | Write-Warning
-      $DevRevision,$year,$month,$day = (($veri -replace('\-','.') ) -split('\.'))
-      "Standard Development Versioning for $DevRevision dated ${month}-${day}-${year}" | Write-Warning
-      [version]$version = ( ( ($DevRevision),($year),($month),($day) ) -join "." )
+      $DevRevision = (($veri -replace('\-','.') ) -split('\.')) | Select-Object -First 1
+      "Standard Development Versioning for $DevRevision dated ${dateCreated}" | Write-Warning
+      [version]$version = ( ( ($DevRevision),($dateCreated) ) -join "." )
       $vert = "${version}-${kind}"
     }
     'portable' {


### PR DESCRIPTION
## Description

Fixes the update script regex and removes 32 bit references.

## Motivation and Context

Fixes #2338 
The 32 bit builds are completely gone now, so the 32bit references in the install script can be removed.

## How Has this Been Tested?

Script tested on Windows 10, packages tested in Chocolatey test env.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

