### PR TITLE
(maint) Remove unsupported CLI versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -28,9 +28,6 @@ body:
       options:
         - 2.3.0
         - 2.2.2
-        - 2.2.0
-        - 2.1.0
-        - 2.0.0
         - Other (note in the comments)
     validations:
       required: true


### PR DESCRIPTION
## Description
Remove unsupported CLI versions. See the [wiki for supported versions](https://github.com/chocolatey-community/chocolatey-packages/wiki/Supported-Chocolatey-CLI-versions).

## Motivation and Context
Unsupported CLI versions are still in the issue template.

## How Has this Been Tested?
N/A

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).
