### PR TITLE
(multiple) Remove unsupported reference on Chocolatey CLI

### DIFF
--- a/automatic/apache-httpd/apache-httpd.nuspec
+++ b/automatic/apache-httpd/apache-httpd.nuspec
@@ -41,7 +41,6 @@ Example: `choco install apache-httpd --params '"/installLocation:C:\HTTPD /port:
 ]]></description>
     <tags>apache httpd webserver admin</tags>
     <dependencies>
-      <dependency id="chocolatey" version="1.2.0" />
       <dependency id="vcredist140" version="14.32.31332" />
    </dependencies>
   </metadata>

--- a/automatic/blender/blender.nuspec
+++ b/automatic/blender/blender.nuspec
@@ -54,8 +54,6 @@ Blender is a free and open-source professional-grade 3D computer graphics and vi
     <dependencies>
       <dependency id="vcredist2008" version="9.0.30729.6161" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <!--We could set chocolatey to version 0.10.4, but that version was broken so we use 0.10.5-->
-      <dependency id="chocolatey" version="0.10.5" />
     </dependencies>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/blender</packageSourceUrl>
   </metadata>

--- a/automatic/chromium/chromium.nuspec
+++ b/automatic/chromium/chromium.nuspec
@@ -27,10 +27,6 @@
     <licenseUrl>https://chromium.googlesource.com/chromium/src.git/+/refs/heads/master/LICENSE</licenseUrl>
     <tags>chromium admin google cross-platform foss chrome browser</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/chromium</packageSourceUrl>
-    <dependencies>
-      <dependency id="chocolatey" version="0.10.5" />
-    </dependencies>
-
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/cmake.install/cmake.install.nuspec
+++ b/automatic/cmake.install/cmake.install.nuspec
@@ -43,10 +43,6 @@ For example: `choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'`
     <releaseNotes>#### Program
 * [News](https://blog.kitware.com/tag/CMake/)
 * [Changelog](https://www.cmake.org/download/#latest)</releaseNotes>
-    <dependencies>
-      <!--We could set chocolatey to version 0.10.4, but that version was broken so we use 0.10.5-->
-      <dependency id="chocolatey" version="0.10.5" />
-    </dependencies>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/cmake.portable/cmake.portable.nuspec
+++ b/automatic/cmake.portable/cmake.portable.nuspec
@@ -27,10 +27,6 @@
     <releaseNotes>#### Program
 * [News](https://blog.kitware.com/tag/CMake/)
 * [Changelog](https://www.cmake.org/download/#latest)</releaseNotes>
-    <dependencies>
-      <!--We could set chocolatey to version 0.10.4, but that version was broken so we use 0.10.5-->
-      <dependency id="chocolatey" version="0.10.5" />
-    </dependencies>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/codelite/codelite.nuspec
+++ b/automatic/codelite/codelite.nuspec
@@ -32,8 +32,6 @@ programming languages which runs best on all major Plattforms (OSC, Windows and 
     <releaseNotes>https://github.com/eranif/codelite/releases/tag/17.0.0</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <!--We could set chocolatey to version 0.10.4, but that version was broken so we use 0.10.5-->
-      <dependency id="chocolatey" version="0.10.5" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/freevideoeditor/freevideoeditor.nuspec
+++ b/automatic/freevideoeditor/freevideoeditor.nuspec
@@ -50,10 +50,6 @@ Hardware acceleration, multi-color Chroma Key, adjustable parameters settings an
 ![screenshot](https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/67298954b9fd1ba4826a4cdedf542266aa64f1fd/automatic/freevideoeditor/screenshot.jpg)
 ]]></description>
     <releaseNotes>http://www.videosoftdev.com/free-video-editor#accordion10</releaseNotes>
-    <dependencies>
-      <!--We could set chocolatey to version 0.10.4, but that version was broken so we use 0.10.5-->
-      <dependency id="chocolatey" version="0.10.5" />
-    </dependencies>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/git.portable/git.portable.nuspec
+++ b/automatic/git.portable/git.portable.nuspec
@@ -31,9 +31,6 @@ Git for Windows focuses on offering a lightweight, native set of tools that brin
     <licenseUrl>http://www.gnu.org/licenses/old-licenses/gpl-2.0.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@10a8d98b2f320b565fa5349a4352e79666db71ff/icons/git.svg</iconUrl>
-    <dependencies>
-      <dependency id="chocolatey" version="0.9.10" />
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/jitsi/jitsi.nuspec
+++ b/automatic/jitsi/jitsi.nuspec
@@ -25,10 +25,6 @@ Jitsi (formerly SIP Communicator) is a free and open source multiplatform voice 
     <copyright>2004–2012 Emil Ivov</copyright>
     <tags>jitsi voip audio video messaging desktop-sharing video-call chat conferencing file-transfer softphone admin</tags>
     <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/automatic/jitsi</packageSourceUrl>
-    <dependencies>
-      <!--We could set chocolatey to version 0.10.4, but that version was broken so we use 0.10.5-->
-      <dependency id="chocolatey" version="0.10.5" />
-    </dependencies>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/jubler/jubler.nuspec
+++ b/automatic/jubler/jubler.nuspec
@@ -55,8 +55,6 @@ Jubler is a tool to edit text-based subtitles. It can be used as an authoring so
       <dependency id="javaruntime" version="8.0" />
       <dependency id="smplayer" version="16.8.0" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <!--We could set chocolatey to version 0.10.4, but that version was broken so we use 0.10.5-->
-      <dependency id="chocolatey" version="0.10.5" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/mkvtoolnix/mkvtoolnix.nuspec
+++ b/automatic/mkvtoolnix/mkvtoolnix.nuspec
@@ -25,7 +25,6 @@ With these tools one can get information about (mkvinfo) Matroska files, extract
     <docsUrl>https://mkvtoolnix.download/docs.html</docsUrl>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="chocolatey" version="0.10.5" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/msys2/msys2.nuspec
+++ b/automatic/msys2/msys2.nuspec
@@ -53,7 +53,6 @@ Example: `choco install msys2 --params "/NoUpdate /InstallDir:C:\your\install\pa
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/msys2</packageSourceUrl>
     <docsUrl>https://github.com/msys2/msys2/wiki</docsUrl>
     <dependencies>
-      <dependency id="chocolatey" version="0.10.8" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
     </dependencies>
   </metadata>

--- a/automatic/notepadplusplus.commandline/notepadplusplus.commandline.nuspec
+++ b/automatic/notepadplusplus.commandline/notepadplusplus.commandline.nuspec
@@ -47,10 +47,6 @@ Based on the powerful editing component Scintilla, Notepad++ is written in C++ a
     <projectSourceUrl>https://github.com/notepad-plus-plus/notepad-plus-plus</projectSourceUrl>
     <mailingListUrl>https://notepad-plus-plus.org/community/</mailingListUrl>
     <bugTrackerUrl>https://github.com/notepad-plus-plus/notepad-plus-plus/issues</bugTrackerUrl>
-    <dependencies>
-      <!--We could set chocolatey to version 0.10.4, but that version was broken so we use 0.10.5-->
-      <dependency id="chocolatey" version="0.10.5" />
-    </dependencies>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/openssl.light/openssl.light.nuspec
+++ b/automatic/openssl.light/openssl.light.nuspec
@@ -26,7 +26,6 @@ The Win32 OpenSSL Installation Project is dedicated to providing a simple instal
 Example: `choco install openssl.light --params "/InstallDir:C:\your\install\path"`
 ]]></description>
     <dependencies>
-      <dependency id="chocolatey" version="0.10.5" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
       <dependency id="vcredist140" version="14.12.25810" />
     </dependencies>

--- a/automatic/php/php.nuspec
+++ b/automatic/php/php.nuspec
@@ -37,7 +37,6 @@ For example: `choco install php --package-parameters='"/ThreadSafe ""/InstallDir
     <dependencies>
       <dependency id="vcredist140" version="14.28.29325.2" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="chocolatey" version="0.10.0" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/pspp/pspp.nuspec
+++ b/automatic/pspp/pspp.nuspec
@@ -46,8 +46,6 @@ PSPP can perform descriptive statistics, T-tests, anova, linear and logistic reg
 ]]></description>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <!--We could set chocolatey to version 0.10.4, but that version was broken so we use 0.10.5-->
-      <dependency id="chocolatey" version="0.10.5" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/rapidee/RapidEE.nuspec
+++ b/automatic/rapidee/RapidEE.nuspec
@@ -37,9 +37,6 @@
 Example: `choco install rapidee --params "/NoShortcut"`
 ]]></description>
     <releaseNotes>http://www.rapidee.com/en/history</releaseNotes>
-    <dependencies>
-      <dependency id="chocolatey" version="0.10.8" />
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/automatic/videoder/videoder.nuspec
+++ b/automatic/videoder/videoder.nuspec
@@ -29,7 +29,6 @@ and want to preserve their mobile data for more precious moments in te future.
     <docsUrl>https://www.videoder.com</docsUrl>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="chocolatey" version="0.10.5" />
     </dependencies>
   </metadata>
   <files>

--- a/manual/cdburnerxp/cdburnerxp.nuspec
+++ b/manual/cdburnerxp/cdburnerxp.nuspec
@@ -72,8 +72,6 @@ CDBurnerXP is a free application to burn CDs and DVDs, including Blu-Ray and HD-
     <docsUrl>http://maxima.sourceforge.net/documentation.html</docsUrl>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <!--We could set chocolatey to version 0.10.4, but that version was broken so we use 0.10.5-->
-      <dependency id="chocolatey" version="0.10.5" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
## Description

This updates the references for packages that requires
a specific version of Chocolatey CLI, to remove those
references that required a version that we no longer
support.


## Motivation and Context

We do not want to keep referencing Chocolatey CLI when the required version is one that we no longer support. At the time, the earliest version we support is 1.3.0.

## How Has this Been Tested?

No functional changes has been made, and as such has not been tested through the Chocolatey Test Environment.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

Marked as a breaking change, as it techhnically is. However, it is a breaking change introduced by cleaning up packages.

## Checklist:

- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).
