### PR TITLE
(waterfox) Get-GitHubRelease require switches

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 */jubler*             @AdmiringWorm
 */juju*               @AdmiringWorm
 */transifex*          @chocolatey-community/chocolatey-team-maintainers
-*/waterfox*           @AdmiringWorm
+*/waterfox*           @AdmiringWorm @tunisiano187
 */composer*           @johnstevenson
 */k9s*                @danielkoek
 */krew*               @jetersen

--- a/automatic/waterfox/update.ps1
+++ b/automatic/waterfox/update.ps1
@@ -48,7 +48,7 @@ function Get-Waterfox {
   )
   switch ($Build) {
     "Classic" {
-      $LatestRelease = Get-GitHubRelease WaterfoxCo Waterfox-Classic
+      $LatestRelease = Get-GitHubRelease -OwnerName WaterfoxCo -RepositoryName Waterfox-Classic
 
       @{
         PackageName = "waterfox-classic"
@@ -61,7 +61,7 @@ function Get-Waterfox {
     }
 
     "Current" {
-      $LatestRelease = Get-GitHubRelease WaterfoxCo Waterfox
+      $LatestRelease = Get-GitHubRelease -OwnerName WaterfoxCo -RepositoryName Waterfox
       $TagVersion = $LatestRelease.tag_name
 
       @{


### PR DESCRIPTION
## Description
The Get-GithubRelease needs the -owner... switches

## Motivation and Context
fixes https://github.com/chocolatey-community/chocolatey-packages/issues/2584

## How Has this Been Tested?
On my computer

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [X] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [X] The changes only affect a single package (not including meta package).