### PR TITLE
(python3-streams) Fix Python 3 License Parsing

### DIFF
--- a/automatic/python/README.md
+++ b/automatic/python/README.md
@@ -1,4 +1,4 @@
-# <img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/python.svg" width="48" height="48"/> [python](https://chocolatey.org/packages/python)
+# <img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/python.svg" width="48" height="48" alt="Python logo"/> [python](https://chocolatey.org/packages/python)
 
 Python is a programming language that lets you work more quickly and integrate your systems more effectively. You can learn to use Python and see almost immediate gains in productivity and lower maintenance costs.
 

--- a/automatic/python3-streams/README.md
+++ b/automatic/python3-streams/README.md
@@ -1,4 +1,4 @@
-# <img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/python.svg" width="48" height="48"/> [python314](https://community.chocolatey.org/packages/python314)
+# <img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/python.svg" width="48" height="48" alt="Python logo"/> [python314](https://community.chocolatey.org/packages/python314)
 
 Python 3.x is a programming language that lets you work more quickly and integrate your systems more effectively. You can learn to use Python 3.x and see almost immediate gains in productivity and lower maintenance costs.
 

--- a/automatic/python3-streams/tools/chocolateyInstall.ps1
+++ b/automatic/python3-streams/tools/chocolateyInstall.ps1
@@ -37,7 +37,7 @@ if ($installLocation -ne $installDir) {
 }
 else { Write-Host "Python installed to: '$installDir'" }
 
-if (($Env:PYTHONHOME -ne $null) -and ($Env:PYTHONHOME -ne $InstallDir)) {
+if (($null -ne $Env:PYTHONHOME) -and ($Env:PYTHONHOME -ne $InstallDir)) {
   Write-Warning "Environment variable PYTHONHOME points to different version: $Env:PYTHONHOME"
 }
 
@@ -48,6 +48,5 @@ if ($pp.NoLockdown) {
   Protect-InstallFolder `
     -packageName $env:ChocolateyPackageName `
     -defaultInstallPath $defaultFolder `
-    -folder $installLocation  
+    -folder $installLocation
 }
-

--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -3,6 +3,7 @@
 Add-Type -Assembly System.IO.Compression
 
 $release_files_url = 'https://www.python.org/api/v2/downloads/release_file/'
+$old_license_statement = "`nPSF LICENSE AGREEMENT FOR PYTHON"
 $license_statement = "PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2"
 
 if ($MyInvocation.MyCommand -ne '.') {
@@ -44,7 +45,7 @@ function SetCopyright {
   # license text for legal/LICENSE.txt
   $license_entry = $zip.GetEntry("$($Latest.ZipName)/license.txt")
   $Latest.License = [System.IO.StreamReader]::new($license_entry.Open()).ReadToEnd()
-  if (!$Latest.License.Contains($license_statement)) {
+  if (!$Latest.License.Contains($license_statement) -and !$Latest.License.Contains($old_license_statement)) {
     throw "Python's license may have changed."
   }
 

--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -3,7 +3,7 @@
 Add-Type -Assembly System.IO.Compression
 
 $release_files_url = 'https://www.python.org/api/v2/downloads/release_file/'
-$license_statement = "`nPSF LICENSE AGREEMENT FOR PYTHON"
+$license_statement = "PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2"
 
 if ($MyInvocation.MyCommand -ne '.') {
 function global:au_SearchReplace {

--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -132,9 +132,9 @@ function GetStreams() {
     }
   }
 
-  $streams = @{ }
+  $streams = [ordered]@{}
 
-  $latest_versions.GetEnumerator() | ForEach-Object {
+  $latest_versions.GetEnumerator() | Sort-Object { [int]$_.Name } -Descending | ForEach-Object {
     $minor_version = $_.Name
     $latest_version = $_.Value
     $versionTwoPart = "3.$minor_version"

--- a/automatic/python3-streams/update.ps1
+++ b/automatic/python3-streams/update.ps1
@@ -45,6 +45,8 @@ function SetCopyright {
   # license text for legal/LICENSE.txt
   $license_entry = $zip.GetEntry("$($Latest.ZipName)/license.txt")
   $Latest.License = [System.IO.StreamReader]::new($license_entry.Open()).ReadToEnd()
+  Remove-Item "$PSScriptRoot\legal\LICENSE.txt" -Force
+  [System.IO.File]::WriteAllText("$PSScriptRoot\legal\LICENSE.txt", $Latest.License)
   if (!$Latest.License.Contains($license_statement) -and !$Latest.License.Contains($old_license_statement)) {
     throw "Python's license may have changed."
   }

--- a/automatic/python3/README.md
+++ b/automatic/python3/README.md
@@ -1,4 +1,4 @@
-  # <img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/python.svg" width="48" height="48"/> [python3](https://chocolatey.org/packages/python3)
+  # <img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/python.svg" width="48" height="48" alt="Python logo"/> [python3](https://chocolatey.org/packages/python3)
 
   Python 3.x is a programming language that lets you work more quickly and integrate your systems more effectively. You can learn to use Python 3.x and see almost immediate gains in productivity and lower maintenance costs.
 


### PR DESCRIPTION
## Description
The Python license has changed. This has broken the parsing logic and new versions are failing to be picked up by the automatic updater.

## Motivation and Context
Python 3.13.2, 3.12.9, 3.11.11, and 3.11.10 have all been missed by the automatic updater. This change fixes the logic so the packages will be correctly created.

## How Has this Been Tested?
I ran the `update.ps1` script and `update_all.ps1` and confirmed that the packages are correctly created.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).