### PR TITLE
(nodejs*) Update NodeJS updater to support v23

### DIFF
--- a/automatic/nodejs.install/README.md
+++ b/automatic/nodejs.install/README.md
@@ -8,6 +8,7 @@ This package runs the official Node JS installer, resulting in Node.exe and NPM 
 ## Notes
 
 - While this package now provides both **Current** and **LTS** releases of Node.js, it is still recommended to use the [nodejs-lts][] package if only targeting the latest LTS release is required.
+- Starting with version 23.x, installations for 32bit platforms are no longer supported. If this is required, an older version is required to be used.
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 
 [nodejs-lts]: https://chocolatey.org/packages/nodejs-lts "Node.js LTS Package"

--- a/automatic/nodejs.install/legal/VERIFICATION.full.txt
+++ b/automatic/nodejs.install/legal/VERIFICATION.full.txt
@@ -1,0 +1,18 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's content are trustworthy.
+
+The installer/archive has been downloaded from the authors official download link listed on <https://nodejs.org/en/download/prebuilt-installer>
+and can be verified using the following:
+
+1. Download the following installers/archives
+   - 32-Bit: <DIRECT_32BIT_DOWNLOAD_URL>
+   - 64-Bit: <DIRECT_64BIT_DOWNLOAD_URL>
+2. Use one of the following methods to obtain the checksum
+   - Use powershell function 'Get-FileHash'
+   - Use chocolatey utility 'checksum.exe'
+3. Verify the downloaded installers/archives matches the following CHECKSUM_TYPE checksum:
+   - 32-Bit Checksum: <32BIT_CHECKSUM>
+   - 64-Bit Checksum: <64BIT_CHECKSUM>
+
+Additionally, the included 'LICENSE.txt' have been obtained from <https://github.com/nodejs/node/blob/03023fa7ae060c082a014f792d5d1f481a599460/LICENSE>.

--- a/automatic/nodejs.install/legal/VERIFICATION.x64.txt
+++ b/automatic/nodejs.install/legal/VERIFICATION.x64.txt
@@ -1,0 +1,16 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's content are trustworthy.
+
+The installer/archive has been downloaded from the authors official download link listed on <https://nodejs.org/en/download/prebuilt-installer>
+and can be verified using the following:
+
+1. Download the following installers/archives
+   - 64-Bit: <DIRECT_64BIT_DOWNLOAD_URL>
+2. Use one of the following methods to obtain the checksum
+   - Use powershell function 'Get-FileHash'
+   - Use chocolatey utility 'checksum.exe'
+3. Verify the downloaded installers/archives matches the following CHECKSUM_TYPE checksum:
+   - 64-Bit Checksum: <64BIT_CHECKSUM>
+
+Additionally, the included 'LICENSE.txt' have been obtained from <https://github.com/nodejs/node/blob/03023fa7ae060c082a014f792d5d1f481a599460/LICENSE>.

--- a/automatic/nodejs.install/tools/chocolateyInstall.ps1
+++ b/automatic/nodejs.install/tools/chocolateyInstall.ps1
@@ -1,21 +1,16 @@
-﻿$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Stop'
 
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
-
-$filePath32 = "$toolsPath\node-v20.18.0-x86.msi"
-$filePath64 = "$toolsPath\node-v20.18.0-x64.msi"
-$installFile = if ((Get-OSArchitectureWidth 64) -and $env:chocolateyForceX86 -ne 'true') {
-                      Write-Host "Installing 64 bit version"; $filePath64 }
-               else { Write-Host "Installing 32 bit version"; $filePath32 }
 
 $packageArgs = @{
   PackageName    = 'nodejs.install'
   FileType       = 'msi'
   SoftwareName   = 'Node.js'
-  File           = $installFile
+  File           = "$toolsPath\"
+  File64         = "$toolsPath\"
   SilentArgs     = '/quiet ADDLOCAL=ALL'
   ValidExitCodes = @(0)
 }
 Install-ChocolateyInstallPackage @packageArgs
 
-Remove-Item -Force $filePath32, $filePath64 -ea 0
+Remove-Item -Force "$toolsPath\*.exe","$toolsPath\*.msi" -ea 0

--- a/automatic/nodejs/README.md
+++ b/automatic/nodejs/README.md
@@ -8,6 +8,7 @@ This package runs the official Node JS installer, resulting in Node.exe and NPM 
 ## Notes
 
 - While this package now provides both **Current** and **LTS** releases of Node.js, it is still recommended to use the [nodejs-lts][] package if only targeting the latest LTS release is required.
-- - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
+- Starting with version 23.x, installations for 32bit platforms are no longer supported. If this is required, an older version is required to be used.
+- **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 
 [nodejs-lts]: https://chocolatey.org/packages/nodejs-lts "Node.js LTS Package"


### PR DESCRIPTION
## Description

This updates the NodeJS updater to support version 23 of the
application, while still keeping support for older versions.

This also refreshes the VERIFICATION.txt used, as well as the install
script to make use of a more (upcoming) standardized template.

fixes #2556

## Motivation and Context

To continue publishing versions of the NodeJS package.

## How Has this Been Tested?

Only the updater has been tested.

1. Run `.\update_all.ps1 -ForcedPackages 'nodejs.install\23' nodejs.install`
2. Verify the package was properly updated to v23.x of NodeJS
3. Run `.\update_all.ps1 -ForcedPackages 'nodejs.install\23' nodejs.install`
4. Verify the packgae was properly updated to v22.x of NodeJS
5. Repeat step 1-2.
6. Repeat steps 1-5 using `nodejs` instead of `nodejs.install`

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

