### PR TITLE
(thunderbird) update script use ESR

### DIFF
--- a/automatic/thunderbird/update.ps1
+++ b/automatic/thunderbird/update.ps1
@@ -7,9 +7,10 @@ $product  = 'thunderbird'
 function global:au_AfterUpdate {
   $version = $Latest.RemoteVersion
   CreateChecksumsFile -ToolsDirectory "$PSScriptRoot\tools" `
-    -ExecutableName "Thunderbird Setup $version.exe" `
+    -ExecutableName "Thunderbird Setup $($version)esr.exe" `
     -Version $version `
-    -Product $product
+    -Product $product `
+    -ExtendedRelease
 }
 
 function global:au_SearchReplace {


### PR DESCRIPTION
## Description

Update the thunderbird script to use ESR for the update helper.

## Motivation and Context

Fixes #2515

Thunderbird was updated to use ESR naming for the executables.

## How Has this Been Tested?

Ran update script on Windows 10 22H2

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

