### PR TITLE
(python3-streams) fix AU script

### DIFF
--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -42,14 +42,14 @@ function SetCopyright {
   $zip = [IO.Compression.ZipArchive]::new($response_stream)
 
   # license text for legal/LICENSE.txt
-  $license_entry = $zip.GetEntry("$($Latest.ZipName)/license.txt")
+  $license_entry = $zip.Entries | Where-Object Name -eq "license.txt"
   $Latest.License = [System.IO.StreamReader]::new($license_entry.Open()).ReadToEnd()
   if (!$Latest.License.Contains($license_statement)) {
     throw "Python's license may have changed."
   }
 
   # copyright information for nuspec
-  $copyright_entry = $zip.GetEntry("$($Latest.ZipName)/copyright.txt")
+  $copyright_entry = $zip.Entries | Where-Object Name -eq "copyright.txt"
   $reader = [System.IO.StreamReader]::new($copyright_entry.Open())
   (1..5) | ForEach-Object {$reader.ReadLine()}  # skip header
   $copyright = ''


### PR DESCRIPTION
## Description

The zip directory naming is inconsistent, this directly uses the filenames to find the appropriate license and copyright files.

## Motivation and Context

Fixes #2555

## How Has this Been Tested?

Tested on Win10 and in test env

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

