### PR TITLE
(vim) Fix for issue #2390

### DIFF
--- a/automatic/vim/tools/chocolateyinstall.ps1
+++ b/automatic/vim/tools/chocolateyinstall.ps1
@@ -20,7 +20,7 @@ $installArgs = @{
 
 '$installDir', ($installDir | Out-String), '$packageArgs', ($packageArgs | Out-String), '$installArgs', ($installArgs | Out-String) | ForEach-Object { Write-Debug $_ }
 
-Install-ChocolateyZipPackage @packageArgs | Write-Debug
+Get-ChocolateyUnzip @packageArgs | Write-Debug
 Start-ChocolateyProcessAsAdmin @installArgs | Write-Debug
 Set-Content -Path "$toolsDir\installDir" -Value $installDir
 Create-SymbolicLink


### PR DESCRIPTION
Use Get-ChocolateyUnzip instead of Install-ChocolateyZipPackage to install Vim.

## Description

As mentioned in #2390, I replaced Install-ChocolateyZipPackage with Get-ChocolateyUnzip in the installation script.

## Motivation and Context

Fixes [issue #2390](https://github.com/chocolatey-community/chocolatey-packages/issues/2390), where auto-validation fails because of a missing checksum required with Install-ChocolateyZipPackage

## How Has this Been Tested?

After applying the fix, I downloaded the Vim zip files and created a package with `choco pack`.
I installed this on a VM, and it installed Vim without errors.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
