### PR TITLE
(1password) Fix OPW4 stream not pushed

### DIFF
--- a/automatic/1password/update.ps1
+++ b/automatic/1password/update.ps1
@@ -8,6 +8,15 @@ if (($IncludeStream -match "^OPW(?<major>\d+)") -and (Test-Path "$PSScriptRoot\.
   try {
     $oldVersion = $global:au_Version
     . "./update.ps1" -NoUpdateCheck
+    $packages = Get-ChildItem "*.nupkg"
+
+    if ($packages) {
+      Copy-Item $packages -Destination $PSScriptRoot
+      # We also need to commit any changes, but only do this when running in a CI environment
+      if ($env:APPVEYOR -eq $true) {
+        git add . --update
+      }
+    }
 
     if ($oldVersion) {
       $global:au_Version = $oldVersion


### PR DESCRIPTION
## Description

This fixes an issue where a manual package used by an automatic update script is not pushed to the Community Repository.

## Motivation and Context

We want to be able to push fix versions of 1password package that have been moved to the manual directory.

## How Has this Been Tested?

Limited testing. Run

1. `.\update_all.ps1 1password -ForcedPackages '1password\OPW4'`
2. Ensure that the 1password4 nupkg package was copied to the 1password directory.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
