### PR TITLE
(clementine) Fix version checks

### DIFF
--- a/automatic/clementine/update.ps1
+++ b/automatic/clementine/update.ps1
@@ -1,6 +1,7 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = 'https://www.clementine-player.org/downloads'
+$releases = 'https://api.github.com/repos/clementine-player/Clementine/releases'
+$publicReleases = 'https://www.clementine-player.org/downloads'
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge
@@ -14,7 +15,7 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt" = @{
-      "(?i)(^\s*location on\:?\s*)\<.*\>" = "`${1}<$releases>"
+      "(?i)(^\s*location on\:?\s*)\<.*\>" = "`${1}<$publicReleases>"
       "(?i)(\s*1\..+)\<.*\>"              = "`${1}<$($Latest.URL32)>"
       "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType32)"
       "(?i)(^\s*checksum(32)?\:).*"       = "`${1} $($Latest.Checksum32)"
@@ -25,15 +26,34 @@ function global:au_SearchReplace {
   }
 }
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-
-  $re      = '\.exe$'
-  $url     = $download_page.links | ? href -match $re | select -First 1 -expand href
-  $version = Split-Path (Split-Path $url) -Leaf
-  @{
-    URL32 = $url
-    Version = $version
+  $download_page = Invoke-RestMethod -Uri $releases
+  $streams = @{}
+  $download_page | ForEach-Object {
+    if ($_.prerelease -eq $True) {
+      $key = "pre"
+      $version = $_.tag_name -replace '-[^-]+$' -replace '([0-9]+)\.([0-9]+)\.([0-9]+)(rc[0-9]+)-([0-9]+)', '$1.$2.$3.$5-$4'
+    }
+    else {
+      $key = "stable"
+      $version = $_.tag_name -replace '-[^-]+$' -replace '-', '.'
+    }
+    $url = $_.assets | Where-Object { $_.name -match '\.exe$' } | Select-Object -First 1 -ExpandProperty browser_download_url
+    if ($url -and !$streams.ContainsKey($key)) {
+      $streams.Add($key, @{
+        Version = $version
+        URL32 = $url
+      })
+    }
   }
+  return @{ Streams = $streams }
+
+  # $re      = '\.exe$'
+  # $url     = $download_page.links | ? href -match $re | select -First 1 -expand href
+  # $version = Split-Path (Split-Path $url) -Leaf
+  # @{
+  #   URL32 = $url
+  #   Version = $version
+  # }
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
## Description
The version check is stuck on 1.3.1. This change attempts to use the GitHub API to retrieve the latest version.

## Motivation and Context
Clementine is stuck on an old version, several years out of date.

## How Has this Been Tested?
Executed `update.ps1` locally.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).