### PR TITLE
(alldup) Fix use of the innerText property

### DIFF
--- a/automatic/alldup/update.ps1
+++ b/automatic/alldup/update.ps1
@@ -19,7 +19,7 @@ function global:au_GetLatest {
 
   $re = 'alldup.*\.exe$'
   $url     = $download_page.links | Where-Object href -match $re | Select-Object -First 1 -expand href
-  $version = $download_page.links | Where-Object href -match "alldup_version\.php$" | Select-Object -first 1 -expand innerText
+  $version = ($download_page.links | Where-Object href -match "alldup_version\.php$" | Select-Object -first 1).outerHTML -replace '<[^>]*>'
 
   @{ URL32 = $url; Version = $version }
 }


### PR DESCRIPTION
## Description
Switch to using the outerHTML property instead of the abandoned innerText property.

## Motivation and Context
PowerShell Core switched from the Internet Explorer COM Object to a cross-platform implementation, meaning innerText no longer exists.

## How Has this Been Tested?
Tested the `update.ps1` script locally.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).