### PR TITLE
(chromium) Only Internalizes x64 Binary

### DIFF
--- a/automatic/chromium/legal/VERIFICATION.txt
+++ b/automatic/chromium/legal/VERIFICATION.txt
@@ -7,7 +7,6 @@ location on <https://github.com/henrypp/chromium/releases/> (the listed mirrors 
 and can be verified by doing the following:
 
 1. Download the following:
-  32-Bit software: <https://storage.googleapis.com/chromium-browser-snapshots/Win/1270670/mini_installer.exe>
   64-Bit software: <https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1270673/mini_installer.exe>
 2. Get the checksum using one of the following methods:
   - Using powershell function 'Get-FileHash'
@@ -15,7 +14,6 @@ and can be verified by doing the following:
 3. The checksums should match the following:
 
   checksum type: sha256
-  checksum32: 0C6333FC96808ADB0F0E9BF8B04FCA31A9C616E2FFCA9CAC86BED10A428029BD
   checksum64: AB1CCFD1F8CB09F3AB1447495056D13D4F5BF3E7EBB3B5322A270F446C02EB8B
 
 The file 'LICENSE.txt' has been obtained from <https://chromium.googlesource.com/chromium/src.git/+/master/LICENSE>

--- a/automatic/chromium/tools/chocolateyInstall.ps1
+++ b/automatic/chromium/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop'
-$scriptDir=$toolsDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-. (Join-Path $scriptDir 'helper.ps1')
+$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+. (Join-Path $toolsDir 'helper.ps1')
 
 $version = "124.0.6350.0-snapshots"
 $hive = "hkcu"
@@ -15,17 +15,23 @@ if (Test-Path $Chromium) {
 
 $packageArgs = @{
   packageName   = 'chromium'
-  file          = "$toolsdir\chromium_x32.exe"
+  url           = 'https://chromium_x32.exe'
+  checksum      = ''
+  checksumType  = 'SHA256'
   file64        = "$toolsdir\chromium_x64.exe"
   fileType      = 'exe'
   silentArgs    = $silentArgs
   validExitCodes= @(0)
   softwareName  = 'Chromium'
 }
-if ( Get-CompareVersion -version $version -notation "-snapshots" -package "chromium" ) {
-Install-ChocolateyInstallPackage @packageArgs 
+if (Get-CompareVersion -version $version -notation "-snapshots" -package "chromium") {
+  if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) {
+    Install-ChocolateyPackage @packageArgs
+  } else {
+    Install-ChocolateyInstallPackage @packageArgs
+  }
 } else {
-Write-Host "Chromium $version is already installed."
+  Write-Host "Chromium $version is already installed."
 }
 # Detritus Package Cleanup
 $detritus = @("exe","tmp","ignore")

--- a/automatic/chromium/update.ps1
+++ b/automatic/chromium/update.ps1
@@ -1,4 +1,5 @@
-﻿
+Import-Module au
+
 Import-Module Chocolatey-AU
     $releases = 'https://chromium.woolyss.com/api/v5/?os=win<bit>&type=<type>&out=json'
     $ChecksumType = 'sha256'
@@ -6,69 +7,70 @@ Import-Module Chocolatey-AU
 function global:au_SearchReplace {
   @{
     ".\legal\verification.txt" = @{
-    "(?i)(\s*32\-Bit Software.*)\<.*\>"        = "`${1}<$($Latest.URL32)>"
-    "(?i)(\s*64\-Bit Software.*)\<.*\>"        = "`${1}<$($Latest.URL64)>"
-    "(?i)(^\s*checksum\s*type\:).*"            = "`${1} $($Latest.ChecksumType32)"
-    "(?i)(^\s*checksum32\:).*"                 = "`${1} $($Latest.Checksum32)"
-    "(?i)(^\s*checksum64\:).*"                 = "`${1} $($Latest.Checksum64)"
+      "(?i)(\s*64\-Bit Software.*)\<.*\>"        = "`${1}<$($Latest.URL64)>"
+      "(?i)(^\s*checksum\s*type\:).*"            = "`${1} $($Latest.ChecksumType32)"
+      "(?i)(^\s*checksum64\:).*"                 = "`${1} $($Latest.Checksum64)"
     }
     ".\tools\chocolateyInstall.ps1" = @{
-    '(^[$]version\s*=\s*)(".*")'               = "`$1""$($Latest.Version)"""
-	  "(?i)(^\s*file\s*=\s*`"[$]toolsdir\\).*"   = "`${1}$($Latest.FileName32)`""
-	  "(?i)(^\s*file64\s*=\s*`"[$]toolsdir\\).*" = "`${1}$($Latest.FileName64)`""
+      '(^[$]version\s*=\s*)(["''].*["''])'       = "`$1'$($Latest.Version)'"
+      "(?i)(^\s*url\s*=\s*').*"                  = "`${1}$($Latest.URL32)'"
+      "(?i)(^\s*checksumType\s*=\s*').*"         = "`${1}$($Latest.ChecksumType32)'"
+      "(?i)(^\s*checksum\s*=\s*').*"           = "`${1}$($Latest.Checksum32)'"
+      "(?i)(^\s*file64\s*=\s*`"[$]toolsdir\\).*" = "`${1}$($Latest.FileName64)`""
     }
     ".\chromium.nuspec" = @{
-    "(?i)(^\s*\<title\>).*(\<\/title\>)"       = "`${1}$($Latest.Title)`${2}"
+      "(?i)(^\s*\<title\>).*(\<\/title\>)"       = "`${1}$($Latest.Title)`${2}"
     }
   }
 }
 
 function global:au_BeforeUpdate {
     Get-RemoteFiles -Purge -FileNameBase "$($Latest.PackageName)"
+
+    # Removing the 32-bit software in order to reduce package size.
+    Remove-Item $PSScriptRoot\tools\chromium_x32.exe
 }
 
 function Get-Chromium {
-param(
-	[string]$releases,
-	[string]$Title,
+  param(
+    [string]$ReleasesBaseUrl = 'https://chromium.woolyss.com/api/v5/?os=win<bit>&type=<type>&out=json',
+
+    [Parameter(Mandatory)]
+    [string]$Title,
+
     [Parameter()]
     [ValidateNotNullOrEmpty()]
     [ValidateSet('dev-official','stable-sync','stable-nosync-arm')]
-    [string]$type = 'dev-official'
-)
- # Change the URI for the specific type and bit
-    $releases = $releases -replace('<type>', $type )
-    $releases_x32 = $releases -replace('<bit>','32')
-    $releases_x64 = $releases -replace('<bit>','64')
-    $download_page32 = Invoke-WebRequest -Uri $releases_x32
-    $download_page64 = Invoke-WebRequest -Uri $releases_x64
- # Convert Respose from Json
-    $chromium32 = $download_page32 | ConvertFrom-Json
-    $chromium64 = $download_page64 | ConvertFrom-Json
- # Get values from the hashtable
-    $url32 = $chromium32.chromium.windows.download
-    $url64 = $chromium64.chromium.windows.download
-    $version32 = $chromium32.chromium.windows.version
-    $version64 = $chromium64.chromium.windows.version
- # Compare versions default to 64bit version for any variance
-    if ($version32 -ne $version64) { $version = $version64 } else { $version = $version32 }
- # Build Version for Snapshots or Stable
-    $build = @{$true="-snapshots";$false=""}[ $type -eq 'dev-official' ]
-    
+    [string]$Type = 'dev-official'
+  )
+  # Change the URI for the specific type and bit and get the information
+  $chromium32 = Invoke-RestMethod -Uri ($ReleasesBaseUrl -replace '<type>', $type -replace '<bit>', '32') -UseBasicParsing
+  $chromium64 = Invoke-RestMethod -Uri ($ReleasesBaseUrl -replace '<type>', $type -replace '<bit>', '64') -UseBasicParsing
+
+  # Compare versions default to 64bit version for any variance
+  $version = if ($chromium32.chromium.windows.version -ne $chromium64.chromium.windows.version) {
+    $chromium64.chromium.windows.version
+  } else {
+    $chromium32.chromium.windows.version
+  }
+
+  # Update Version for Snapshots or Stable
+  $version += @{$true="-snapshots";$false=""}[ $Type -eq 'dev-official' ]
+
 	@{
 		Title = $Title
-		URL32 = $url32
-		URL64 = $url64
-		Version = "$version$build"
-		ChecksumType32 = $ChecksumType
-		ChecksumType64 = $ChecksumType
+		URL32 = $chromium32.chromium.windows.download
+		URL64 = $chromium64.chromium.windows.download
+		Version = $version
+		ChecksumType32 = $checksumType
+		ChecksumType64 = $checksumType
 	}
 }
 
 function global:au_GetLatest {
   $streams = [ordered] @{
-    stable = Get-Chromium -releases $releases -Title "Chromium" -type "stable-sync"
-    snapshots = Get-Chromium -releases $releases -Title "Chromium Snapshots" -type "dev-official"
+    stable = Get-Chromium -Title "Chromium" -Type "stable-sync"
+    snapshots = Get-Chromium -Title "Chromium Snapshots" -Type "dev-official"
   }
 
   return @{ Streams = $streams }


### PR DESCRIPTION
## Description
This change removes the x86 binary from the package, leaving a link to it.

## Motivation and Context
The final nupkg was too large to push to CCR, so we needed to cut space.

This change should serve many users, while still enabling x86 usage. 

As commented in the previous pull request, the decision was made to continue containing the x86 install.

Fixes #2295

Recreates #2299

## How Has this Been Tested?
- Built using `update_all.ps1`
- Installed with defaults
- Installed with `-x86` (note: hasn't been tested on an actual x86 machine)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).