### PR TITLE
(php) Add vcredist version for PHP 8.4

### DIFF
--- a/automatic/php/update.ps1
+++ b/automatic/php/update.ps1
@@ -56,6 +56,7 @@ function Get-Dependency() {
   $dep = $url -split '\-' | Select-Object -last 1 -skip 1
 
   $result = @{
+    'vs17' = @{ Id = 'vcredist140'; Version = '14.42.34433' }
     'vs16' = @{ Id = 'vcredist140'; Version = '14.28.29325.2' }
     'vc15' = @{ Id = 'vcredist140'; Version = '14.16.27012.6' }
     'vc14' = @{ Id = 'vcredist140'; Version = '14.0.24215.1' }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
Added `vcredist` version for PHP 8.4

## Motivation and Context
PHP 8.4 uses` vs17`, so the `php` update script needs to have a `vcredist` version for that.

## How Has this Been Tested?
By running the update script and generating the packages locally.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).