### PR TITLE
(git) Respect build in version number

### DIFF
--- a/automatic/git.install/update.ps1
+++ b/automatic/git.install/update.ps1
@@ -39,7 +39,7 @@ function global:au_GetLatest {
     $tagUrl = $download_page.Links | Where-Object href -match 'releases/tag/.*windows' | Select-Object -First 1 -ExpandProperty href
     $tagName = $tagUrl -split '\/' | Select-Object -Last 1
 
-    $version = $tagName -split '^v|\.windows' | Select-Object -Last 1 -Skip 1
+    $version = $tagName.TrimStart('v') -replace '\.windows',''
 
     @{
         Version = $version


### PR DESCRIPTION
## Description
Currently the version check will not respect changes of the build number resulting in bugfix releases not updated automatically.

## How Has this Been Tested?

Local test for latest release 2.47.0.2

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).