### PR TITLE
[nmap] Remove autohotkey max version requirement

### DIFF
--- a/automatic/nmap/nmap.nuspec
+++ b/automatic/nmap/nmap.nuspec
@@ -29,7 +29,7 @@
     <docsUrl>https://nmap.org/docs.html</docsUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/nmap</packageSourceUrl>
     <dependencies>
-      <dependency id="autohotkey" version="[1.1.33.10, 2.0.0)" />
+      <dependency id="autohotkey" version="1.1.33.10" />
       <dependency id="vcredist140" version="14.31.31103" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
Remove autohotkey max version requirement for nmap as it breaks deps for other choco packages, like Discord

Refs to #2623

## How Has this Been Tested?
Locally

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My pull request is not coming from the master branch.
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
