### PR TITLE
(kubernetes-cli) Fix Update.ps1 (Prerelease version broke all)

### DIFF
--- a/automatic/kubernetes-cli/update.ps1
+++ b/automatic/kubernetes-cli/update.ps1
@@ -42,7 +42,7 @@ function global:au_GetLatest {
 
     foreach ($minor_version in $minor_version_changelogs) {
         if ($streams.ContainsKey($minor_version)) {
-          return
+          continue
         }
 
         $minor_changelog_page = Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/CHANGELOG-$($minor_version).md"
@@ -52,7 +52,7 @@ function global:au_GetLatest {
           | Select-Object -First 1
 
         if (!$url64) {
-          return
+          continue
         }
 
         if ($url64 -match "/v(?<version>\d+(\.\d+)+)/kubernetes-client-windows-amd64.tar.gz") {

--- a/scripts/Get-GitHubRelease.ps1
+++ b/scripts/Get-GitHubRelease.ps1
@@ -16,7 +16,7 @@
     [Parameter(Mandatory, Position = 1)]
     [string]$Name,
 
-    # The Name of the tag to get the relase for. Will default to the latest release.
+    # The Name of the tag to get the release for. Will default to the latest release.
     [string]$TagName,
 
     # GitHub token, used to reduce rate-limiting or access private repositories (needs repo scope)

--- a/scripts/Get-GitHubRepositoryFileContent.ps1
+++ b/scripts/Get-GitHubRepositoryFileContent.ps1
@@ -1,0 +1,65 @@
+﻿function Get-GitHubRepositoryFileContent {
+  <#
+    .Synopsis
+      Returns the content of a given file in a repository via the REST API
+
+    .Link
+      https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28
+
+    .Example
+      Get-GitHubRepositoryFileContent Kubernetes Kubernetes CHANGELOG/README.md
+
+    .Notes
+      Seems to be a lot faster than IWRing raw files.
+  #>
+  [CmdletBinding()]
+  param(
+    # The owner of the repository
+    [Parameter(Mandatory)]
+    [string]$Owner,
+
+    # The repository containing the file
+    [Parameter(Mandatory)]
+    [string]$Repository,
+
+    # The path to the file within the repository
+    [Parameter(ValueFromPipeline)]
+    [string]$Path,
+
+    # The branch, tag, or reference to get the content from. Defaults to the repository's default branch.
+    [Alias('ref', 'Tag')]
+    [string]$Branch,
+
+    # Returns the raw response
+    [switch]$Raw
+  )
+  process {
+    $restArgs = @{
+      Uri     = "https://api.github.com/repos/$($Owner)/$($Repository)/contents/$($Path.TrimStart('/'))"
+      Headers = @{
+        'Accept'               = 'application/vnd.github+json'
+        'X-GitHub-Api-Version' = '2022-11-28'
+      }
+    }
+    if ($Branch) {
+      $restArgs.Body = @{ref = $Branch}
+    }
+    if ($env:github_api_key) {
+      $restArgs.Headers.Authorization = "Bearer $($env:github_api_key)"
+    }
+
+    $Result = Invoke-RestMethod @restArgs -UseBasicParsing
+
+    if ($Raw) {
+      $Result
+    } elseif ($Result.encoding -eq 'base64') {
+      # Assumption made about the file being UTF8, here
+      [System.Text.Encoding]::UTF8.GetString(
+        [System.Convert]::FromBase64String($Result.content)
+      )
+    } else {
+      Write-Warning "$($Path) encoded as '$($Result.encoding)'"
+      $Result.content
+    }
+  }
+}

--- a/scripts/au_extensions.psm1
+++ b/scripts/au_extensions.psm1
@@ -9,6 +9,7 @@ $funcs = @(
   'Clear-DependenciesList'
   'Get-AllGitHubReleases'
   'Get-GitHubRelease'
+  'Get-GitHubRepositoryFileContent'
   'Set-DescriptionFromReadme'
   'Update-ChangelogVersion'
   'Update-OnETagChanged'


### PR DESCRIPTION
## Description

Changing to `continue` rather than `return` when a URL isn't matched fixes an issue where a pre-release version broke our regex.

Also takes advantage of the REST API to get the changelogs, which improves performance from ~164s to ~86s on my machine.

We may consider releasing prerelease streams at some point, but we don't currently do so - otherwise, we could fix up the regex to respect full semver versions.

## Motivation and Context

GetLatest was failing to return anything. On inspection, it seems that a latest -alpha release was causing get latest to return immediately instead of listing the rest of the available streams.

## How Has this Been Tested?

- Before changes:
    ![image](https://github.com/chocolatey-community/chocolatey-packages/assets/1975761/d4d38738-a99b-4735-be75-e9d0578f0bfa)
- With just the fix to `continue`:
    ![image](https://github.com/chocolatey-community/chocolatey-packages/assets/1975761/06499674-7bd9-49f2-8efd-0599cdbbd9fd)
- Including the change to using the REST API:
    ![image](https://github.com/chocolatey-community/chocolatey-packages/assets/1975761/34b887ca-5f02-4874-a4a2-1ea852d1016a)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
