### PR TITLE
(cyg-get) Space in $cygRoot

### DIFF
--- a/manual/cyg-get/cyg-get.nuspec
+++ b/manual/cyg-get/cyg-get.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>cyg-get</id>
     <title>cyg-get</title>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <authors>Red Hat, Inc.</authors>
     <owners>chocolatey-community,micahlmartin</owners>
     <summary>A utility to install Cygwin packages.</summary>

--- a/manual/cyg-get/tools/cyg-get.ps1
+++ b/manual/cyg-get/tools/cyg-get.ps1
@@ -58,10 +58,10 @@ if ($help -or $packageNames -join '|' -eq '/?') {
     }
 
     $cygwinsetup = "$cygRoot\cygwinsetup.exe"
-    $cygLocalPackagesDir = join-path $cygRoot packages
+    $cygLocalPackagesDir = join-path "$cygRoot" packages
     $cygInstallPackageList = $packageNames -join ','
 
-    $cygArgs = "--root $cygRoot --local-package-dir $cygLocalPackagesDir"
+    $cygArgs = "--root `"$cygRoot`" --local-package-dir `"$cygLocalPackagesDir`""
 
     $windowStyle = 'Minimized'
     if (!$notSilent) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->
Correct a bug when $cygRoot contain space.

## Description
<!-- Describe your changes in detail -->
Adding some " to allow space in variable $cygRoot.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
If CygWin is installed in "C:\Program Files\CygWin64", "cyg-get firefox" install defaults packages and firefox in the directory "C:\Program".

<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/chocolatey-community/chocolatey-packages/issues/2489
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
choco install -y --params "/InstallDir:'C:\Program Files\CygWin64' /site:'ftp://ftp-stud.hs-esslingen.de/pub/Mirrors/sources.redhat.com/cygwin/'" Cygwin
choco install -y cyg-get
cyg-get install firefox

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
