### PR TITLE
(gom-player) New version check

### DIFF
--- a/automatic/gom-player/update.ps1
+++ b/automatic/gom-player/update.ps1
@@ -1,7 +1,7 @@
 ﻿Import-Module Chocolatey-AU
 
 $releases     = 'https://www.gomlab.com/gomplayer-media-player/'
-$versions     = 'https://www.gomlab.com/ajax/update.gom?page=1&lang=eng&product=GOMPLAYER&update_lang=eng'
+$versions     = 'https://www.gomlab.com/en/gomplayer-media-player/release-note'
 $softwareName = 'GOM Player'
 
 function global:au_BeforeUpdate {
@@ -27,10 +27,10 @@ function global:au_GetLatest {
   $re = '\.exe$'
   $url32 = $download_page.Links | Where-Object href -match $re | Select-Object -first 1 -expand href
 
-  $verRe = '((?:\d+\.){2,3}\d+)'
+  $verRe = '(V (?:\d+\.){2,3}\d+)'
   $version_page = Invoke-WebRequest -Uri $versions -UseBasicParsing
   if ($version_page.Content -match $verRe) {
-    $version32 = $Matches[1]
+    $version32 = $Matches[1].Trim('V ')
   }
 
   @{


### PR DESCRIPTION
## Description
The website has been updated, the webpage with the version doesn't exist anymore. Getting the latest version from the releases notes instead

## Motivation and Context
The automatic updating wasn't working anymore.
I've updated it to solve the problem

## How Has this Been Tested?
Powershell

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).