### PR TITLE
(calibre) Fix version parsing

### DIFF
--- a/automatic/calibre/update.ps1
+++ b/automatic/calibre/update.ps1
@@ -26,7 +26,7 @@ function global:au_GetLatest {
     $versionHyperlink = $download_page.links | Select-Object -First 1
     if ($versionHyperlink.Title -notmatch 'Release (7[\d\.]+)' ) { throw "Calibre version 7.x not found on $releases" }
 
-    $version = $versionHyperlink.InnerText
+    $version = ($versionHyperlink.outerHTML) -replace '<[^>]+>'
     $url64   = 'https://download.calibre-ebook.com/<version>/calibre-64bit-<version>.msi'
     $url64   = $url64 -replace '<version>', $version
 


### PR DESCRIPTION
## Description
The version detection for calibre uses innerText, which does not exist in PowerShell Core.

## Motivation and Context
Fix the version detection so it works with PowerShell Core.

## How Has this Been Tested?
Executed the `update.ps1` script locally.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).