### PR TITLE
(GH-2334) (notepadplusplus.commandline)(notepadplusplus.install) Stop relaunch as Admin

### DIFF
--- a/automatic/notepadplusplus.commandline/tools/chocolateyInstall.ps1
+++ b/automatic/notepadplusplus.commandline/tools/chocolateyInstall.ps1
@@ -18,6 +18,5 @@ Get-ChocolateyUnzip @packageArgs
 Remove-Item $toolsPath\*.zip -ea 0
 
 if ($programRunning -and (Test-Path $programRunning)) {
-  Write-Host "Running stopped program"
-  Start-Process $programRunning
+  Write-Host "Please reopen Notepad++ to continue using."
 }

--- a/automatic/notepadplusplus.install/tools/chocolateyInstall.ps1
+++ b/automatic/notepadplusplus.install/tools/chocolateyInstall.ps1
@@ -39,6 +39,5 @@ Write-Host "$packageName installed to '$installLocation'"
 Install-BinFile -Path "$installLocation\notepad++.exe" -Name 'notepad++'
 
 if ($programRunning -and (Test-Path $programRunning)) {
-  Write-Host "Running stopped program"
-  Start-Process $programRunning
+  Write-Host "Please reopen Notepad++ to continue using."
 }


### PR DESCRIPTION
_NOTE: This will require pushing a package fix version._

## Description
Removes relaunching Notepad++ as part of the package.

## Motivation and Context
This fixes #2334: the problem that launching the application does so in the context of the elevated Chocolatey CLI session.

## How Has this Been Tested?
This replaces the `Write-Host` text and removes the Start-Process that launched the application in the elevated context.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).