### PR TITLE
(winscp*) Fixing URL parsing for download

### DIFF
--- a/automatic/winscp.install/update.ps1
+++ b/automatic/winscp.install/update.ps1
@@ -1,7 +1,7 @@
 ﻿Import-Module Chocolatey-AU
 
 $releases = 'https://winscp.net/eng/downloads.php'
-$re  = 'WinSCP.+\.exe$'
+$re  = 'WinSCP.+\.exe/download$'
 
 function global:au_SearchReplace {
    @{
@@ -24,7 +24,7 @@ function global:au_GetLatest {
     $url = @($download_page.links | Where-Object href -match $re) -notmatch 'beta|rc' | ForEach-Object href
     $url = 'https://winscp.net/eng' + $url
     $version   = $url -split '-' | Select-Object -Last 1 -Skip 1
-    $file_name = $url -split '/' | Select-Object -last 1
+    $file_name = $url -split '/' | Select-Object -last 1 -Skip 1
     @{
         Version      = $version
         URL32        = "https://sourceforge.net/projects/winscp/files/WinSCP/$version/$file_name/download"

--- a/automatic/winscp.portable/update.ps1
+++ b/automatic/winscp.portable/update.ps1
@@ -1,7 +1,7 @@
 ﻿Import-Module Chocolatey-AU
 
 $releases = 'https://winscp.net/eng/downloads.php'
-$re  = 'WinSCP.+Portable\.zip$'
+$re  = 'WinSCP.+Portable\.zip/download$'
 
 function global:au_SearchReplace {
    @{
@@ -33,7 +33,7 @@ function global:au_GetLatest {
     $url = @($download_page.links | Where-Object href -match $re) -notmatch 'beta|rc' | ForEach-Object href
     $url = 'https://winscp.net/eng' + $url
     $version   = $url -split '-' | Select-Object -Last 1 -Skip 1
-    $file_name = $url -split '/' | Select-Object -last 1
+    $file_name = $url -split '/' | Select-Object -last 1 -Skip 1
     @{
         Version      = $version
         URL32        = "https://sourceforge.net/projects/winscp/files/WinSCP/$version/$file_name/download"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
WinSCP url has changed, appending a /download to the link.
This changes updates de URL and the parsing that goes along with it.

## Motivation and Context
The package was failing to update on the community repo.

## How Has this Been Tested?
Lightly, as I'm on a traiin :)

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

