### PR TITLE
(itunes) Add ERROR_SUCCESS_REBOOT_REQUIRED (3010) to Valid Exit Codes

### DIFF
--- a/automatic/itunes/tools/chocolateyInstall.ps1
+++ b/automatic/itunes/tools/chocolateyInstall.ps1
@@ -13,7 +13,7 @@ $packageArgs = @{
   checksum64     = '08f399888efd2ddb16147c28e893cf60c8c6a997f06e4fae89b14886cb5bdeb4'
   checksumType64 = 'sha256'
   silentArgs     = "/qn /norestart"
-  validExitCodes = @(0, 2010, 1641)
+  validExitCodes = @(0, 2010, 1641, 3010)
   unzipLocation  = Get-PackageCacheLocation
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Title says it all for the most part. Adding 3010 (`ERROR_SUCCESS_REBOOT_REQUIRED`) to `itunes`'s list of valid exit codes.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

When I was upgrading to the latest package version (12.13.3.2), `iTunes64.msi` returned this exit code.

In this situation, this would cause Chocolatey CLI to print a misleading error message, despite both the package installation and underlying software installation succeeding. We should avoid suggesting an error condition occurred when no apparent problem exists.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

1. `choco pack` against the modified package code.
2. Produce any condition that will require a reboot to successfully complete installation.
    - Interestingly, I can consistently reproduce this with a clean image, despite taking no conscious action to force this situation. I suspect this may have become the standard install workflow with newer versions of iTunes.
3. Within the Chocolatey Test Environment, install the modified package with `choco install itunes --source="'.;https://community.chocolatey.org/api/v2/'"`, to source the package's dependencies from the Community Repository, while also prioritizing the modified package version.
4. Confirm `itunes` installs successfully without printing an error message.
5. Restart Windows.
6. Confirm iTunes itself has installed as expected.

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
