### PR TITLE
(zotero) add 64-bit installer option (re-re-try)

### DIFF
--- a/automatic/zotero/legal/LICENSE.txt
+++ b/automatic/zotero/legal/LICENSE.txt
@@ -1,12 +1,15 @@
-Zotero is Copyright © 2006, 2007, 2008, 2009, 2010, 2011
-Center for History and New Media, George Mason University,
+Zotero is Copyright © 2018 Corporation for Digital Scholarship, 
+Vienna, Virginia, USA http://digitalscholar.org
+
+Copyright © 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017
+Roy Rosenzweig Center for History and New Media, George Mason University,
 Fairfax, Virginia, USA  http://zotero.org
 
-The Center for History and New Media distributes the Zotero source code
+The Corporation for Digital Scholarship distributes the Zotero source code
 under the GNU Affero General Public License, version 3 (AGPLv3). The full text
 of this license is given below.
 
-The Zotero name is a registered trademark of George Mason University.
+The Zotero name is a registered trademark of the Corporation for Digital Scholarship.
 See http://zotero.org/trademark for more information.
 
 Third-party copyright in this distribution is noted where applicable.
@@ -676,3 +679,4 @@ specific requirements.
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
 <http://www.gnu.org/licenses/>.
+

--- a/automatic/zotero/legal/VERIFICATION.txt
+++ b/automatic/zotero/legal/VERIFICATION.txt
@@ -2,17 +2,22 @@ VERIFICATION
 Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
-The embedded software have been downloaded from the listed download
-location on <https://www.zotero.org/download/> (The listed url gets redirected to another one)
-and can be verified by doing the following:
+Package can be verified like this:
 
-1. Download the following <https://download.zotero.org/client/release/7.0.13/Zotero-7.0.13_win32_setup.exe>
+1. Go to
+
+   x32: https://download.zotero.org/client/release/7.0.13/Zotero-7.0.13_win32_setup.exe
+   x64: https://download.zotero.org/client/release/7.0.13/Zotero-7.0.13_x64_setup.exe
+
+   to download the installer.
+
 2. Get the checksum using one of the following methods:
   - Using powershell function 'Get-FileHash'
   - Use chocolatey utility 'checksum.exe'
 3. The checksums should match the following:
 
-  checksum type: sha256
-  checksum: 4429D3E4CCFCF9AA3BF44381223E469AD3DE9E635158C39E94A2E80BA93A7C66
+  checksum32: 4429D3E4CCFCF9AA3BF44381223E469AD3DE9E635158C39E94A2E80BA93A7C66
+  checksum64: 1525119D643DC6766531DCE53BC315967596E309E1D57DC531774C0CE3B06F5B
 
-The file 'LICENSE.txt' has been obtained from <https://github.com/zotero/zotero/blob/929288f9811a5026053ae154ca08cc4a9da13c52/COPYING>
+The file 'LICENSE.txt' has been obtained from 
+   https://raw.githubusercontent.com/zotero/zotero/refs/heads/main/COPYING

--- a/automatic/zotero/legal/VERIFICATION.txt
+++ b/automatic/zotero/legal/VERIFICATION.txt
@@ -16,6 +16,7 @@ Package can be verified like this:
   - Use chocolatey utility 'checksum.exe'
 3. The checksums should match the following:
 
+  checksum type: SHA256
   checksum32: 4429D3E4CCFCF9AA3BF44381223E469AD3DE9E635158C39E94A2E80BA93A7C66
   checksum64: 1525119D643DC6766531DCE53BC315967596E309E1D57DC531774C0CE3B06F5B
 

--- a/automatic/zotero/tools/chocolateyInstall.ps1
+++ b/automatic/zotero/tools/chocolateyInstall.ps1
@@ -1,16 +1,23 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition
+$File32Name = 'Zotero-7.0.13_win32_setup.exe'
+$File64Name = 'Zotero-7.0.13_x64_setup.exe'
+
+$File32Path = Join-Path $toolsPath $File32Name
+$File64Path = Join-Path $toolsPath $File64Name
 
 $packageArgs = @{
-  packageName    = $env:ChocolateyPackageName
-  fileType       = 'exe'
-  silentArgs     = '/S'
-  validExitCodes = @(0)
-  softwareName   = 'Zotero'
-  file           = "$toolsPath\Zotero-7.0.13_win32_setup.exe"
+   packageName    = $env:ChocolateyPackageName
+   softwareName   = "Zotero*"
+   fileType       = 'exe'
+   file           = "$File32Path"
+   file64         = "$File64Path"
+   silentArgs     = '/S'
+   validExitCodes = @(0)
 }
 
 Install-ChocolateyInstallPackage @packageArgs
 
-Remove-Item -Force -ea 0 "$toolsPath\*.exe","$toolsPath\*.ignore"
+Remove-Item "$File32Path","$File64Path" -Force -ea 0

--- a/automatic/zotero/tools/chocolateyUninstall.ps1
+++ b/automatic/zotero/tools/chocolateyUninstall.ps1
@@ -2,7 +2,7 @@
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
-  softwareName  = 'Zotero'
+  softwareName  = "Zotero*"
   fileType      = 'exe'
   silentArgs    = '/S'
   validExitCodes= @(@(0))
@@ -19,7 +19,7 @@ if ($key.Count -eq 1) {
     Uninstall-ChocolateyPackage @packageArgs
   }
 } elseif ($key.Count -eq 0) {
-  Write-Warning "$packageName has already been uninstalled by other means."
+  Write-Warning "$env:ChocolateyPackageName has already been uninstalled by other means."
 } elseif ($key.Count -gt 1) {
   Write-Warning "$($key.Count) matches found!"
   Write-Warning "To prevent accidental data loss, no programs will be uninstalled."

--- a/automatic/zotero/update.ps1
+++ b/automatic/zotero/update.ps1
@@ -1,42 +1,36 @@
 ﻿Import-Module Chocolatey-AU
 Import-Module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
-$releases = 'https://www.zotero.org/download/client/dl?channel=release&platform=win32'
-$softwareName = 'Zotero'
+$releases = 'https://www.zotero.org/download/client/dl?channel=release&platform=win-x64'
 
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
 function global:au_SearchReplace {
-  $version = $Latest.Version.ToString()
-
   @{
     ".\legal\VERIFICATION.txt" = @{
-      "(?i)(\s*1\..+)\<.*\>" = "`${1}<$($Latest.URL32)>"
-      "(?i)(^\s*checksum\s*type\:).*" = "`${1} $($Latest.ChecksumType32)"
-      "(?i)(^\s*checksum(32)?\:).*" = "`${1} $($Latest.Checksum32)"
+      "(?i)(^\s*x32\:).*" = "`${1} $($Latest.URL32)"
+      "(?i)(^\s*x64\:).*" = "`${1} $($Latest.URL64)"
+      "(?i)(^\s*checksum32\:).*" = "`${1} $($Latest.Checksum32)"
+      "(?i)(^\s*checksum64\:).*" = "`${1} $($Latest.Checksum64)"
     }
     ".\tools\chocolateyInstall.ps1" = @{
-      "(?i)^(\s*softwareName\s*=\s*)'.*'" = "`${1}'$softwareName'"
-      "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName32)`""
-    }
-    ".\tools\chocolateyUninstall.ps1" = @{
-      "(?i)^(\s*softwareName\s*=\s*)'.*'" = "`${1}'$softwareName'"
-    }
-    ".\$($Latest.PackageName).nuspec" = @{
-      "(\<releaseNotes\>).*(\<\/releaseNotes\>)" = "`${1}https://www.zotero.org/support/$($version.Major).$($version.Minor)_changelog`${2}"
+      "(?i)(^[$]File32Name =).*" = "`${1} '$($Latest.URL32.split('/')[-1])'"
+      "(?i)(^[$]File64Name =).*" = "`${1} '$($Latest.URL64.split('/')[-1])'"
     }
   }
 }
 
 function global:au_GetLatest {
-    $url = Get-RedirectedUrl -url $releases
+   $url64 = Get-RedirectedUrl -url $releases
+   $url32 = $url64 -replace 'x64','win32'
 
-    $version  = $url -split '/' | Select-Object -Last 1 -Skip 1
+   $version  = $url64 -split '/' | Where-Object {$_ -match '^\d+\.\d[0-9.]*$'} | Select-Object -Last 1
 
-    @{
-        Version      = $version
-        URL32        = $url
-    }
+   @{
+      Version      = $version
+      URL32        = $url32
+      URL64        = $url64
+   }
 }
 
 update -ChecksumFor none

--- a/automatic/zotero/update.ps1
+++ b/automatic/zotero/update.ps1
@@ -22,7 +22,7 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
    $url64 = Get-RedirectedUrl -url $releases
-   $url32 = $url64 -replace 'x64','win32'
+   $url32 = Get-RedirectedUrl -url $releases.replace('-x64','32')
 
    $version  = $url64 -split '/' | Where-Object {$_ -match '^\d+\.\d[0-9.]*$'} | Select-Object -Last 1
 

--- a/automatic/zotero/zotero.nuspec
+++ b/automatic/zotero/zotero.nuspec
@@ -2,30 +2,32 @@
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
+    <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>zotero</id>
-    <title>Zotero</title>
-    <owners>chocolatey-community</owners>
     <version>7.0.13</version>
-    <authors>Center for History and New Media, et. al.</authors>
-    <summary>Zotero [zoh-TAIR-oh] is a free, easy-to-use tool to help you collect, organize, cite, and share your research sources. </summary>
+    <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/zotero</packageSourceUrl>
+    <owners>chocolatey-community</owners>
+    <!-- == SOFTWARE SPECIFIC SECTION == -->
+    <title>Zotero</title>
+    <authors>Corporation for Digital Scholarship</authors>
+    <projectUrl>https://www.zotero.org/</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@53607633ce049d5d75ac668f4408faaeced36bc3/icons/zotero.png</iconUrl>
+    <copyright>Copyright © 2018 Corporation for Digital Scholarship, Vienna, Virginia, USA. Copyright © 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Roy Rosenzweig Center for History and New Media, George Mason University,Fairfax, Virginia, USA</copyright>
+    <licenseUrl>https://github.com/zotero/zotero/blob/e746da4faba46533f35db7cbe04c91c757134a44/COPYING</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://www.zotero.org/support/dev/source_code</projectSourceUrl>
+    <docsUrl>https://www.zotero.org/support</docsUrl>
+    <mailingListUrl>https://forums.zotero.org/discussions</mailingListUrl>
+    <bugTrackerUrl>https://github.com/zotero/zotero/issues</bugTrackerUrl>
+    <tags>zotero productivity foss cross-platform references manager bibliography citations research embedded</tags>
+    <summary>Zotero [zoh-TAIR-oh] is a free, easy-to-use tool to help you collect, organize, cite, and share your research sources. </summary>
     <!-- Do not touch the description here in the nuspec file. Description is imported during update from the Readme.md file -->
     <description><![CDATA[Zotero is free and open-source reference management software to manage bibliographic data and related research materials (such as PDF files). Notable features include web browser integration, online syncing, generation of in-text citations, footnotes and bibliographies, as well as integration with the word processors Microsoft Word, LibreOffice, OpenOffice.org Writer and NeoOffice.
 
 
 ![screenshot](https://cdn.rawgit.com/chocolatey/chocolatey-coreteampackages/d1d9f0154e370315e49f245a26a7d23e89a705cc/automatic/zotero/screenshot.png)
 ]]></description>
-    <projectUrl>https://www.zotero.org/</projectUrl>
-    <tags>zotero references manager bibliography foss cross-platform admin</tags>
-    <copyright>2006-2011, Center for History and New Media, George Mason University, Fairfax, Virginia, USA</copyright>
-    <licenseUrl>https://github.com/zotero/zotero/blob/master/COPYING</licenseUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <releaseNotes>https://www.zotero.org/support/._changelog</releaseNotes>
-    <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/zotero</packageSourceUrl>
-    <projectSourceUrl>https://www.zotero.org/support/dev/source_code</projectSourceUrl>
-    <docsUrl>https://www.zotero.org/support</docsUrl>
-    <mailingListUrl>https://forums.zotero.org/discussions</mailingListUrl>
-    <bugTrackerUrl>https://github.com/zotero/zotero/issues</bugTrackerUrl>
+    <releaseNotes>https://www.zotero.org/support/changelog</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
     </dependencies>


### PR DESCRIPTION
Third-time is the charm!  😄 

This adds the new install option for 64-bit Zotero and simplifies the update a bit.  This is essentially [the same PR as submitted -- and closed -- previously](https://github.com/chocolatey-community/chocolatey-packages/pull/2546) but the version has been updated and it is hopefully "cleaner".

## Description

* Modified the `update.ps1` to grab both 32-bit and 64-bit installer URLs, download the EXEs and replace the information in the `VERIFICATION.txt` file. 
* Modified `chocolateyinstall.ps1` to install either 32-bit or 64-bit flavor of Zotero. 
* Adjusted the `VERIFICATION.txt file` to better match the "standards" already in the repo.  
* Added to `chocolateyinstall.ps1` and `chocolateyuninstall.ps1` files to work for both bit levels. 
* Updated and re-arranged metadata in the .nuspec to match the order of a new package. 
* Updated the LICENSE.txt file to match changes at the project.

## Motivation and Context

This addresses [issue 2531](https://github.com/chocolatey-community/chocolatey-packages/issues/2531)

32-bit Zotero works fine on 64-bit systems, but regularly pops up a dialog indicating that it's not the most efficient version for the environment. The upgrade from 32-bit to 64-bit is as simple as a re-install, so fixing this package to have both bit-levels was fairly straightforward.

## How Has this Been Tested?
In Windows 11 and the official test environment.  Installed the 32-bit-only, v7.0.9 package then upgraded to the local, modified v7.0.11 package from this PR with no trouble. Also installed the proposed package without upgrading. Uninstalls worked too.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the Chocolatey Test Environment(https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
