### PR TITLE
(chocolatey-packages) Update security protocol handling in test_all.ps1 for PowerShell 6+

### DIFF
--- a/test_all.ps1
+++ b/test_all.ps1
@@ -75,10 +75,14 @@ $options = [ordered]@{
   }
 }
 
-[System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor
-  768 -bor
-  [System.Net.SecurityProtocolType]::Tls -bor
-  [System.Net.SecurityProtocolType]::Ssl3
+# https://github.com/majkinetor/au/issues/142
+
+if ($PSVersionTable.PSVersion.major -ge 6) {
+  $AvailableTls = [enum]::GetValues('Net.SecurityProtocolType') | Where-Object { $_ -ge 'Tls' } # PowerShell 6+ does not support SSL3, so use TLS minimum
+  $AvailableTls.ForEach({[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor $_})
+} else {
+  [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor [System.Net.SecurityProtocolType]::Tls -bor [System.Net.SecurityProtocolType]::Ssl3
+}
 
 $global:info = updateall -Name $Name -Options $Options
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description

The test_all.ps1 script fails to set the appropriate security protocols for PowerShell versions earlier than 6. This pull request backports a fix from [chocolatey-au](https://github.com/majkinetor/au/issues/142).

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

This change fixes a problem I experienced when testing locally.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

I tested this locally. Making the change made the error go away and set the security protocols correctly.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).