### PR TITLE
(octave.portable) Remove 32 bit support

### DIFF
--- a/automatic/octave.portable/legal/VERIFICATION.txt
+++ b/automatic/octave.portable/legal/VERIFICATION.txt
@@ -8,7 +8,6 @@ location on <https://www.gnu.org/software/octave/download.html>
 and can be verified by doing the following:
 
 1. Download the following:
-  32-bit software: <https://ftp.gnu.org/gnu/octave/windows/octave-8.2.0-w32.7z>
   64-bit software: <https://ftp.gnu.org/gnu/octave/windows/octave-8.2.0-w64.7z>
 
 2. Get the checksum using one of the following methods:
@@ -18,7 +17,6 @@ and can be verified by doing the following:
 3. The checksums should match the following:
 
   checksum type: sha256
-  checksum32: 9d6a81d86d7128775f8e821d89704582da81cee51400071c6d099118c983f37a
   checksum64: 6c07a7e5cf748e2efc2ae719dd8ad9b07e41cf7abb645b84cf753b6e0cc2bfd4
 
 File 'gpl-3.0.txt' is obtained from <https://www.gnu.org/software/octave/license.html>

--- a/automatic/octave.portable/tools/chocolateyInstall.ps1
+++ b/automatic/octave.portable/tools/chocolateyInstall.ps1
@@ -5,27 +5,20 @@ $version = '8.2.0'
 $toolsDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
 $progDir  = "$toolsDir\octave"
 
-$osBitness = Get-OSArchitectureWidth
 
 $packageArgs = @{
   PackageName    = 'octave.portable'
   UnzipLocation  = $toolsDir
-  Url            = 'https://ftp.gnu.org/gnu/octave/windows/octave-8.2.0-w32.7z'
   Url64          = 'https://ftp.gnu.org/gnu/octave/windows/octave-8.2.0-w64.7z'
-  Checksum       = '9d6a81d86d7128775f8e821d89704582da81cee51400071c6d099118c983f37a'
   Checksum64     = '6c07a7e5cf748e2efc2ae719dd8ad9b07e41cf7abb645b84cf753b6e0cc2bfd4'
-  ChecksumType   = 'sha256'
   ChecksumType64 = 'sha256'
 }
 
 Install-ChocolateyZipPackage @packageArgs
 
 # Rename unzipped folder
-If (Test-Path "$toolsDir\octave-$version-w$osBitness") {
-  Rename-Item -Path "$toolsDir\octave-$version-w$osBitness" -NewName 'octave'
-}
-If (Test-Path "$toolsDir\octave-$version") {
-  Rename-Item -Path "$toolsDir\octave-$version" -NewName 'octave'
+If (Test-Path "$toolsDir\octave-$version-w64") {
+  Rename-Item -Path "$toolsDir\octave-$version-w64" -NewName 'octave'
 }
 
 # Don't create shims for any executables
@@ -35,7 +28,7 @@ foreach ($file in $files) {
 }
 
 # Link batch
-$path = "$progDir\mingw$osBitness\bin\octave.bat"
+$path = "$progDir\mingw64\bin\octave.bat"
 Install-BinFile -Name 'octave'     -Path $path -Command '--gui' -UseStart
 Install-BinFile -Name 'octave-cli' -Path $path -Command '--no-gui'
 
@@ -65,7 +58,7 @@ if ($pp.Count -gt 0) {
   }
 
   if ($paths.Count -gt 0) {
-    $icon   = "$progDir\mingw$osBitness\share\octave\$version\imagelib\octave-logo.ico"
+    $icon   = "$progDir\mingw64\share\octave\$version\imagelib\octave-logo.ico"
     $target = "$progDir\octave.vbs"
 
     $paths.GetEnumerator() | foreach-object {

--- a/automatic/octave.portable/update.ps1
+++ b/automatic/octave.portable/update.ps1
@@ -6,30 +6,21 @@ Import-Module AU
 $releases = "https://ftp.gnu.org/gnu/octave/windows/?C=M;O=D"
 
 function global:au_BeforeUpdate {
-  $checksumType = 'sha256'
-  $Latest.ChecksumType64 = $Latest.ChecksumType32 = $checksumType
-
-  $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32 -Algorithm $checksumType
-  $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64 -Algorithm $checksumType
+  $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64 -Algorithm $Latest.checksumType64
 }
 
 function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt"      = @{
-      "(?i)(^\s*32\-bit software.*)\<.*\>" = "`${1}<$($Latest.URL32)>"
       "(?i)(^\s*64\-bit software.*)\<.*\>" = "`${1}<$($Latest.URL64)>"
-      "(?i)(^\s*checksum\s*type\:).*"      = "`${1} $($Latest.ChecksumType32)"
-      "(?i)(^\s*checksum32?\:).*"          = "`${1} $($Latest.Checksum32)"
+      "(?i)(^\s*checksum\s*type\:).*"      = "`${1} $($Latest.ChecksumType64)"
       "(?i)(^\s*checksum64\:).*"           = "`${1} $($Latest.Checksum64)"
     }
 
     ".\tools\chocolateyInstall.ps1" = @{
       "(?i)(^\s*\`$version\s*=\s*)('.*')"     = "`${1}'$($Latest.Version)'"
-      "(?i)(^\s*Url\s*=\s*)('.*')"            = "`${1}'$($Latest.URL32)'"
       "(?i)(^\s*Url64\s*=\s*)('.*')"          = "`${1}'$($Latest.URL64)'"
-      "(?i)(^\s*Checksum\s*=\s*)('.*')"       = "`${1}'$($Latest.Checksum32)'"
       "(?i)(^\s*Checksum64\s*=\s*)('.*')"     = "`${1}'$($Latest.Checksum64)'"
-      "(?i)(^\s*ChecksumType\s*=\s*)('.*')"   = "`${1}'$($Latest.ChecksumType32)'"
       "(?i)(^\s*ChecksumType64\s*=\s*)('.*')" = "`${1}'$($Latest.ChecksumType64)'"
     }
 
@@ -43,18 +34,10 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-  $re   = 'octave-.*-.*w(64|32)\.7z$'
-  $urls = $download_page.links | where-object href -match $re | select-object -First 2 -expand href | foreach-object{ New-Object uri([uri]$releases, $_) }
+  $re   = 'octave-.*-.*w64\.7z$'
+  $url64 = $download_page.links | where-object href -match $re | select-object -First 1 -expand href | foreach-object{ New-Object uri([uri]$releases, $_) }
 
-  $url32 = $urls -match "w32" | select-object -first 1
-  $url64 = $urls -match "w64" | select-object -first 1
-
-  $version32 = $url32 -split '[-]' | select-object -Last 1 -Skip 1
   $version64 = $url64 -split '[-]' | select-object -Last 1 -Skip 1
-
-  if ($version32 -ne $version64) {
-    throw "32bit and 64bit versions do not match. Please Investigate."
-  }
 
   $releases_url  = "https://www.gnu.org/software/octave/news.html"
   $releases_page = Invoke-WebRequest -Uri $releases_url -UseBasicParsing
@@ -62,11 +45,11 @@ function global:au_GetLatest {
   $releaseNotes  = $releases_page.links | where-object href -match $re | select-object -First 1 -expand href | foreach-object { New-Object uri([uri]$releases_url, $_) }
 
   return @{
-    Version      = $version32.Replace('_', '.')
-    URL32        = $url32
+    Version      = $version64.Replace('_', '.')
     URL64        = $url64
     ReleaseNotes = $releaseNotes
     UpdateYear   = (Get-Date).ToString('yyyy')
+    ChecksumType64 = 'sha256'
   }
 }
 


### PR DESCRIPTION
## Description

As per https://octave.org/download, there are no longer official 32 bit binaries for windows as of v8.4.0. This PR removes the 32 bit support from the package so it can be updated.

## Motivation and Context

Fixes #2406

## How Has this Been Tested?

Update script ran on Windows 10, package tested in Chocolatey test env.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

