### PR TITLE
(autohotkey) add square brackets to au_SearchReplace nuspec

### DIFF
--- a/automatic/autohotkey/update.ps1
+++ b/automatic/autohotkey/update.ps1
@@ -6,7 +6,7 @@
 function global:au_SearchReplace {
   @{
         "$($Latest.PackageName).nuspec" = @{
-            "(\<dependency .+?`"$($Latest.PackageName).install`" version=)`"([^`"]+)`"" = "`$1`"$($Latest.Version)`""
+            "(\<dependency .+?`"$($Latest.PackageName).install`" version=)`"([^`"]+)`"" = "`$1`"[$($Latest.Version)]`""
         }
     }
  }


### PR DESCRIPTION
## Description
I'm hoping this package will be the new example referenced from chocolatey-au. Even if it's not, having a locked installer package version seems to be best practice for metapackages going forward.

## Motivation and Context
For more on this, see [chocolatey-au issue #69](https://github.com/chocolatey-community/chocolatey-au/issues/69)

## How Has this Been Tested?
None

## Screenshot (if appropriate, usually isn't needed):
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
