### PR TITLE
(nodejs.install) Fix auto-update by avoiding setting 32-bit URLs for NodeJS 23+

### DIFF
--- a/automatic/nodejs.install/update.ps1
+++ b/automatic/nodejs.install/update.ps1
@@ -63,11 +63,18 @@ function global:au_GetLatest {
     $url32 = "https://nodejs.org/dist/$version/node-$version-x86.msi"
     $url64 = "https://nodejs.org/dist/$version/node-$version-x64.msi"
 
-    $streams.Add($versionStrict.Major.ToString(), @{
+    if ($versionStrict.Major -lt 23) {
+      $streams.Add($versionStrict.Major.ToString(), @{
         Version = $versionStrict.ToString()
-        URL32   = $url32
-        URL64   = $url64
+        URL32 = $url32
+        URL64 = $url64
       })
+    } else {
+      $streams.Add($versionStrict.Major.ToString(), @{
+        Version = $versionStrict.ToString()
+        URL64 = $url64
+      })
+    }
   }
 
   return @{ Streams = $streams }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
As noted in #2556 the auto-update for NodeJS is broken as NodeJS dropped 32-bit support. This change at least should unblock the auto-update for other releases (priority should be v22 soon-to-be-LTS patches coming through).

The v23 package itself will need some further work to handle cases where there is no 32-bit version gracefully. For now I only have time to try and unblock updates/patches for other versions, not address a non-LTS release like v23.

## Motivation and Context
Partially addresses #2556 to at least unblock auto-updates for NodeJS `< 23`.

## How Has this Been Tested?
Locally sanity tested the update script.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).