### PR TITLE
(7zip.install) Fix uninstaller key lookup to ignore standalone 7zip zstandard

### DIFF
--- a/automatic/7zip.install/tools/chocolateyUninstall.ps1
+++ b/automatic/7zip.install/tools/chocolateyUninstall.ps1
@@ -3,7 +3,7 @@
 $packageName = '7zip.install'
 
 $uninstalled = $false
-[array]$key = Get-UninstallRegistryKey -SoftwareName '7-zip*'
+[array]$key = Get-UninstallRegistryKey -SoftwareName '7-zip*' | Where-Object { $_.DisplayName -notlike '7-zip zs*' }
 
 if ($key.Count -eq 1) {
   $key | ForEach-Object {


### PR DESCRIPTION
Change uninstaller to ignore entries in registry from standalone 7-zip zstandard.

The standalone 7zip zstandard program (such as from winget mcmilk.7zip-zstd package) creates an entry in the registry beginning with "7-Zip ZS".

Because the choco package simply checks for entries beginning with "7-zip", this causes problems.

If both programs are installed, choco fails to uninstall either, because it detects the two entries.

And if the user runs the 7-zip uninstaller manually, subsequently running 'choco uninstall 7-zip.install' detects the "7-Zip ZS" key and uninstalls it eroneously.

<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).