### PR TITLE
(doc) Updated docs and PR template to confirm PR's should not come from master

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@
 - [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
 - [ ] I have updated the package description and it is less than 4000 characters.
 - [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
-- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
+- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
 - [ ] The changes only affect a single package (not including meta package).
 
 <!-- The following section can be removed if the package has not been migrated from another location -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,7 @@
 ## Checklist:
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My pull request is not coming from the master branch.
 - [ ] My code follows the code style of this repository.
 - [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
 - [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,7 @@ Additionally, if a user is assigned to an issue, it will not be automatically ma
 Pull requests fixing a bug or an outdated package do not need to have an associated issue.
 
 **Do not open a pull request when there is already an open pull request for the same issue or bug, as this will lead to your pull request being closed.**
+**Do create a branch for your pull request and not open it from the master branch, as we cannot accept pull requests from the master branch.**
 
 When opening a new pull request, you are required to input all the information requested by the pull request template used.
 An existing issue marked by a maintainer with `up for grabs` or `0 - Backlog` must exist before opening a pull request for new features, enhancements, or migrating a package.
@@ -144,7 +145,7 @@ However, suppose you open a pull request without an associated issue. In that ca
 Your changes should only affect a single package unless the package(s) in question consists of a meta, `.install` and `.portable` package. In this case, you can submit all three packages in the same pull request.
 There may also be other exceptions, but these will be on a case-by-case basis only when approved by a repository maintainer.
 
-Read the [Code Conventions](#code-conventions) before opening the pull request.
+Read the [Code Conventions](#conventions--guidelines) before opening the pull request.
 
 ### Pull Request Title
 


### PR DESCRIPTION
## Description
Document that master should not be used for PR's.

## Motivation and Context
This is tribal knowledge, but is not officially documented.

## How Has this Been Tested?
N/A

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).
