### PR TITLE
(autohotkey.install) add to to description about virus positives

### DIFF
--- a/automatic/autohotkey.install/README.md
+++ b/automatic/autohotkey.install/README.md
@@ -27,3 +27,9 @@ AutoHotkey is a free, open source macro-creation and automation software utility
 - `/DefaultVer` - Can be `U64` (UNICODE 64-bit),`U32` (UNICODE 32-bit) or `A32` (ANSI 32-bit). By default UNICODE version will be installed of adequate architecture depending on your machine and/or OS.
 
 Example: `choco install autohotkey.install --params='/DefaultVer:A32'`
+
+## Notes
+
+- Please see the [Autohotkey FAQ](https://www.autohotkey.com/docs/v2/FAQ.htm#Virus) for information on false positive anti-virus detections.
+
+- **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**


### PR DESCRIPTION
## Description

Adds a note about the high virus count to the description of the package, copied from `autohotkey.portable`

## Motivation and Context

The package currently has a high virus count, and cannot be exempted as it does not have the note in the package description like the `.portable` package has. 

Related issue #2187

## How Has this Been Tested?

Ran update script and ensured that nuspec was updated correctly.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

