### PR TITLE
(cygwin) Avoid using innerText

### DIFF
--- a/automatic/cygwin/update.ps1
+++ b/automatic/cygwin/update.ps1
@@ -38,7 +38,7 @@ function global:au_GetLatest {
   $result = @{
     URL64        = $url | Where-Object {$_ -match 'x86_64' } | Select-Object -First 1
     ReleaseNotes = $rn.href
-    Version      = $rn.innerText
+    Version      = $rn.outerHTML -replace '<[^>]+>'
     PackageName  = 'Cygwin'
   }
 


### PR DESCRIPTION
## Description
Use outerHTML instead of innerText to work with PowerShell Core.

## Motivation and Context
The update script does not work with PowerShell Core.

## How Has this Been Tested?
Executed `update.ps1` locally.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).