### PR TITLE
(winscp.install) Update File Path To Not Use Get-Item/Globbing

### DIFF
--- a/automatic/winscp.install/tools/chocolateyInstall.ps1
+++ b/automatic/winscp.install/tools/chocolateyInstall.ps1
@@ -5,8 +5,8 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 $packageArgs = @{
   packageName    = 'winscp'
   fileType       = 'exe'
-  file           = Get-Item $toolsPath\*.exe
-  file64         = Get-Item $toolsPath\*.exe
+  file           = "$toolsPath\WinSCP-$($env:ChocolateyPackageVersion)-Setup.exe"
+  file64         = "$toolsPath\WinSCP-$($env:ChocolateyPackageVersion)-Setup.exe"
   silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 }
 Install-ChocolateyInstallPackage @packageArgs

--- a/automatic/winscp.install/tools/chocolateyInstall.ps1
+++ b/automatic/winscp.install/tools/chocolateyInstall.ps1
@@ -5,8 +5,8 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 $packageArgs = @{
   packageName    = 'winscp'
   fileType       = 'exe'
-  file           = "$toolsPath\WinSCP-$($env:ChocolateyPackageVersion)-Setup.exe"
-  file64         = "$toolsPath\WinSCP-$($env:ChocolateyPackageVersion)-Setup.exe"
+  file           = "$toolsPath\WinSCP-6.3.4-Setup.exe"
+  file64         = "$toolsPath\WinSCP-6.3.4-Setup.exe"
   silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 }
 Install-ChocolateyInstallPackage @packageArgs

--- a/automatic/winscp.install/update.ps1
+++ b/automatic/winscp.install/update.ps1
@@ -4,21 +4,13 @@ $releases = 'https://winscp.net/eng/downloads.php'
 $re  = 'WinSCP.+\.exe/download$'
 
 function global:au_SearchReplace {
-    $FileVersion = if ($Latest.FileVersion -ne $Latest.Version) {
-        $Latest.FileVersion
-    } else {
-        '$($env:ChocolateyPackageVersion)'
-    }
-
-   @{
+    @{
         "$($Latest.PackageName).nuspec" = @{
             "(\<releaseNotes\>).*?(\</releaseNotes\>)" = "`${1}$($Latest.ReleaseNotes)`$2"
         }
         "tools\chocolateyInstall.ps1"   = @{
-            # We use ChocolateyPackageVersion to minimise changes to the package code -
-            # If using a patchfix version, use the fileversion instead of the packageversion.
-            '(?i)(\s*file\s*=\s*["'']\$toolsPath\\WinSCP-)(\$\(\$env:ChocolateyPackageVersion\)|.+)(-Setup\.exe["''])' = "`${1}$($FileVersion)`${3}"
-            '(?i)(\s*file64\s*=\s*["'']\$toolsPath\\WinSCP-)(\$\(\$env:ChocolateyPackageVersion\)|.+)(-Setup\.exe["''])' = "`${1}$($FileVersion)`${3}"
+            "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\).*"   = "`${1}$($Latest.FileName32)`""
+            "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName32)`""
         }
         ".\legal\VERIFICATION.txt" = @{
           "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL32)"
@@ -38,7 +30,6 @@ function global:au_GetLatest {
     $file_name = $url -split '/' | Select-Object -last 1 -Skip 1
     @{
         Version      = $version
-        FileVersion  = $version
         URL32        = "https://sourceforge.net/projects/winscp/files/WinSCP/$version/$file_name/download"
         FileName32   = $file_name
         ReleaseNotes = "https://winscp.net/download/WinSCP-${version}-ReadMe.txt"


### PR DESCRIPTION
## Description

Instead of getting a wildcarded path, we are more specific about the path to the installer we want to run.

## Motivation and Context

Upgrading when multiple versions of the installer were present for whatever reason may fail unexpectedly.

Fixes #2433

## How Has this Been Tested?

- Upgraded from 6.3.3 to 6.3.4 (new)
- Upgraded from 6.3.4 to 6.3.4.20240703 (patchfix)
- Tested building of regular and patchfix versions to ensure logic worked

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- ~[ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)~
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
