### PR TITLE
(mkvtoolnix) fix AU script

### DIFF
--- a/automatic/mkvtoolnix/update.ps1
+++ b/automatic/mkvtoolnix/update.ps1
@@ -1,7 +1,7 @@
 ﻿Import-Module Chocolatey-AU
 
 $domain = 'https://mkvtoolnix.download'
-$releases = "$domain/windows/releases"
+$releases = "$domain/windows/releases/"
 
 
 function global:au_SearchReplace {


### PR DESCRIPTION
## Description

Updates the AU script to work again

## Motivation and Context

Fixes #2570

Looks like there was a breaking change on the releases website, it now requires a trailing slash.

## How Has this Been Tested?

Tested on Win10 and in test env

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).


