### PR TITLE
(autohotkey) Fix AutoHotkey version retrieval

### DIFF
--- a/automatic/autohotkey.install/update.ps1
+++ b/automatic/autohotkey.install/update.ps1
@@ -1,6 +1,5 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = 'https://autohotkey.com/download/2.0'
 $v1Version = '1.1.36.02'
 $v1Filename = "AutoHotkey_$($v1Version)_setup.exe"
 

--- a/automatic/autohotkey.install/update.ps1
+++ b/automatic/autohotkey.install/update.ps1
@@ -44,8 +44,9 @@ function global:au_BeforeUpdate {
 }
 
 function global:au_GetLatest {
-    $version = Invoke-WebRequest -Uri "$releases\version.txt" -UseBasicParsing | ForEach-Object Content
-    $url     = "https://github.com/AutoHotkey/AutoHotkey/releases/download/v$($version)/AutoHotkey_$($version)_setup.exe"
+  $releaseInformation = Invoke-RestMethod -Uri 'https://api.github.com/repos/AutoHotkey/AutoHotKey/releases'
+    $version = $releaseInformation[0].tag_name -replace 'v'
+    $url     = ($releaseInformation[0].assets | Where-Object -Property name -Like '*.exe').browser_download_url
     @{
         Version  = $version
         URL      = $url


### PR DESCRIPTION
## Description
The AutoHotKey version detection relies on the AutoHotKey website, which is protected by CloudFlare. This change modifies the process to use the GitHub API instead.

## Motivation and Context
AutoHotKey version detection is broken.

## How Has this Been Tested?
Executed the `update.ps1` script locally.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).