### PR TITLE
(quiterss) Fixes Update.ps1

### DIFF
--- a/automatic/quiterss/update.ps1
+++ b/automatic/quiterss/update.ps1
@@ -1,14 +1,18 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = 'https://quiterss.org/en/download'
+$releases = 'https://quiterss.org/files/'
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-    $url   = $download_page.links | ? href -match '.exe$' | select -First 1 -expand href
-    $version = $url -split '-' | select -First 1 -Skip 1
+    $releases_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+    $available_versions = $releases_page.links | Where-Object {$_.title -and $_.title.TrimEnd('_') -as [version]} | Sort-Object {$_.title.TrimEnd('_') -as [version]}
+    $latest_version_url = $releases.TrimEnd('/') + '/' + $available_versions[-1].href
+
+    $download_page = Invoke-WebRequest -Uri $latest_version_url -UseBasicParsing
+    $url   = $download_page.links | ? href -match '\.exe$' | Select-Object -First 1 -expand href
+    $version = $url -split '-' | Select-Object -First 1 -Skip 1
 
     @{
-        URL32   = 'https://quiterss.org' + $url
+        URL32   = $latest_version_url + $url
         Version = $version
     }
 }


### PR DESCRIPTION
## Description

Changes the update script to parse the folder structure, find the latest version, and find the exe within that folder.

## Motivation and Context

The format of the downloads page (and what looks like the entire website) has changed quite considerably, to a hosted files/folders layout. This was breaking the update script.

## How Has this Been Tested?

- `Update_All.ps1 -Name quiterss -Forced quiterss` # [Succeeds]
- `choco install quiterss --Source Desktop --confirm`  # [Succeeds]

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
