### PR TITLE
(gitextensions) Update .NET dependency

### DIFF
--- a/automatic/gitextensions/gitextensions.nuspec
+++ b/automatic/gitextensions/gitextensions.nuspec
@@ -47,7 +47,7 @@
     <dependencies>
       <dependency id="git" version="2.17.1.2" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="dotnet-6.0-desktopruntime" version="6.0.13" />
+      <dependency id="dotnet-8.0-desktopruntime" version="8.0.8" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
## Description

Update the .NET dependency on Git Extensions

## Motivation and Context

The minimum .NET version of Git Extensions is now .NET 8.0.8.

## How Has this Been Tested?

Installed package with updated dependencies and confirmed it worked as expected.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

Fixes #2535 