### PR TITLE
Fix Speccy checksum

### DIFF
--- a/automatic/speccy/speccy.nuspec
+++ b/automatic/speccy/speccy.nuspec
@@ -5,7 +5,7 @@
     <id>speccy</id>
     <title>Speccy</title>
     <owners>chocolatey-community</owners>
-    <version>1.33.75</version>
+    <version>1.33.75.20240621</version>
     <authors>Piriform LTD</authors>
     <summary>Speccy will give you detailed statistics on every piece of hardware in your computer.</summary>
     <description><![CDATA[

--- a/automatic/speccy/tools/chocolateyInstall.ps1
+++ b/automatic/speccy/tools/chocolateyInstall.ps1
@@ -3,12 +3,12 @@
 $packageName = 'speccy'
 $url32       = 'https://download.ccleaner.com/spsetup133.exe'
 $url64       = $url32
-$checksum32  = 'e0edaee0d47ae9ddbb9ac78c9bcede8e25e082b87eb14654242b97c48ba847f5'
+$checksum32  = '03C35FCB1D10CF478C0B9896699937E6E262DAA4F4A4353A7CC56B238FE86892'
 $checksum64  = $checksum32
 
 if ($Env:ChocolateyPackageParameters -match '/UseSystemLocale') {
     Write-Host "Using system locale"
-    $locale = "/L=" + (Get-Culture).LCID 
+    $locale = "/L=" + (Get-Culture).LCID
 }
 
 $packageArgs = @{


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
Checksum changed in Speccy, install is currently failing due to checksum error. Package version appears to be the same. Had to adjust version number for package verifier to succeed.

## Motivation and Context
see above

## How Has this Been Tested?
Packed and confirmed install

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package has not been migrated from another location -->