### PR TITLE
(calibre) switch AU script to use Github for version

### DIFF
--- a/automatic/calibre/update.ps1
+++ b/automatic/calibre/update.ps1
@@ -20,7 +20,7 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
     $githubLatestRelease = "https://github.com/kovidgoyal/calibre/releases/latest"
-    $download_page = Invoke-WebRequest -Uri $githubLatestRelease
+    $download_page = Invoke-WebRequest -Uri $githubLatestRelease -UseBasicParsing
 
     $versionHyperlink = $download_page.BaseResponse.ResponseUri
 

--- a/automatic/calibre/update.ps1
+++ b/automatic/calibre/update.ps1
@@ -1,8 +1,6 @@
 ﻿Import-Module Chocolatey-AU
 Import-Module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
-$releases = 'https://download.calibre-ebook.com/7.html'
-
 function global:au_BeforeUpdate {
   $Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64
 }
@@ -21,12 +19,12 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases
+    $githubLatestRelease = "https://github.com/kovidgoyal/calibre/releases/latest"
+    $download_page = Invoke-WebRequest -Uri $githubLatestRelease
 
-    $versionHyperlink = $download_page.links | Select-Object -First 1
-    if ($versionHyperlink.Title -notmatch 'Release (7[\d\.]+)' ) { throw "Calibre version 7.x not found on $releases" }
+    $versionHyperlink = $download_page.BaseResponse.ResponseUri
 
-    $version = $versionHyperlink.InnerText
+    $version =  ($versionHyperlink.Segments | Select-Object -Last 1).trim("v")
     $url64   = 'https://download.calibre-ebook.com/<version>/calibre-64bit-<version>.msi'
     $url64   = $url64 -replace '<version>', $version
 


### PR DESCRIPTION
## Description
 
Updates AU script to scrape Github releases page to get the latest version number.

## Motivation and Context

Update script outdated. 
Does not use the Github download URL, as Github binaries removed from older releases.

Fixes #2646 

## How Has this Been Tested?

Win11 and test env

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

