### PR TITLE
Adds Argument Completers To Update_All Script

### DIFF
--- a/update_all.ps1
+++ b/update_all.ps1
@@ -1,6 +1,41 @@
 # AU Packages Template: https://github.com/majkinetor/au-packages-template
+[CmdletBinding()]
+param(
+    # Specific packages to update
+    [ArgumentCompleter({
+        param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+        $Directory = if ($FakeBoundParameters['Root']) {
+            $FakeBoundParameters['Root']
+        } else {
+            "$PSScriptRoot\automatic"
+        }
+        (Get-ChildItem $Directory -Directory).Name.Where{
+            $_ -like "*$WordToComplete*" -and
+            $_ -notin $FakeBoundParameters['Name']
+        }
+    })]
+    [string[]]$Name,
 
-param([string[]] $Name, [string] $ForcedPackages, [string] $Root = "$PSScriptRoot\automatic")
+    # Packages to update regardless of the state of the upstream repository
+    [ArgumentCompleter({
+        param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+        $Directory = if ($FakeBoundParameters['Root']) {
+            $FakeBoundParameters['Root']
+        } else {
+            "$PSScriptRoot\automatic"
+        }
+
+        (Get-ChildItem $Directory -Directory).Name.Where{
+            $_ -like "*$WordToComplete*"
+        } | Group-Object {
+            $_ -in $FakeBoundParameters['Name']
+        } | Sort-Object | Select-Object -ExpandProperty Group
+    })]
+    [string]$ForcedPackages,
+
+    # The directory to update packages in
+    [string]$Root = "$PSScriptRoot\automatic"
+)
 
 if (Test-Path $PSScriptRoot/update_vars.ps1) {
     . $PSScriptRoot/update_vars.ps1


### PR DESCRIPTION
## Description

When running the `Update_All.ps1` script, `-Name` can now tab-complete from the list of existing packages in the specified root-directory, and ForcedPackages can tab complete from existing packages _prioritising those already in Name_.

Definitely up for chatting if this actually fits other users, here, but I think it's a nice change to have - and it shouldn't _break_ anyone else's workflow.

## Motivation and Context

When testing PRs or branches, I frequently run Update_All with specific name or forced packages.

As a quality of life improvement, being able to tab complete packages in the arguments for the update_all script for use when developing or testing packages is pretty neat.

https://github.com/chocolatey-community/chocolatey-packages/assets/1975761/7e9f52df-49f9-4a5f-8ad1-5b5cb26b16de

## How Has this Been Tested?

Tested locally on PowerShell 5.1.

## Types of changes
- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- [x] New feature (non-breaking change which adds functionality)
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [ ] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- ~[ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)~
- ~[ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.~
- ~[ ] The changes only affect a single package (not including meta package).~
