### PR TITLE
(filezilla) Fixes DownloadPage Request

### DIFF
--- a/automatic/filezilla/update.ps1
+++ b/automatic/filezilla/update.ps1
@@ -20,7 +20,9 @@ function global:au_SearchReplace {
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -FileNameBase "FileZilla_$($Latest.Version)"}
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing -UserAgent "Chocolatey"
+    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing -UserAgent "Chocolatey" -Headers @{
+        "Accept" = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+    }
     $url32 = $download_page.Links | Where-Object href -match "win32\-setup\.exe" | Select-Object -first 1 -expand href
     $url64 = $download_page.Links | Where-Object href -match "win64\-setup\.exe" | Select-Object -first 1 -expand href
     $version = $url32 -split '_' | Where-Object { $_ -match '^\d+\.[\d\.]+$' } | Select-Object -first 1


### PR DESCRIPTION
## Description
This updates the `Invoke-WebRequest` used in the Filezilla update script to find the versions to add an accept header.

## Motivation and Context
The filezilla update was failing due to an invalid version.

On investigation, the returned page had no useful content. This change fixes that, and allows us to continue grabbing updated links.

## How Has this Been Tested?
Before changes:
![image](https://github.com/chocolatey-community/chocolatey-packages/assets/1975761/0d2cb811-8598-4fcf-afa7-009f90bb0d8f)

After changes:
![image](https://github.com/chocolatey-community/chocolatey-packages/assets/1975761/961fc040-6b21-4d9d-ad21-580cae2d3262)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).