### PR TITLE
(virtualbox) fix au script

### DIFF
--- a/automatic/virtualbox/update.ps1
+++ b/automatic/virtualbox/update.ps1
@@ -11,9 +11,20 @@ function GetLatest {
   $url      = $download_page.links | Where-Object href -match '\.exe$' | Select-Object -first 1 -expand href
   $version  = $url -split '/' | Select-Object -Last 1 -Skip 1
   $base_url = $url -replace '[^/]+$'
+  
+  $majorVersion = $version.split("\.") | Select-Object -First 1
+  $minorVersion = $version.split("\.") | Select-Object -First 1 -Skip 1
+  if ([int]$majorVersion -gt 7) {
+      $URLep = "${base_url}Oracle_VirtualBox_Extension_Pack-${version}.vbox-extpack"
+  } elseif (([int]$majorVersion -eq 7) -and ([int]$minorVersion -ge 1)) {
+      $URLep = "${base_url}Oracle_VirtualBox_Extension_Pack-${version}.vbox-extpack"
+  } else {
+      $URLep = "${base_url}Oracle_VM_VirtualBox_Extension_Pack-${version}.vbox-extpack"
+  }
+  
   @{
     URL32         = $url
-    URLep         = "${base_url}Oracle_VM_VirtualBox_Extension_Pack-${version}.vbox-extpack"
+    URLep         = $URLep
     Version       = $version
   }
 }


### PR DESCRIPTION

## Description

The virtualbox extension package changed naming conventions with the v7.1 release. This updates the AU script to reflect that changed convention.

## Motivation and Context

Fixes #2545

## How Has this Been Tested?

Tested on Win10 and in test env

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

