### PR TITLE
(tortoisesvn) Fix finding download URL from SourceForge

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,7 +61,6 @@ install:
       'chocolatey' = $chocoVersion
       'wormies-au-helpers' = '0.4.1'
       'chocolatey-core.extension' = '1.4.0'
-      'autohotkey.install' = '1.1.35.00'
       'chocolatey-community-validation.extension' = '0.1.0'
     }.GetEnumerator() | % {
       if (!(Test-Path "${env:nupkg_cache_path}\$($_.Key).$($_.Value).nupkg")) { rm "${env:nupkg_cache_path}\$($_.Key).*.nupkg" ; Invoke-WebRequest "https://chocolatey.org/api/v2/package/$($_.Key)/$($_.Value)" -OutFile "${env:nupkg_cache_path}\$($_.Key).$($_.Value).nupkg" }

--- a/automatic/tortoisesvn/update.ps1
+++ b/automatic/tortoisesvn/update.ps1
@@ -21,15 +21,11 @@ function global:au_SearchReplace {
      }
 }
 
-function Get-ActualUrl([uri]$url) {
-  $download_page = Invoke-WebRequest -UseBasicParsing -Uri $url
-
-  $result = $download_page.links | Where-Object "data-release-url" -ilike "*downloads.sourceforge.net/*TortoiseSVN-*.msi*" | Select-Object -First 1 -ExpandProperty "data-release-url"
-  if ($result.Contains("?")) {
-    $result = $result.Split("?")[0]
+function Get-ActualUrl([string]$url) {
+  if (!$url.EndsWith("/")) {
+    $url += "/"
   }
-
-  return $result
+  return $url + "download"
 }
 
 function global:au_GetLatest {
@@ -54,6 +50,7 @@ function global:au_GetLatest {
         URL32 = Get-ActualUrl $url32
         URL64 = Get-ActualUrl $url64
         Version = $version32
+        FileType = "msi"
     }
     return $result
 }

--- a/automatic/tortoisesvn/update.ps1
+++ b/automatic/tortoisesvn/update.ps1
@@ -25,6 +25,9 @@ function Get-ActualUrl([uri]$url) {
   $download_page = Invoke-WebRequest -UseBasicParsing -Uri $url
 
   $result = $download_page.links | Where-Object "data-release-url" -ilike "*downloads.sourceforge.net/*TortoiseSVN-*.msi*" | Select-Object -First 1 -ExpandProperty "data-release-url"
+  if ($result.Contains("?")) {
+    $result = $result.Split("?")[0]
+  }
 
   return $result
 }

--- a/automatic/tortoisesvn/update.ps1
+++ b/automatic/tortoisesvn/update.ps1
@@ -24,9 +24,9 @@ function global:au_SearchReplace {
 function Get-ActualUrl([uri]$url) {
   $download_page = Invoke-WebRequest -UseBasicParsing -Uri $url
 
-  $path = $download_page.links | ? href -match 'redir.*\.msi$' | select -first 1 -expand href
+  $result = $download_page.links | Where-Object "data-release-url" -ilike "*downloads.sourceforge.net/*TortoiseSVN-*.msi*" | Select-Object -First 1 -ExpandProperty "data-release-url"
 
-  return $url.Scheme + "://" + $url.Host + $path
+  return $result
 }
 
 function global:au_GetLatest {


### PR DESCRIPTION
The current attempt of finding the download URL on SourceForge for TortoiseSVN doesn't work anymore.
It now gets the URL by checking data-release-url for "downloads.sourceforge.net".

## How Has this Been Tested?
I tested it with VSCode. It returned downloadable URLs. They were both downloadable with Firefox and System.Net.WebClient (PowerShell).
I also ran Update-Package and it completed without errors.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).