### PR TITLE
(vcredist140) remove old os version checks

### DIFF
--- a/automatic/vcredist140/tools/chocolateyInstall.ps1
+++ b/automatic/vcredist140/tools/chocolateyInstall.ps1
@@ -8,30 +8,6 @@ $silentArgs = '/quiet /norestart'
 $validExitCodes = @(0, 1638, 3010)
 $force = $Env:chocolateyPackageParameters -like '*Force*'
 
-Write-Verbose 'Checking Service Pack requirements'
-$os = Get-WmiObject -Class Win32_OperatingSystem
-$version = [Version]$os.Version
-if ($version -ge [Version]'6.1' -and $version -lt [Version]'6.2' -and $os.ServicePackMajorVersion -lt 1)
-{
-  # On Windows 7 / Server 2008 R2, Service Pack 1 is required.
-  throw 'This package requires Service Pack 1 to be installed first. The "KB976932" package may be used to install it.'
-}
-elseif ($version -ge [Version]'6.0' -and $version -lt [Version]'6.1' -and $os.ServicePackMajorVersion -lt 2)
-{
-  # On Windows Vista / Server 2008, Service Pack 2 is required.
-  throw 'This package requires Service Pack 2 to be installed first.'
-}
-elseif ($version -ge [Version]'5.2' -and $version -lt [Version]'6.0' -and $os.ServicePackMajorVersion -lt 2)
-{
-  # On Windows Server 2003 / XP x64, Service Pack 2 is required.
-  throw 'This package requires Service Pack 2 to be installed first.'
-}
-elseif ($version -ge [Version]'5.1' -and $version -lt [Version]'5.2' -and $os.ServicePackMajorVersion -lt 3)
-{
-  # On Windows XP, Service Pack 3 is required.
-  throw 'This package requires Service Pack 3 to be installed first.'
-}
-
 $runtimes = @{
   'x64' = @{ RegistryPresent = $false; RegistryVersion = $null; DllVersion = $null; InstallData = $installData64; Applicable = ((Get-OSArchitectureWidth) -eq 64) -and ($env:chocolateyForceX86 -ne 'true') }
   'x86' = @{ RegistryPresent = $false; RegistryVersion = $null; DllVersion = $null; InstallData = $installData32; Applicable = $true }


### PR DESCRIPTION
## Description

Removes old OS version checks 

## Motivation and Context

As Windows XP, vista and 7 are no longer supported by current versions of Chocolatey CLI, the checks in this package can be removed for these older OS versions. These checks are not supported in windows sandbox currently, as per #2618 

https://docs.chocolatey.org/en-us/chocolatey-components-dependencies-and-support-lifecycle/

Fixes #2618 

## How Has this Been Tested?

Package tested on Win 10 and in test env

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
