### PR TITLE
(tixati) Fix for app running on update (#2182)

### DIFF
--- a/automatic/tixati/tools/chocolateyInstall.ps1
+++ b/automatic/tixati/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-foreach ($process in (Get-Process "$env:ChocolateyPackageName*" -ErrorAction SilentlyContinue)) {
-   Stop-Process -Name $process.ProcessName -Force
+if (Get-Process "Tixati*" -ErrorAction SilentlyContinue) {
+   Throw "Tixati is running!  To prevent data loss, please fully quit Tixati before attempting to upgrade it."
 }
 
 $toolsDir   = Split-Path -parent $MyInvocation.MyCommand.Definition

--- a/automatic/tixati/tools/chocolateyInstall.ps1
+++ b/automatic/tixati/tools/chocolateyInstall.ps1
@@ -1,5 +1,9 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+foreach ($process in (Get-Process "$env:ChocolateyPackageName*" -ErrorAction SilentlyContinue)) {
+   Stop-Process -Name $process.ProcessName -Force
+}
+
 $toolsDir   = Split-Path -parent $MyInvocation.MyCommand.Definition
 $fileName = 'tixati-3.19-1.install.exe'
 $dlDir = "$Env:TEMP\chocolatey\$($Env:ChocolateyPackageName)\$($Env:ChocolateyPackageVersion)"

--- a/automatic/tixati/tools/chocolateyUninstall.ps1
+++ b/automatic/tixati/tools/chocolateyUninstall.ps1
@@ -1,5 +1,9 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+foreach ($process in (Get-Process "$env:ChocolateyPackageName*" -ErrorAction SilentlyContinue)) {
+   Stop-Process -Name $process.ProcessName -Force
+}
+
 $packageName     = 'tixati'
 $installLocation = Get-AppInstallLocation $packageName
 $uninstaller     = "$installLocation\uninstall.exe"

--- a/automatic/tixati/tools/chocolateyUninstall.ps1
+++ b/automatic/tixati/tools/chocolateyUninstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-foreach ($process in (Get-Process "$env:ChocolateyPackageName*" -ErrorAction SilentlyContinue)) {
-   Stop-Process -Name $process.ProcessName -Force
+if (Get-Process "Tixati*" -ErrorAction SilentlyContinue) {
+   Throw "Tixati is running!  To prevent data loss, please fully quit Tixati before attempting to uninstall it."
 }
 
 $packageName     = 'tixati'


### PR DESCRIPTION
## Description
This should fix [issue #2182](https://github.com/chocolatey-community/chocolatey-packages/issues/2182) by ~~first closing~~ *notifying the user and quitting if* any Tixati application processes running on install or uninstall.

## Motivation and Context
The Tixati package is significantly behind because issue #2812 has held it up (and I'm tired of waiting).  The choice was either to fail upgrades (or installs) with a message to close/quit if the Tixati application was running or to unilaterally close the process and perform the upgrade.  I chose the ~~latter~~ *former, after feedback and consideration*.

## How Has this Been Tested?
I started Tixati and then upgraded it via `choco upgrade tixati -y`.  Note:  this PR has not been run through the official Test Environment, but:

1. The current (pre-PR) package code *has* been tested/approved.
2. The added code (`Get-Process` and `Stop-Process`) are compatible back to PowerShell v2 (at least).
3. The problem this fixes can't be tested in an automated way because the application must be running.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
