### PR TITLE
(graphviz) fix typo preventing uninstallation

### DIFF
--- a/automatic/graphviz/tools/chocolateyUninstall.ps1
+++ b/automatic/graphviz/tools/chocolateyUninstall.ps1
@@ -14,7 +14,7 @@ if ($key.Count -eq 1) {
             file                   = "$($_.UninstallString.Replace(' /x86=0', ''))"   #"C:\Program Files\OpenSSH\uninstall.exe" /x86=0
         }
 
-        $installLocation = (Get-Item $key.UninstallString).DirectoryName
+        $installLocation = $_.UninstallString.DirectoryName
         Write-Debug "$packageName installed in: $installLocation"
         
         if (!$installLocation) { 

--- a/automatic/graphviz/tools/chocolateyUninstall.ps1
+++ b/automatic/graphviz/tools/chocolateyUninstall.ps1
@@ -14,7 +14,7 @@ if ($key.Count -eq 1) {
             file                   = "$($_.UninstallString.Replace(' /x86=0', ''))"   #"C:\Program Files\OpenSSH\uninstall.exe" /x86=0
         }
 
-        $installLocation = $_.UninstallString.DirectoryName
+        $installLocation = $(Split-Path $_.UninstallString.trim('"') )
         Write-Debug "$packageName installed in: $installLocation"
         
         if (!$installLocation) { 


### PR DESCRIPTION
Fixes #2512

## Description
Typo in the powershell script, the code made no sense and would crash.


## Motivation and Context
Uninstallation was not possible due to crash of unintall powershel script

## How Has this Been Tested?
The fixed script was run successfully and uninstallation succeeded

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ x] The changes only affect a single package (not including meta package).

