### PR TITLE
Updated Code::Blocks package to Code::Blocks release 25.03

### DIFF
--- a/automatic/codeblocks/codeblocks.nuspec
+++ b/automatic/codeblocks/codeblocks.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>codeblocks</id>
-    <version>20.3.0.20210213</version>
+    <version>25.3.0.20250331</version>
     <title>Code::Blocks</title>
     <authors>The Code::Blocks Team</authors>
     <owners>chocolatey-community purity</owners>
@@ -80,7 +80,7 @@ This package downloads the installer with the included GCC compiler.
 
 ]]></description>
     <summary>Code::Blocks is a free C++ IDE.</summary>
-    <releaseNotes>https://www.codeblocks.org/changelogs/20.03</releaseNotes>
+    <releaseNotes>https://www.codeblocks.org/changelogs/25.03</releaseNotes>
     <tags>codeblocks C++ IDE admin foss cross-platform</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/codeblocks</packageSourceUrl>
     <dependencies>

--- a/automatic/codeblocks/legal/VERIFICATION.txt
+++ b/automatic/codeblocks/legal/VERIFICATION.txt
@@ -5,13 +5,13 @@ in verifying that this package's contents are trustworthy.
 The installer has been downloaded from the sourceforge mirror listed on <https://www.codeblocks.org/downloads/binaries>
 and can be verified like this:
 
-1. Go to <https://sourceforge.net/projects/codeblocks/files/Binaries/20.03/Windows/codeblocks-20.03mingw-setup.exe>
+1. Go to <https://sourceforge.net/projects/codeblocks/files/Binaries/25.03/Windows/codeblocks-25.03mingw-setup.exe>
    to download the installer
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum: 862479A6D45B8A36FFC09FC4C63CD0850155088E33BD8CAD9075FB6FCB1F43C2
+  checksum: 528364CB5E3F969BF70A789399632323D2E9E65691817DBABF457F27E6A2CD7A
 
 File 'LICENSE.txt' is obtained from <http://svn.code.sf.net/p/codeblocks/code/trunk/>


### PR DESCRIPTION
## Description
Updated Code::Blocks packages from release 20.03 to 25.03

## Motivation and Context
Support newer releases of Code::Blocks

## How Has this Been Tested?
Created new package (nupkg) and tested installation
Respective files not point o the executable of the new installer and release notes and folders on project site
Installer needs to be downloaded and renamed to Windows.exe as it is the case in the 20.03 release chocolatey package)

## Screenshot (if appropriate, usually isn't needed):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [ ] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).
