### PR TITLE
(tribler) Fixes Update.ps1

### DIFF
--- a/automatic/tribler/update.ps1
+++ b/automatic/tribler/update.ps1
@@ -23,8 +23,8 @@ function global:au_GetLatest {
   $LatestRelease = Get-GitHubRelease Tribler tribler
 
   @{
-    URL32        = $LatestRelease.assets | Where-Object {$_.name.EndsWith("x86.exe")} | Select-Object -ExpandProperty browser_download_url
-    URL64        = $LatestRelease.assets | Where-Object {$_.name.EndsWith("x64.exe")} | Select-Object -ExpandProperty browser_download_url
+    URL32        = $LatestRelease.assets | Where-Object {$_.name.EndsWith("x86.exe") -and $_.name -notmatch '-debug_'} | Select-Object -ExpandProperty browser_download_url
+    URL64        = $LatestRelease.assets | Where-Object {$_.name.EndsWith("x64.exe") -and $_.name -notmatch '-debug_'} | Select-Object -ExpandProperty browser_download_url
     Version      = $LatestRelease.tag_name.TrimStart("v")
     ReleaseNotes = $LatestRelease.html_url
   }


### PR DESCRIPTION
## Description

This change excludes assets that match -debug_ from the GetLatest logic.

## Motivation and Context

Tribler's releases now include debug executables, which were being picked up by the current logic.

## How Has this Been Tested?

- Tested updating the package, successfully generated a new version

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
