### PR TITLE
(ant-renamer) Fix file download

### DIFF
--- a/automatic/ant-renamer/update.ps1
+++ b/automatic/ant-renamer/update.ps1
@@ -29,7 +29,14 @@ function global:au_GetLatest {
 
     $version  = [regex]::Match($download_page.Content, "Version\s+([0-9\.]+)").Groups[1].Value;
 
-    return @{ URL32 = $url; Version = $version }
+    $FileName = $url -split '/' | Select-Object -Last 1
+
+    return @{
+      URL32    = $url
+      FileName = $FileName
+      FileType = 'exe'
+      Version  = $version
+    }
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
## Description
Ant Renamer is hosted on SourceForge. The download function fails because the file type is detected as exe/download, as with all SourceForge URLs.

## Motivation and Context
Fix the broken automatic update function.

## How Has this Been Tested?
Tested the `update.ps1` script, which successfully updates to version 2.13.0.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).