### PR TITLE
(azcopy) Fix script to handle URL redirection in PowerShell Core

### DIFF
--- a/automatic/azcopy10/update.ps1
+++ b/automatic/azcopy10/update.ps1
@@ -2,34 +2,6 @@
 
 $releases = 'https://aka.ms/downloadazcopy-v10-windows'
 
-# Define a function to handle the 301 redirection and retrieve headers
-function Get-RedirectedUrl {
-  param (
-      [string]$Url
-  )
-  # Use .NET HttpClient for better control
-  $handler = New-Object System.Net.Http.HttpClientHandler
-  $handler.AllowAutoRedirect = $false  # Prevent auto-following redirects
-
-  $client = New-Object System.Net.Http.HttpClient($handler)
-
-  try {
-      # Create a HEAD request
-      $request = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Head, $Url)
-      $response = $client.SendAsync($request).Result
-
-      if ($response.StatusCode -eq [System.Net.HttpStatusCode]::MovedPermanently -or `
-          $response.StatusCode -eq [System.Net.HttpStatusCode]::Found) {
-          return $response.Headers.Location.AbsoluteUri
-      } else {
-          throw "Unexpected status code: $($response.StatusCode)"
-      }
-  }
-  finally {
-      $client.Dispose()
-  }
-}
-
 function global:au_GetLatest {
     $url64 = Get-RedirectedUrl -Url $releases
     $url32 = $url64 -replace "amd64", "386"


### PR DESCRIPTION
## Description
The script fails in PowerShell Core because of the change to how redirects are handled by Invoke-WebRequest. This change uses System.Net objects to avoid this behaviour.

## Motivation and Context
Fix the script to work in PowerShell Core.

## How Has this Been Tested?
Executed `update.ps1` locally.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).