### PR TITLE
(vscode-insiders.install) fix update script, remove 32 bit support

### DIFF
--- a/automatic/vscode-insiders.install/tools/chocolateyInstall.ps1
+++ b/automatic/vscode-insiders.install/tools/chocolateyInstall.ps1
@@ -22,13 +22,10 @@ function Get-MergeTasks {
 $packageArgs = @{
   packageName    = "$env:ChocolateyPackageName"
   fileType       = 'exe'
-  url            = 'https://az764295.vo.msecnd.net/insider/02d3b49d8035a9b30db3b0ae706796af9b1a4260/VSCodeSetup-ia32-1.81.0-insider.exe'
   url64bit       = 'https://az764295.vo.msecnd.net/insider/02d3b49d8035a9b30db3b0ae706796af9b1a4260/VSCodeSetup-x64-1.81.0-insider.exe'
 
   softwareName   = 'Microsoft Visual Studio Code Insiders'
 
-  checksum       = 'cba008c12f5e66b97542bcb43d95c52b3a8057e142a06d7afff727302c774f26f637677e595e7ba5b8dd0f41f779eb5d69228a1b712c003ae7512e2df3498e65'
-  checksumType   = 'sha512'
   checksum64     = '173026bd10cb004ee2cbd14e3a5808bb5aeff14da7513b95480a8c2b75e47f9de517a34f624c4d5a3e4f070d99501a7598ab7f0ecae9a277f815686d52df7096'
   checksumType64 = 'sha512'
 

--- a/automatic/vscode-insiders.install/update.ps1
+++ b/automatic/vscode-insiders.install/update.ps1
@@ -1,46 +1,36 @@
 ﻿import-module au
 import-module "$PSScriptRoot\..\..\extensions\chocolatey-core.extension\extensions\chocolatey-core.psm1"
 
-$releases32 = 'https://update.code.visualstudio.com/api/update/win32/insider/VERSION'
-$releases64 = 'https://update.code.visualstudio.com/api/update/win32-x64/insider/VERSION'
+$releases64 = 'https://update.code.visualstudio.com/api/update/win32-x64/insider/0000000000000000000000000000000000000000'
 
 if ($MyInvocation.InvocationName -ne '.') {
   function global:au_BeforeUpdate {
-    $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32 -Algorithm $Latest.ChecksumType
-    $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64 -Algorithm $Latest.ChecksumType
+    $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64 -Algorithm $Latest.ChecksumType64
   }
 }
 
 function global:au_SearchReplace {
   @{
     'tools\chocolateyInstall.ps1' = @{
-      "(?i)(^\s*url\s*=\s*)('.*')"               = "`$1'$($Latest.URL32)'"
       "(?i)(^\s*url64bit\s*=\s*)('.*')"          = "`$1'$($Latest.URL64)'"
-      "(?i)(^\s*checksum\s*=\s*)('.*')"          = "`$1'$($Latest.Checksum32)'"
       "(?i)(^\s*checksum64\s*=\s*)('.*')"        = "`$1'$($Latest.Checksum64)'"
-      "(?i)(^\s*checksumType(64)?\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType)'"
+      "(?i)(^\s*checksumType64\s*=\s*)('.*')"    = "`$1'$($Latest.ChecksumType64)'"
     }
   }
 }
 
 function global:au_GetLatest {
-  $json32 = Invoke-WebRequest -UseBasicParsing -Uri $releases32 | ConvertFrom-Json
   $json64 = Invoke-WebRequest -UseBasicParsing -Uri $releases64 | ConvertFrom-Json
 
-  if ($json32.productVersion -ne $json64.productVersion) {
-    throw "Different versions for 32-Bit and 64-Bit detected."
-  }
-
   # Strip `-insider`
-  $version = $($($json32.productVersion).split('-insider')[0])
+  $version = $($($json64.productVersion).split('-insider')[0])
   # Get date from timestamp
-  $date = $(Get-Date -Format "yyyyMMdd" $(Get-Date 01.01.1970).AddMilliseconds($json32.timestamp))
+  $date = $(Get-Date -Format "yyyyMMdd" $(Get-Date 01.01.1970).AddMilliseconds($json64.timestamp))
 
   @{
-    Version      = "$version.$date"
-    URL32        = $json32.Url
-    URL64        = $json64.Url
-    ChecksumType = 'sha512'
+    Version        = "$version.$date"
+    URL64          = $json64.Url
+    ChecksumType64 = 'sha512'
   }
 }
 


### PR DESCRIPTION
## Description

Removes 32 bit from the package, fixes up the update script. 

## Motivation and Context

32 bit builds have been discontinued, and the syntax of the update check url changed
Fixes #2404

## How Has this Been Tested?

Update script tested on Windows 10, package tested in Chocolatey test env

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

