### PR TITLE
(ruby*) Fix updater and implement license check

### DIFF
--- a/automatic/ruby.install/legal/VERIFICATION.txt
+++ b/automatic/ruby.install/legal/VERIFICATION.txt
@@ -23,5 +23,4 @@ Using Chocolatey AU:
 
    Get-RemoteChecksum https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.4.1-1/rubyinstaller-3.4.1-1-x64.exe
 
-File 'license.txt' is obtained from:
-   https://raw.githubusercontent.com/oneclick/rubyinstaller2/master/LICENSE.txt
+File 'LICENSE.txt' is obtained from: https://raw.githubusercontent.com/oneclick/rubyinstaller2/master/LICENSE.txt

--- a/automatic/ruby.install/ruby.install.nuspec
+++ b/automatic/ruby.install/ruby.install.nuspec
@@ -29,7 +29,7 @@ Example: `choco install ruby --package-parameters="'/NoPath  ""/InstallDir:C:\yo
     <projectSourceUrl>https://github.com/ruby/ruby</projectSourceUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/ruby.install</packageSourceUrl>
     <bugTrackerUrl>https://bugs.ruby-lang.org/projects/ruby-master/issues</bugTrackerUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <releaseNotes>https://www.ruby-lang.org/en/downloads/releases/</releaseNotes>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@aad7c15bfbec43c3716f8a82bc3af22e1a55579d/icons/ruby.svg</iconUrl>
   </metadata>

--- a/automatic/ruby.install/update.ps1
+++ b/automatic/ruby.install/update.ps1
@@ -11,16 +11,37 @@ function global:au_SearchReplace {
     }
 
     ".\legal\VERIFICATION.txt"      = @{
-      "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL32)"
-      "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
-      "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
-      "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
-      "(?i)(Get-RemoteChecksum).*" = "`${1} $($Latest.URL64)"
+      "(?i)(\s+x32:).*"              = "`${1} $($Latest.URL32)"
+      "(?i)(\s+x64:).*"              = "`${1} $($Latest.URL64)"
+      "(?i)(checksum32:).*"          = "`${1} $($Latest.Checksum32)"
+      "(?i)(checksum64:).*"          = "`${1} $($Latest.Checksum64)"
+      "(?i)(Get-RemoteChecksum).*"   = "`${1} $($Latest.URL64)"
+      "(?i)(is obtained from:\s*).*" = "`${1} $($Latest.LicenseUrl)"
     }
   }
 }
 
-function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
+function global:au_BeforeUpdate($Package) {
+  if ($MyInvocation.InvocationName -ne '.') {
+    $Latest.LicenseURl = $Package.nuspecXml.package.metadata.licenseUrl
+    $outputFile = "$PSScriptRoot\legal\LICENSE.txt"
+
+    if (Test-Path $outputFile) {
+      Remove-Item $outputFile
+    }
+
+    Invoke-WebRequest -Uri $Latest.LicenseUrl -OutFile $outputFile
+    $content = Get-Content $outputFile
+
+    $hasMatch = $content | Where-Object { $_ -match "You may distribute the software" }
+
+    if (!$hasMatch) {
+      throw "The License has changed, please verify redistribution rights and update the license check."
+    }
+  }
+
+  Get-RemoteFiles -Purge -NoSuffix
+}
 
 function GetStreams() {
   param($releaseUrls)

--- a/automatic/ruby.install/update.ps1
+++ b/automatic/ruby.install/update.ps1
@@ -37,7 +37,7 @@ function GetStreams() {
     if ($streams.$versionTwoPart) { return }
 
     $url64 = $_ | Select-Object -ExpandProperty href
-    $url32 = $releaseUrls | Where-Object href -notmatch $re64 | Where-Object href -match $version | Select-Object -ExpandProperty href
+    $url32 = $releaseUrls | Where-Object href -notmatch "$re64|arm" | Where-Object href -match $version | Select-Object -ExpandProperty href
 
     if (!$url32 -or !$url64) {
       Write-Host "Skipping due to missing installer: '$version'"; return

--- a/automatic/ruby.portable/ruby.portable.nuspec
+++ b/automatic/ruby.portable/ruby.portable.nuspec
@@ -21,7 +21,7 @@ Ruby is a dynamic, open source programming language focusing on simplicity and p
     <projectSourceUrl>https://github.com/ruby/ruby</projectSourceUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/ruby.portable</packageSourceUrl>
     <bugTrackerUrl>https://bugs.ruby-lang.org/projects/ruby-master/issues</bugTrackerUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <releaseNotes>https://www.ruby-lang.org/en/downloads/releases/</releaseNotes>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@aad7c15bfbec43c3716f8a82bc3af22e1a55579d/icons/ruby.svg</iconUrl>
   </metadata>

--- a/automatic/ruby.portable/update.ps1
+++ b/automatic/ruby.portable/update.ps1
@@ -11,16 +11,37 @@ function global:au_SearchReplace {
     }
 
     ".\legal\VERIFICATION.txt"      = @{
-      "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL32)"
-      "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
-      "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
-      "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
-      "(?i)(Get-RemoteChecksum).*" = "`${1} $($Latest.URL64)"
+      "(?i)(\s+x32:).*"              = "`${1} $($Latest.URL32)"
+      "(?i)(\s+x64:).*"              = "`${1} $($Latest.URL64)"
+      "(?i)(checksum32:).*"          = "`${1} $($Latest.Checksum32)"
+      "(?i)(checksum64:).*"          = "`${1} $($Latest.Checksum64)"
+      "(?i)(Get-RemoteChecksum).*"   = "`${1} $($Latest.URL64)"
+      "(?i)(is obtained from:\s*).*" = "`${1} $($Latest.LicenseUrl)"
     }
   }
 }
 
-function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
+function global:au_BeforeUpdate($Package) {
+  if ($MyInvocation.InvocationName -ne '.') {
+    $Latest.LicenseURl = $Package.nuspecXml.package.metadata.licenseUrl
+    $outputFile = "$PSScriptRoot\legal\LICENSE.txt"
+
+    if (Test-Path $outputFile) {
+      Remove-Item $outputFile
+    }
+
+    Invoke-WebRequest -Uri $Latest.LicenseUrl -OutFile $outputFile
+    $content = Get-Content $outputFile
+
+    $hasMatch = $content | Where-Object { $_ -match "You may distribute the software" }
+
+    if (!$hasMatch) {
+      throw "The License has changed, please verify redistribution rights and update the license check."
+    }
+  }
+
+  Get-RemoteFiles -Purge -NoSuffix
+}
 
 function GetStreams() {
   param($releaseUrls)

--- a/automatic/ruby.portable/update.ps1
+++ b/automatic/ruby.portable/update.ps1
@@ -40,7 +40,7 @@ function GetStreams() {
     if ($streams.$versionTwoPart) { return }
 
     $url64 = $_ | Select-Object -ExpandProperty href
-    $url32 = $releaseUrls | Where-Object href -notmatch $re64 | Where-Object href -match $version | Select-Object -ExpandProperty href
+    $url32 = $releaseUrls | Where-Object href -notmatch "$re64|arm" | Where-Object href -match $version | Select-Object -ExpandProperty href
 
     if (!$url32 -or !$url64) {
       Write-Host "Skipping due to missing installer: '$version'"; return


### PR DESCRIPTION
## Description

This fixes the issue with the updater not picking up the latest version of the package, as well as implementing a new feature to ensure that we only update when the license is what we expect it to be.
This check also includes the latest edition of the license in the package.

## Motivation and Context

- Fixes #2639
- To ensure we do not update the package if distribution rights changes.

## How Has this Been Tested?

1. Run `.\update_all.ps1 -Name 'ruby*'`.
2. Verify all ruby packages is updated to `3.4.2.1` (The version number may be different during your run).
3. Verify the `LICENSE.txt` file was replaced with the latest edition of the license.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_. **NOT tested, as there is an exemption in the contributing guidelines for the changes made**
- [x] The changes only affect a single package (not including meta package).