### PR TITLE
(git) Prepare for 2.49.0 update

### DIFF
--- a/automatic/git.install/README.md
+++ b/automatic/git.install/README.md
@@ -19,3 +19,4 @@ Example for passing in package parameters:
 
 - The package uses default install options minus desktop icons.
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
+- Starting with version 2.49.0, installers for 32bit platforms are no longer available. If this is required, use an older version of the package.

--- a/automatic/git.install/README.md
+++ b/automatic/git.install/README.md
@@ -17,5 +17,5 @@ Example for passing in package parameters:
 
 ## Notes
 
-- The package uses default install options minus cheetah integration and desktop icons. Cheetah prevents a good upgrade scenario, so it has been removed.
+- The package uses default install options minus desktop icons.
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**

--- a/automatic/git.install/legal/VERIFICATION.txt
+++ b/automatic/git.install/legal/VERIFICATION.txt
@@ -5,14 +5,12 @@ in verifying that this package's contents are trustworthy.
 The installer has been downloaded from GitHub and can be verified like this:
 
 1. Download the following installers:
-  32-Bit: <https://github.com/git-for-windows/git/releases/download/v2.48.1.windows.1/Git-2.48.1-32-bit.exe>
   64-Bit: <https://github.com/git-for-windows/git/releases/download/v2.48.1.windows.1/Git-2.48.1-64-bit.exe>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: 
-  checksum32: FDF9BE6795AFD911B4ED87417F2D5AC547798B5B47441B9F71984CDDEF943C3A
   checksum64: CE45E23275049F4B36EDD90D5FD986A1E230EFB6C511E9260A90176CE8E825DF
 
 File 'LICENSE.txt' is obtained from <https://github.com/git-for-windows/git/blob/703601d6780c32d33dadf19b2b367f2f79e1e34c/COPYING>

--- a/automatic/git.install/tools/chocolateyInstall.ps1
+++ b/automatic/git.install/tools/chocolateyInstall.ps1
@@ -9,7 +9,6 @@ Stop-GitSSHAgent
 # Workaround for chocolateyBeforeModify.ps1 being bypassed if upgrading via metapackage (chocolatey/choco#1092)
 Stop-GitGPGAgent
 
-$fileName32 = 'Git-2.48.1-32-bit.exe'
 $fileName64 = 'Git-2.48.1-64-bit.exe'
 $silentArgs = "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/NOCANCEL", "/SP-", "/LOG", (Get-InstallComponents $pp)
 $silentArgs += Get-InstallOptions $pp
@@ -18,7 +17,6 @@ $packageArgs = @{
     PackageName    = 'git.install'
     FileType       = 'exe'
     SoftwareName   = 'Git'
-    File           = Get-Item $toolsPath\$fileName32
     File64         = Get-Item $toolsPath\$fileName64
     SilentArgs     = $silentArgs
 }

--- a/automatic/git.install/update.ps1
+++ b/automatic/git.install/update.ps1
@@ -6,11 +6,10 @@ $releases = "$domain/git-for-windows/git/releases/latest"
 function global:au_BeforeUpdate {
   $releaseAssets = Get-GitHubRelease -Owner 'git-for-windows' -Name 'git' -Tag $Latest.TagName | ForEach-Object assets
 
-  $Latest.URL32 = $releaseAssets | Where-Object name -match "Git-.+-32-bit.exe" | ForEach-Object browser_download_url
   $Latest.URL64 = $releaseAssets | Where-Object name -match "Git-.+-64-bit.exe" | ForEach-Object browser_download_url
 
-  if (!$Latest.URL32 -or !$Latest.URL64) {
-    throw "64bit or 32bit URL is missing"
+  if (!$Latest.URL64) {
+    throw "64bit URL is missing"
   }
 
   Get-RemoteFiles -Purge -NoSuffix
@@ -19,15 +18,12 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
     @{
         ".\tools\chocolateyInstall.ps1" = @{
-            "(^[$]fileName32\s*=\s*)('.*')" = "`$1'$($Latest.FileName32)'"
             "(^[$]fileName64\s*=\s*)('.*')" = "`$1'$($Latest.FileName64)'"
         }
 
         ".\legal\verification.txt" = @{
-            "(?i)(32-Bit.+)\<.*\>" = "`${1}<$($Latest.URL32)>"
             "(?i)(64-Bit.+)\<.*\>" = "`${1}<$($Latest.URL64)>"
             "(?i)(checksum type:\s+).*" = "`${1}$($Latest.ChecksumType)"
-            "(?i)(checksum32:\s+).*" = "`${1}$($Latest.Checksum32)"
             "(?i)(checksum64:\s+).*" = "`${1}$($Latest.Checksum64)"
         }
      }

--- a/automatic/git.portable/README.md
+++ b/automatic/git.portable/README.md
@@ -7,7 +7,6 @@ Git for Windows focuses on offering a lightweight, native set of tools that brin
 
 * **Git BASH**: Git for Windows provides a BASH emulation used to run Git from the command line. *NIX users should feel right at home, as the BASH emulation behaves just like the "git" command in LINUX and UNIX environments.
 * **Git GUI**: As Windows users commonly expect graphical user interfaces, Git for Windows also provides the Git GUI, a powerful alternative to Git BASH, offering a graphical version of just about every Git command line function, as well as comprehensive visual diff tools.
-* **Shell Integration**: Simply right-click on a folder in Windows Explorer to access the BASH or GUI.
 
 ## Notes
 

--- a/automatic/git.portable/README.md
+++ b/automatic/git.portable/README.md
@@ -11,3 +11,4 @@ Git for Windows focuses on offering a lightweight, native set of tools that brin
 ## Notes
 
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
+- Starting with version 2.49.0, Portable versions for 32bit platforms are no longer available. If this is required, use an older version of the package.

--- a/automatic/git.portable/legal/VERIFICATION.txt
+++ b/automatic/git.portable/legal/VERIFICATION.txt
@@ -5,14 +5,12 @@ in verifying that this package's contents are trustworthy.
 The installer has been downloaded from GitHub and can be verified like this:
 
 1. Download the following installers:
-  32-Bit: <https://github.com/git-for-windows/git/releases/download/v2.48.1.windows.1/PortableGit-2.48.1-32-bit.7z.exe>
   64-Bit: <https://github.com/git-for-windows/git/releases/download/v2.48.1.windows.1/PortableGit-2.48.1-64-bit.7z.exe>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: 
-  checksum32: 63DDBC7EA11EA8A1375F39F45D38F928DBEC564360AD12DD11D0D649474063A0
   checksum64: A4335111B3363871CAC632BE93D7466154D8EB08782FF55103866B67D6722257
 
 File 'LICENSE.txt' is obtained from <https://github.com/git-for-windows/git/blob/703601d6780c32d33dadf19b2b367f2f79e1e34c/COPYING>

--- a/automatic/git.portable/tools/chocolateyInstall.ps1
+++ b/automatic/git.portable/tools/chocolateyInstall.ps1
@@ -4,7 +4,6 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
   PackageName    = 'git.portable'
-  FileFullPath   = Get-Item $toolsPath\*-32-bit.7z.exe
   FileFullPath64 = Get-Item $toolsPath\*-64-bit.7z.exe
   Destination    = "$(Get-ToolsLocation)\git"
 }

--- a/automatic/git.portable/update.ps1
+++ b/automatic/git.portable/update.ps1
@@ -6,11 +6,10 @@ $releases = "$domain/git-for-windows/git/releases/latest"
 function global:au_BeforeUpdate {
   $releaseAssets = Get-GitHubRelease -Owner 'git-for-windows' -Name 'git' -Tag $Latest.TagName | ForEach-Object assets
 
-  $Latest.URL32 = $releaseAssets | Where-Object name -match "PortableGit-.+-32-bit.7z.exe" | ForEach-Object browser_download_url
   $Latest.URL64 = $releaseAssets | Where-Object name -match "PortableGit-.+-64-bit.7z.exe" | ForEach-Object browser_download_url
 
-  if (!$Latest.URL32 -or !$Latest.URL64) {
-    throw "64bit or 32bit URL is missing"
+  if (!$Latest.URL64) {
+    throw "64bit URL is missing"
   }
 
   Get-RemoteFiles -Purge -NoSuffix
@@ -19,10 +18,8 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
     @{
         ".\legal\verification.txt" = @{
-            "(?i)(32-Bit.+)\<.*\>" = "`${1}<$($Latest.URL32)>"
             "(?i)(64-Bit.+)\<.*\>" = "`${1}<$($Latest.URL64)>"
             "(?i)(checksum type:\s+).*" = "`${1}$($Latest.ChecksumType)"
-            "(?i)(checksum32:\s+).*" = "`${1}$($Latest.Checksum32)"
             "(?i)(checksum64:\s+).*" = "`${1}$($Latest.Checksum64)"
         }
      }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->

## Motivation and Context
Git for Windows stopped building 32-bit installers and 32-bit PortableGit. There are only "64-bit"(AMD64) and ARM64 versions now.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
It hasn't.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).