### PR TITLE
(nodejs.install) Unblock auto-updates by temporarily disabling NodeJS 23

### DIFF
--- a/automatic/nodejs.install/update.ps1
+++ b/automatic/nodejs.install/update.ps1
@@ -43,7 +43,8 @@ function global:au_GetLatest {
     $schedule = $schedules.$name
     $scheduleStart = [datetime]$schedule.start
     $scheduleEnd = [datetime]$schedule.end
-    if (($scheduleStart -le $curDate) -and ($scheduleEnd -ge $curDate)) {
+    # Temporarily disable v23+ updates until the package supports 64-bit only packages per https://github.com/chocolatey-community/chocolatey-packages/issues/2556
+    if (($scheduleStart -le $curDate) -and ($scheduleEnd -ge $curDate) -and ($name -lt 'v23')) {
       $supportedChannels += $name
     }
   }


### PR DESCRIPTION
## Description

Unblocks auto-updates for NodeJS <= v22 by disabling the v23+ streams while the v23 package is separately fixed.

## Motivation and Context

Currently auto-updates are broken for all NodeJS versions ([with this error](https://github.com/chocolatey-community/chocolatey-packages/issues/2555#issuecomment-2426449606)) as Node v23 dropped 32-bit support, breaking the auto-update script for all versions - as noted in the primary issue #2556.

My earlier PR was rejected as noted in [#2557](https://github.com/chocolatey-community/chocolatey-packages/pull/2557#pullrequestreview-2395193803) since the package needs to be updated to properly support 64-bit only packages which that PR didn't do. My earlier PR wasn't deemed complete enough as there are more changes needed to `VERIFICATION.txt` and other places to properly handle a package without a 32-bit variant.

Since I do not have necessary time/context/energy/knowledge/testing environment to fully validate such package changes, I instead propose to decouple the two issues; allow auto-updates to flow through for for v22, v20 etc until the 64-bit-only package can be addressed for v23+.

## How Has this Been Tested?

Ran `./update.ps1` locally to ensure it only tries to update versions < 23.

## Screenshot (if appropriate, usually isn't needed):

```shell
PS /Users/chad/Projects/community/community-chocolatey-packages/automatic/nodejs.install> ./update.ps1
nodejs.install - checking updates using Chocolatey-AU version 1.0.0

*** Stream: 18 ***
URL check
  https://nodejs.org/dist/v18.20.4/node-v18.20.4-x64.msi
  https://nodejs.org/dist/v18.20.4/node-v18.20.4-x86.msi
nuspec version: 18.20.4
remote version: 18.20.4
No new version found

*** Stream: 20 ***
URL check
  https://nodejs.org/dist/v20.18.0/node-v20.18.0-x64.msi
  https://nodejs.org/dist/v20.18.0/node-v20.18.0-x86.msi
nuspec version: 20.18.0
remote version: 20.18.0
No new version found

*** Stream: 22 ***
URL check
  https://nodejs.org/dist/v22.10.0/node-v22.10.0-x64.msi
  https://nodejs.org/dist/v22.10.0/node-v22.10.0-x86.msi
nuspec version: 22.9.0
remote version: 22.10.0
New version is available
Automatic checksum skipped
Running au_BeforeUpdate
Purging msi
Downloading to node-v22.10.0-x86.msi - https://nodejs.org/dist/v22.10.0/node-v22.10.0-x86.msi
Downloading to node-v22.10.0-x64.msi - https://nodejs.org/dist/v22.10.0/node-v22.10.0-x64.msi
Setting package description from README.md
Updating files
  $Latest data:
    Checksum32                (String)     DACA38D494C4D6D023EA0CC4D5F7974173256B80A5E485BF7FCAACE62C36DF85
    Checksum64                (String)     9D8FAD0DC2DA2C57E6FDF38FC85A23DC5EBCD5C414D8DD2948B3C45BD2398895
    ChecksumType32            (String)     sha256
    ChecksumType64            (String)     sha256
    FileName32                (String)     node-v22.10.0-x86.msi
    FileName64                (String)     node-v22.10.0-x64.msi
    FileType                  (String)     msi
    NuspecVersion             (String)     22.9.0
    PackageName               (String)     nodejs.install
    Stream                    (String)     22
    Streams                   (Hashtable)  System.Collections.Hashtable
    URL32                     (String)     https://nodejs.org/dist/v22.10.0/node-v22.10.0-x86.msi
    URL64                     (String)     https://nodejs.org/dist/v22.10.0/node-v22.10.0-x64.msi
    Version                   (String)     22.10.0
  nodejs.install.nuspec
    setting id: nodejs.install
    updating version: 22.9.0 -> 22.10.0
  .\legal\verification.txt
    (?i)(checksum64:\s+).*              = ${1}9D8FAD0DC2DA2C57E6FDF38FC85A23DC5EBCD5C414D8DD2948B3C45BD2398895
    (?i)(64-Bit.+)\<.*\>                = ${1}<https://nodejs.org/dist/v22.10.0/node-v22.10.0-x64.msi>
    (?i)(checksum32:\s+).*              = ${1}DACA38D494C4D6D023EA0CC4D5F7974173256B80A5E485BF7FCAACE62C36DF85
    (?i)(checksum type:\s+).*           = ${1}sha256
    (?i)(32-Bit.+)\<.*\>                = ${1}<https://nodejs.org/dist/v22.10.0/node-v22.10.0-x86.msi>
  .\tools\chocolateyInstall.ps1
    (?i)(^\s*SilentArgs\s*=\s*)'.*'     = ${1}'/quiet ADDLOCAL=ALL'
    (^[$]filePath32\s*=\s*"[$]toolsPath\\)(.*)" = $1node-v22.10.0-x86.msi"
    (^[$]filePath64\s*=\s*"[$]toolsPath\\)(.*)" = $1node-v22.10.0-x64.msi"
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).
