### PR TITLE
(firefox) changed urls for download

### DIFF
--- a/automatic/firefox/update.ps1
+++ b/automatic/firefox/update.ps1
@@ -3,8 +3,8 @@ param($IncludeStream, [switch] $Force)
 Import-Module Chocolatey-AU
 . "$PSScriptRoot\update_helper.ps1"
 
-$releases = 'https://www.mozilla.org/en-US/firefox/all/'
-$releasesESR = 'https://www.mozilla.org/en-US/firefox/organizations/all/'
+$releases = 'https://www.mozilla.org/en-US/firefox/all/desktop-release/win/en-US/'
+$releasesESR = 'https://www.mozilla.org/en-US/firefox/all/desktop-esr/win/en-US/'
 $product = 'firefox'
 
 function global:au_BeforeUpdate {


### PR DESCRIPTION

## Description
Mozilla changed their download pages. So au did not work anymore
change the download urls after investigation and testing.

## Motivation and Context

fixes #2530 

## How Has this Been Tested?
powershell on local machine


## Screenshot (if appropriate, usually isn't needed):

![image](https://github.com/user-attachments/assets/1149f70e-e277-454c-8eca-09327a75fb78)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
