### PR TITLE
(python3-streams) Fix copyright reading logic and zip URL generation in python3-streams

### DIFF
--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -37,6 +37,7 @@ function global:au_SearchReplace {
 
 function SetCopyright {
   # download Python documentation archive
+  Add-Content -Path ".\log.txt" -Value "Downloading $($Latest.ZipUrl)"
   $webrequest = [System.Net.HttpWebRequest]::Create($Latest.ZipUrl)
   $response_stream = $webrequest.GetResponse().GetResponseStream()
   $zip = [IO.Compression.ZipArchive]::new($response_stream)
@@ -140,7 +141,11 @@ function GetStreams() {
     $version = Get-Version $latest_version
 
     $urls = $all_versions[$latest_version]
-    $zip_name = "python-$versionTwoPart-docs-text"
+    if ($minor_version -le '12') {
+      $zip_name = "python-$latest_version-docs-text"
+    } else {
+      $zip_name = "python-$versionTwoPart-docs-text"
+    }
     $zip_url = "https://docs.python.org/$versionTwoPart/archives/$zip_name.zip"
     $license_url = "https://docs.python.org/$versionTwoPart/license.html"
     $streams[$versionTwoPart] = @{

--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -54,7 +54,7 @@ function SetCopyright {
   (1..5) | ForEach-Object {$reader.ReadLine()}  # skip header
   $copyright = ''
   $reading_copyright = $false
-  while (($line = $reader.ReadLine()) -ne $null) {
+  while ($null -ne ($line = $reader.ReadLine())) {
     if (!$line) {
       $copyright += "`n"
       $reading_copyright = $false
@@ -140,12 +140,8 @@ function GetStreams() {
     $version = Get-Version $latest_version
 
     $urls = $all_versions[$latest_version]
-    $zip_name = "python-$latest_version-docs-text"
-    if ($version.Prerelease -eq "" -or $version.Prerelease.StartsWith("rc")) {
-      $zip_url = "https://www.python.org/ftp/python/doc/$latest_version/$zip_name.zip"
-    } else {
-      $zip_url = "https://docs.python.org/$versionTwoPart/archives/$zip_name.zip"
-    }
+    $zip_name = "python-$versionTwoPart-docs-text"
+    $zip_url = "https://docs.python.org/$versionTwoPart/archives/$zip_name.zip"
     $license_url = "https://docs.python.org/$versionTwoPart/license.html"
     $streams[$versionTwoPart] = @{
       URL32          = $urls['86']

--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -37,7 +37,6 @@ function global:au_SearchReplace {
 
 function SetCopyright {
   # download Python documentation archive
-  Add-Content -Path ".\log.txt" -Value "Downloading $($Latest.ZipUrl)"
   $webrequest = [System.Net.HttpWebRequest]::Create($Latest.ZipUrl)
   $response_stream = $webrequest.GetResponse().GetResponseStream()
   $zip = [IO.Compression.ZipArchive]::new($response_stream)
@@ -141,7 +140,7 @@ function GetStreams() {
     $version = Get-Version $latest_version
 
     $urls = $all_versions[$latest_version]
-    if ($minor_version -le '12') {
+    if ($minor_version -le '11') {
       $zip_name = "python-$latest_version-docs-text"
     } else {
       $zip_name = "python-$versionTwoPart-docs-text"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->

As per [CPython issue #2672](https://github.com/python/pythondotorg/issues/2672), alpha and beta builds have no official docs built. Furthermore, as of [CPython PR #124489](https://github.com/python/cpython/pull/124489), the archives we previously referenced are no longer built. The change applies from Python 3.12 onwards based on what I can see in the docs archive.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

The more recent versions of Python do not get packages built, as per [Issue #2555](https://github.com/chocolatey-community/chocolatey-packages/issues/2555). The [previous PR](https://github.com/chocolatey-community/chocolatey-packages/pull/2575) did not work for the 3.14 alpha releases and, based on the CPython issue, may continue to break for new releases.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

I tested the Python3 update script directly and saw the correct versions referenced. I then tested via test_all.ps1 and again saw the correct versions referenced. I then used the generated package files and ran a local test install. I'm running PowerShell 7.4.6 on Windows 11.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [X] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).