### PR TITLE
(inkscape) drop 32 bit support

### DIFF
--- a/automatic/inkscape/README.md
+++ b/automatic/inkscape/README.md
@@ -25,3 +25,4 @@ All Inkscape projects may be exported in formats friendly to web browsers or com
 
 * This software cannot be reinstalled even with the package `--force` option. The installer will not run when the same version is already installed. If you need to reinstall this software, please uninstall the package and then install it again.
 * **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
+* Starting with version 1.4.x, installers for 32bit platforms are no longer available. If this is required, use an older version of the package.

--- a/automatic/inkscape/tools/chocolateyInstall.ps1
+++ b/automatic/inkscape/tools/chocolateyInstall.ps1
@@ -5,9 +5,6 @@ $toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'msi'
-  url            = 'https://inkscape.org/gallery/item/44620/inkscape-1.3.2_2023-11-25_091e20ef0f-x86.msi'
-  checksum       = 'ADA39E3C380AF0E316630D33D31804A320E06D3EC5D8C093CBBC19A1276F81EE'
-  checksumType   = 'sha256'
   file64         = "$toolsPath\inkscape-1.3.2_2023-11-25_091e20e-x64.msi"
   softwareName   = 'InkScape*'
   silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).MsiInstall.log`" ALLUSERS=1"
@@ -37,12 +34,7 @@ elseif ($key.Count -gt 1) {
   Write-Warning "Please uninstall InkScape before installing this package."
 }
 
-if ((Get-OSArchitectureWidth 32) -or ($env:chocolateyForceX86 -eq $true)) {
-  Install-ChocolateyPackage @packageArgs
-}
-else {
-  Install-ChocolateyInstallPackage @packageArgs
-}
+Install-ChocolateyInstallPackage @packageArgs
 
 Get-ChildItem $toolsPath\*.msi | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" } }
 


### PR DESCRIPTION


## Description

As the 32bit version of inkscape has been dropped, remove support from package.

## Motivation and Context

Fixes  #2552

## How Has this Been Tested?

Tested on Win10 22H2 and in test env

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

