### PR TITLE
(nodejs)(nodejs.install) rework update script to be more future-proof (#2452)

### DIFF
--- a/automatic/nodejs.install/update.ps1
+++ b/automatic/nodejs.install/update.ps1
@@ -41,8 +41,8 @@ function global:au_GetLatest {
   $schedules.PSObject.Properties.Name | ForEach-Object {
     $name = $_
     $schedule = $schedules.$name
-    $scheduleStart = [datetime]::parseexact($schedule.start, 'yyyy-MM-dd', $null)
-    $scheduleEnd = [datetime]::parseexact($schedule.end, 'yyyy-MM-dd', $null)
+    $scheduleStart = [datetime]$schedule.start
+    $scheduleEnd = [datetime]$schedule.end
     if (($scheduleStart -le $curDate) -and ($scheduleEnd -ge $curDate)) {
       $supportedChannels += $name
     }
@@ -62,7 +62,11 @@ function global:au_GetLatest {
     $url32 = "https://nodejs.org/dist/$version/node-$version-x86.msi"
     $url64 = "https://nodejs.org/dist/$version/node-$version-x64.msi"
 
-    $streams.Add($versionStrict.Major, @{ Version = $versionStrict.ToString() ; URL32 = $url32; URL64 = $url64 } )
+    $streams.Add($versionStrict.Major.ToString(), @{
+        Version = $versionStrict.ToString()
+        URL32   = $url32
+        URL64   = $url64
+      })
   }
 
   return @{ Streams = $streams }

--- a/automatic/nodejs.install/update.ps1
+++ b/automatic/nodejs.install/update.ps1
@@ -33,35 +33,34 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  [string] $scheduleUri = 'https://raw.githubusercontent.com/nodejs/Release/main/schedule.json'
-  [PSCustomObject] $schedules = Invoke-RestMethod -Uri $scheduleUri -UseBasicParsing
+  $scheduleUri = 'https://raw.githubusercontent.com/nodejs/Release/main/schedule.json'
+  $schedules = Invoke-RestMethod -Uri $scheduleUri -UseBasicParsing
 
-  [datetime] $curDate = (Get-Date).Date
-  [string[]] $supportedChannels = @()
+  $curDate = (Get-Date).Date
+  $supportedChannels = @()
   $schedules.PSObject.Properties.Name | ForEach-Object {
-    [string] $name = $_
-    [PSCustomObject] $schedule = $schedules.$name
-    [datetime] $scheduleStart = [datetime]::parseexact($schedule.start, 'yyyy-MM-dd', $null)
-    [datetime] $scheduleEnd = [datetime]::parseexact($schedule.end, 'yyyy-MM-dd', $null)
+    $name = $_
+    $schedule = $schedules.$name
+    $scheduleStart = [datetime]::parseexact($schedule.start, 'yyyy-MM-dd', $null)
+    $scheduleEnd = [datetime]::parseexact($schedule.end, 'yyyy-MM-dd', $null)
     if (($scheduleStart -le $curDate) -and ($scheduleEnd -ge $curDate)) {
       $supportedChannels += $name
     }
   }
 
-  [string] $versionsUri = 'https://nodejs.org/dist/index.json'
-  [PSCustomObject] $versions = Invoke-RestMethod -Uri $versionsUri -UseBasicParsing
+  $versionsUri = 'https://nodejs.org/dist/index.json'
+  $versions = Invoke-RestMethod -Uri $versionsUri -UseBasicParsing
 
   $streams = @{ }
 
   $supportedChannels | ForEach-Object {
-    [string] $channel = $_
-    [PSCustomObject] $latestVersion = $versions | Where-Object -FilterScript { $_.version.StartsWith($channel) } | Select-Object -First 1
-    Write-Host "$($latestVersion.version) / $($latestVersion.date)"
-    [string] $version = $latestVersion.version
-    [version] $versionStrict = [version]::Parse($latestVersion.version.Substring(1))
+    $channel = $_
+    $latestVersion = $versions | Where-Object -FilterScript { $_.version.StartsWith($channel) } | Select-Object -First 1
+    $version = $latestVersion.version
+    $versionStrict = [version]::Parse($latestVersion.version.Substring(1))
 
-    [string] $url32 = "https://nodejs.org/dist/$version/node-$version-x86.msi"
-    [string] $url64 = "https://nodejs.org/dist/$version/node-$version-x64.msi"
+    $url32 = "https://nodejs.org/dist/$version/node-$version-x86.msi"
+    $url64 = "https://nodejs.org/dist/$version/node-$version-x64.msi"
 
     $streams.Add($versionStrict.Major, @{ Version = $versionStrict.ToString() ; URL32 = $url32; URL64 = $url64 } )
   }

--- a/automatic/nodejs.install/update.ps1
+++ b/automatic/nodejs.install/update.ps1
@@ -58,6 +58,7 @@ function global:au_GetLatest {
     $latestVersion = $versions | Where-Object -FilterScript { $_.version.StartsWith($channel) } | Select-Object -First 1
     $version = $latestVersion.version
     $versionStrict = [version]::Parse($latestVersion.version.Substring(1))
+    if ($streams.ContainsKey($versionStrict.Major.ToString())) { return ; }
 
     $url32 = "https://nodejs.org/dist/$version/node-$version-x86.msi"
     $url64 = "https://nodejs.org/dist/$version/node-$version-x64.msi"


### PR DESCRIPTION
## Description
Instead of parsing a markdown file, the script uses official JSON files to find the latest versions of each support channel.

## Motivation and Context
NodeJS website fundamentaly changed some weeks ago. I reached out to the NodeJS team [(Discussion 52407)](https://github.com/orgs/nodejs/discussions/52407) and got the hints to json files. Fixes #2452

## How Has this Been Tested?
I tested the content of the changed `au_GetLatest` method and also ran the `update.ps1` script (which downloaded the correct files but failed locally because of missing choco command [we dont use choco on our dev systems])

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).
