### PR TITLE
(multiple) Remove empty copyright elements

### DIFF
--- a/automatic/aptana-studio/aptana-studio.nuspec
+++ b/automatic/aptana-studio/aptana-studio.nuspec
@@ -55,7 +55,6 @@ This package installs the standalone version of Aptana Studio.
 ]]></description>
     <summary>Aptana Studio is an open source integrated development environment (IDE) for building Ajax web applications.</summary>
     <releaseNotes>https://github.com/aptana/studio3/wiki/Release-Notes</releaseNotes>
-    <copyright />
     <tags>aptana ide ajax web admin foss cross-platform</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/aptana-studio</packageSourceUrl>
     <dependencies>

--- a/automatic/audacity/audacity.nuspec
+++ b/automatic/audacity/audacity.nuspec
@@ -26,7 +26,6 @@
 ]]></description>
     <projectUrl>https://audacityteam.org/</projectUrl>
     <tags>audacity admin audio dsp foss cross-platform</tags>
-    <copyright></copyright>
     <licenseUrl>https://audacityteam.org/about/license#license</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/audacity.svg</iconUrl>

--- a/automatic/ccleaner/ccleaner.nuspec
+++ b/automatic/ccleaner/ccleaner.nuspec
@@ -22,7 +22,6 @@ It protects your privacy online and makes your computer faster and more secure.
 ]]></description>
     <projectUrl>https://www.piriform.com/ccleaner</projectUrl>
     <tags>ccleaner system cleanup freeware trial registry admin</tags>
-    <copyright></copyright>
     <licenseUrl>https://www.piriform.com/legal/software-license/ccleaner</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@182294b9b95166915fdc2265a90ef37c6b24efd9/icons/ccleaner.png</iconUrl>

--- a/automatic/codeblocks/codeblocks.nuspec
+++ b/automatic/codeblocks/codeblocks.nuspec
@@ -81,7 +81,6 @@ This package downloads the installer with the included GCC compiler.
 ]]></description>
     <summary>Code::Blocks is a free C++ IDE.</summary>
     <releaseNotes>https://www.codeblocks.org/changelogs/20.03</releaseNotes>
-    <copyright />
     <tags>codeblocks C++ IDE admin foss cross-platform</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/codeblocks</packageSourceUrl>
     <dependencies>

--- a/automatic/diskdefragtouch/diskdefragtouch.nuspec
+++ b/automatic/diskdefragtouch/diskdefragtouch.nuspec
@@ -16,7 +16,6 @@ Auslogics Disk Defrag Touch is a product of Auslogics, certified Microsoft® Gol
 ]]></description>
         <projectUrl>http://www.auslogics.com/en/software/disk-defrag-touch/</projectUrl>
         <tags>system freeware gaming admin disk performance defragment</tags>
-        <copyright></copyright>
         <licenseUrl>http://www.auslogics.com/en/legal/</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/136ef0bb871e04da4d9e0e0da37902930c80c2b4/icons/diskdefragtouch.png</iconUrl>

--- a/automatic/ext2fsd/ext2fsd.nuspec
+++ b/automatic/ext2fsd/ext2fsd.nuspec
@@ -37,7 +37,6 @@ Open source ext3/4 file system driver for Windows
     <summary>Open source ext3/4 file system driver for Windows</summary>
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/8a5d2740db65d1750e4312294f4163e348cd5a45/icons/ext2fsd.jpg</iconUrl>
     <releaseNotes>http://www.ext2fsd.com/?cat=3</releaseNotes>
-    <copyright />
     <language>en-US</language>
     <tags>ext3 ext4 file-system foss linux driver admin</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/ext2fsd</packageSourceUrl>

--- a/automatic/ffmpeg-full/ffmpeg-full.nuspec
+++ b/automatic/ffmpeg-full/ffmpeg-full.nuspec
@@ -28,7 +28,6 @@ Security is a high priority and code review is always done with security in mind
 ]]></description>
     <summary>FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec – the leading audio/video codec library.</summary>
     <releaseNotes>https://ffmpeg.org/index.html#news</releaseNotes>
-    <copyright />
     <language>en-US</language>
     <tags>ffmpeg libavcodec foss cli audio video convert cross-platform audio video media full</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/ffmpeg-full</packageSourceUrl>

--- a/automatic/ffmpeg/ffmpeg.nuspec
+++ b/automatic/ffmpeg/ffmpeg.nuspec
@@ -29,7 +29,6 @@ Security is a high priority and code review is always done with security in mind
 ]]></description>
     <summary>FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video. It includes libavcodec – the leading audio/video codec library.</summary>
     <releaseNotes>https://ffmpeg.org/index.html#news</releaseNotes>
-    <copyright />
     <language>en-US</language>
     <tags>ffmpeg libavcodec foss cli audio video convert cross-platform audio video media</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/ffmpeg</packageSourceUrl>

--- a/automatic/flightgear/flightgear.nuspec
+++ b/automatic/flightgear/flightgear.nuspec
@@ -36,7 +36,6 @@ FlightGear is an open-source flight simulator.  It supports a variety of popular
 and is developed by skilled volunteers from around the world.
     </summary>
     <releaseNotes>http://wiki.flightgear.org/Changelog_2020.3</releaseNotes>
-    <copyright />
     <tags>flightgear flight simulator game admin foss cross-platform</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/flightgear</packageSourceUrl>
     <dependencies>

--- a/automatic/freeciv/freeciv.nuspec
+++ b/automatic/freeciv/freeciv.nuspec
@@ -24,7 +24,6 @@ You can play online against other players (multiplayer) or play by yourself agai
 ]]></description>
     <summary>Freeciv is a Free and Open Source empire-building strategy game inspired by the history of human civilization.</summary>
     <releaseNotes>https://www.freeciv.org/wiki/NEWS-3.0.9</releaseNotes>
-    <copyright />
     <tags>freeciv game strategy civilization admin</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/freeciv</packageSourceUrl>
   </metadata>

--- a/automatic/lightworks/lightworks.nuspec
+++ b/automatic/lightworks/lightworks.nuspec
@@ -32,7 +32,6 @@ For a feature comparison, see [www.lwks.com](https://www.lwks.com/index.php?opti
         <projectUrl>http://www.lwks.com/</projectUrl>
         <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/lightworks</packageSourceUrl>
         <tags>NLE video editor lightworks freeware multimedia FOSS cross-platform</tags>
-        <copyright></copyright>
         <licenseUrl>https://en.wikipedia.org/wiki/Freemium</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@11eb42db9030a5a8d735fd56e2ad8bf62d365cff/icons/lightworks.png</iconUrl>

--- a/automatic/mixxx/mixxx.nuspec
+++ b/automatic/mixxx/mixxx.nuspec
@@ -44,7 +44,6 @@
 ]]></description>
     <summary>Cross platform and open Source DJ software</summary>
     <releaseNotes>http://mixxxblog.blogspot.it/</releaseNotes>
-    <copyright />
     <tags>DJ audio mixing party mp3 media cross-platform foss admin</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/mixxx</packageSourceUrl>
     <projectSourceUrl>https://github.com/mixxxdj/mixxx</projectSourceUrl>

--- a/automatic/pandafreeantivirus/pandafreeantivirus.nuspec
+++ b/automatic/pandafreeantivirus/pandafreeantivirus.nuspec
@@ -20,7 +20,6 @@ Panda Free Antivirus scored an impressive 99.9 percent in real-world protection 
     <projectUrl>http://www.pandasecurity.com/</projectUrl>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
     <tags>Antivirus Security Protection NotSilent AutoIt</tags>
-    <copyright></copyright>
     <licenseUrl>http://softwareula.wordpress.com/2010/07/20/panda-cloud-antivirus/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://i.imgur.com/McibFJt.jpg</iconUrl>

--- a/automatic/reshack/reshack.nuspec
+++ b/automatic/reshack/reshack.nuspec
@@ -22,7 +22,6 @@
 ]]></description>
         <projectUrl>http://www.angusj.com/resourcehacker/</projectUrl>
         <tags>freeware hacking resource executables admin</tags>
-        <copyright></copyright>
         <licenseUrl>http://www.angusj.com/resourcehacker/</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@da1a06bf2e600442203ca66680b1d1539002b813/icons/reshack.png</iconUrl>

--- a/automatic/supertuxkart/supertuxkart.nuspec
+++ b/automatic/supertuxkart/supertuxkart.nuspec
@@ -25,7 +25,6 @@ You can do a single race against other karts, compete in one of several Grand Pr
 ]]></description>
     <summary>Open Source 3D kart racing game</summary>
     <releaseNotes />
-    <copyright />
     <tags>supertuxkart foss cross-platform racing game admin</tags>
     <dependencies>
       <dependency id="vcredist2015" version="14.0.24215.20170201" />

--- a/automatic/tixati.portable/tixati.portable.nuspec
+++ b/automatic/tixati.portable/tixati.portable.nuspec
@@ -34,7 +34,6 @@ __Tixati__ is one of the most advanced and flexible BitTorrent clients available
 ]]></description>
         <projectUrl>http://www.tixati.com/</projectUrl>
         <tags>internet network download torrent p2p share admin</tags>
-        <copyright></copyright>
         <licenseUrl>http://www.tixati.com/tixati_eula.txt</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@bee4bc391df114723011dbd5b8a8af2a17c6bf2e/icons/tixati.png</iconUrl>

--- a/automatic/tixati/tixati.nuspec
+++ b/automatic/tixati/tixati.nuspec
@@ -36,7 +36,6 @@ __Tixati__ is one of the most advanced and flexible BitTorrent clients available
 ]]></description>
         <projectUrl>http://www.tixati.com/</projectUrl>
         <tags>internet network download torrent p2p share freeware bittorrent notsilent</tags>
-        <copyright></copyright>
         <licenseUrl>http://www.tixati.com/tixati_eula.txt</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@bee4bc391df114723011dbd5b8a8af2a17c6bf2e/icons/tixati.png</iconUrl>

--- a/automatic/tv-browser/tv-browser.nuspec
+++ b/automatic/tv-browser/tv-browser.nuspec
@@ -42,7 +42,6 @@
 ]]></description>
     <summary>TV-Browser is a digital TV guide.</summary>
     <releaseNotes />
-    <copyright />
     <tags>foss cross-platform tv-browser tv television guide admin</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/tv-browser</packageSourceUrl>
     <dependencies>

--- a/deprecated/packages/ffdshow-x86/ffdshow-x86_32.nuspec
+++ b/deprecated/packages/ffdshow-x86/ffdshow-x86_32.nuspec
@@ -24,7 +24,6 @@ The ffdshow tryouts project is a fork of the original ffdshow project. This fork
 
 This package always installs the 32-bit version, even on a 64-bit OS. If you want to install the 64-bit version on 64-bit systems, install [ffdshow](./ffdshow).</description>
     <summary>The all-in-one codec solution</summary>
-    <copyright />
     <tags>ffdshow DirectShow codec video audio subtitles</tags>
     <dependencies>
       <dependency id="ffdshow" version="1.3.4531.20140718" />

--- a/deprecated/packages/h264tscutter/h264tscutter.nuspec
+++ b/deprecated/packages/h264tscutter/h264tscutter.nuspec
@@ -20,7 +20,6 @@ Download link on official site does not work. This package uses this one instead
     </description>
     <summary>Cut HDTV-Transportstreams</summary>
     <releaseNotes />
-    <copyright />
     <tags>h264 ts cutter cut</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
   </metadata>

--- a/deprecated/packages/lightalloy/lightalloy.nuspec
+++ b/deprecated/packages/lightalloy/lightalloy.nuspec
@@ -17,7 +17,6 @@ Deprecated due to no interest.
     </description>
     <projectUrl>http://www.light-alloy.ru/</projectUrl>
     <tags>Media Video Player admin</tags>
-    <copyright></copyright>
     <licenseUrl>http://www.light-alloy.ru/help/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/e4a49519947c3cff55c17a0b08266c56b0613e64/icons/lightalloy.png</iconUrl>

--- a/deprecated/packages/otterbrowser/otterbrowser.nuspec
+++ b/deprecated/packages/otterbrowser/otterbrowser.nuspec
@@ -16,7 +16,6 @@
 
 Probably beta release (automatic push). Package version less than v1, treat as stable.</description>
     <summary>Project aiming to recreate classic Opera (12.x) UI using Qt5.</summary>
-    <copyright />
     <tags>browser opera qt</tags>
     <dependencies>
       <dependency id="otter-browser" version="0.9.92.20171114" />

--- a/deprecated/packages/truecrypt-langfiles/truecrypt-langfiles.nuspec
+++ b/deprecated/packages/truecrypt-langfiles/truecrypt-langfiles.nuspec
@@ -21,7 +21,6 @@ This package contains all available language files for TrueCrypt, the free open-
     </description>
     <summary>Language files for TrueCrypt, the free open-source disk encryption software</summary>
     <releaseNotes />
-    <copyright />
     <tags>truecrypt language localization i18n</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
   </metadata>

--- a/manual/becyicongrabber/becyicongrabber.nuspec
+++ b/manual/becyicongrabber/becyicongrabber.nuspec
@@ -16,7 +16,6 @@ BeCyIconGrabber is a small utility to view icons and cursors of any sizes that a
     </description>
     <summary>BeCyIconGrabber – extraction of icons/cursors</summary>
     <releaseNotes />
-    <copyright />
     <tags>becyicongrabber extract icons cursors</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
   </metadata>

--- a/manual/clover/clover.nuspec
+++ b/manual/clover/clover.nuspec
@@ -17,7 +17,6 @@ After Clover is installed, you will be able to open multiple folders within the 
     </description>
     <projectUrl>http://ejie.me/</projectUrl>
     <tags>admin freeware windows-explorer file-system file-manager tab tabs </tags>
-    <copyright></copyright>
     <licenseUrl>http://www.scribd.com/doc/164355290/License</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/cf2b66066fc04a6517bbd7bfef76fe2653b5ff7c/icons/Clover.png</iconUrl>

--- a/manual/ffdshow/ffdshow.nuspec
+++ b/manual/ffdshow/ffdshow.nuspec
@@ -19,7 +19,6 @@ ffdshow + X = ffdshow tryouts
 The ffdshow tryouts project is a fork of the original ffdshow project. This fork was created by a group of members at Doom9.org. The last modification to the source code of the original project was done back in May 2006. The ffdshow tryouts project has continued where the original project stopped: Numerous bugs have been fixed, lots of code (that ffdshow borrows from the FFmpeg and Libav projects) has been updated, new features have been added as well as support for new formats.
     </description>
     <summary>The all-in-one codec solution</summary>
-    <copyright />
     <tags>ffdshow DirectShow codec video audio subtitles admin</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
   </metadata>

--- a/manual/keepass-classic-langfiles/keepass-classic-langfiles.nuspec
+++ b/manual/keepass-classic-langfiles/keepass-classic-langfiles.nuspec
@@ -18,7 +18,6 @@ This package extracts a ZIP with all language files into the KeePass program fol
     </description>
     <summary>Language files for KeePass Classic (1.x.)</summary>
     <releaseNotes />
-    <copyright />
     <tags>keepass password safe encryption language-file admin</tags>
     <dependencies>
       <dependency id="keepass-classic" />

--- a/manual/keepass-langfiles/keepass-langfiles.nuspec
+++ b/manual/keepass-langfiles/keepass-langfiles.nuspec
@@ -22,7 +22,6 @@ This package extracts a ZIP with all language files into the KeePass program fol
     </description>
     <summary>Language files for KeePass 2.x.</summary>
     <releaseNotes></releaseNotes>
-    <copyright />
     <tags>keepass password safe encryption language-file admin</tags>
     <dependencies>
       <dependency id="keepass" version="2.41" />

--- a/manual/libreoffice-help/libreoffice-help.nuspec
+++ b/manual/libreoffice-help/libreoffice-help.nuspec
@@ -25,7 +25,6 @@ It is also possible to install multiple Help Packs. To achieve that, install the
     </description>
     <summary>Help Pack for LibreOffice</summary>
     <releaseNotes />
-    <copyright />
     <tags>libreoffice office help admin</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages</packageSourceUrl>
   </metadata>

--- a/manual/pcwrunas/pcwrunas.nuspec
+++ b/manual/pcwrunas/pcwrunas.nuspec
@@ -46,7 +46,6 @@ PcwRunAs4 /u hugo /p secret /app notepad.exe /arg &quot;C:\NewFile.txt&quot;
     </description>
     <summary>Run files as other freeware user</summary>
     <releaseNotes />
-    <copyright />
     <language>de-DE</language>
     <tags>pcwrunas runas cli admin</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/manual/pcwrunas</packageSourceUrl>

--- a/manual/qttabbar-langfiles/qttabbar-langfiles.nuspec
+++ b/manual/qttabbar-langfiles/qttabbar-langfiles.nuspec
@@ -17,7 +17,6 @@ QTTabBar is extension for Windows Explorer that brings tabbed browsing to Micros
     </description>
     <summary>Language files for QTTabBar</summary>
     <releaseNotes />
-    <copyright />
     <tags>productivity windows explorer i18n</tags>
     <dependencies>
       <dependency id="QTTabBar" />

--- a/manual/tsremux/tsremux.nuspec
+++ b/manual/tsremux/tsremux.nuspec
@@ -15,7 +15,6 @@ TsRemux is a transport Stream Re-muxer with blu-ray/Sat/OTA and now MPG/VOB/EVOB
     </description>
     <summary>TsRemux is a transport Stream Re-muxer.</summary>
     <releaseNotes />
-    <copyright />
     <tags>tsremux ts transport-stream remux admin</tags>
     <dependencies>
       <dependency id="wget" />

--- a/unlisted/fiddler4/fiddler4.nuspec
+++ b/unlisted/fiddler4/fiddler4.nuspec
@@ -29,7 +29,6 @@ Fiddler is freeware and can debug traffic from virtually any application, includ
     </description>
     <projectUrl>http://www.telerik.com/fiddler</projectUrl>
     <tags>fiddler freeware fiddler4 web debugging cross-platform proxy admin</tags>
-    <copyright></copyright>
     <licenseUrl>http://www.telerik.com/purchase/license-agreement/fiddler</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/e7940eeec0005981b565d98660c6cb9be1865881/icons/fiddler.svg</iconUrl>


### PR DESCRIPTION
## Description

Removes empty copyright elements from nuspecs

## Motivation and Context

Fixes #2418 

## How Has this Been Tested?

Ran `choco pack` on the changed packages and ensured that the `CPMR0001` rule was not triggered.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).

