### PR TITLE
(tixati) fix updater for the current website layout

### DIFF
--- a/automatic/tixati/update.ps1
+++ b/automatic/tixati/update.ps1
@@ -1,32 +1,40 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = 'https://www.tixati.com/download/'
+$releases = 'https://tixati.com/windows'
+$download = 'https://download.tixati.com/'
 
 function global:au_SearchReplace {
-   @{
-        ".\tools\chocolateyInstall.ps1" = @{
-            "(?i)(^\s*url\s*=\s*)('.*')"        = "`$1'$($Latest.URL32)'"
-            "(?i)(^\s*url64bit\s*=\s*)('.*')"   = "`$1'$($Latest.URL64)'"
-            "(?i)(^\s*checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
-            "(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
-            "(?i)(^[$]fileName\s*=\s*)('.*')"   = "`$1'$($Latest.FileName)'"
-        }
+  @{
+    ".\tools\chocolateyInstall.ps1" = @{
+      "(?i)(^\s*url\s*=\s*)('.*')"        = "`$1'$($Latest.URL32)'"
+      "(?i)(^\s*url64bit\s*=\s*)('.*')"   = "`$1'$($Latest.URL64)'"
+      "(?i)(^\s*checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
+      "(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
+      "(?i)(^[$]fileName\s*=\s*)('.*')"   = "`$1'$($Latest.FileName)'"
     }
+  }
 }
 
+
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri "${releases}windows.html" -UseBasicParsing
-    $url32 = $download_page.links | Where-Object href -match '\.exe$' | Select-Object -First 1 | ForEach-Object href
+  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $url32 = $download_page.links | Where-Object href -match '\.win32-install$' | ForEach-Object href
+  $url64 = $download_page.links | Where-Object href -match '\.win64-install$' | ForEach-Object href
 
-    $download_page = Invoke-WebRequest -Uri "${releases}windows64.html" -UseBasicParsing
-    $url64 = $download_page.links | Where-Object href -match '\.exe$' | Select-Object -First 1 | ForEach-Object href
+  $url32 -match 'tixati-([0-9]+.[0-9]+)-[0-9]+.win32-install'
+  $version = $Matches[1]
+  $file32 = $Matches[0]
+  $filename = $file32 -replace ('.win32-install', '.install.exe')
 
-    $url64 -match '(?<=tixati-).+?(?=\.win64)'
-    $version = $Matches[0] -replace '-.+$'
+  $url64 -match 'tixati-[0-9]+.[0-9]+-[0-9]+.win64-install'
+  $file64 = $Matches[0]
 
-    $fileName = (Split-Path $url64 -Leaf) -replace 'win64-'
-
-    @{ URL32 = $url32; URL64 = $url64; Version = $version; FileName = $fileName }
+  @{
+    Version  = $version;
+    FileName = $filename;
+    URL32    = -join ($download, $file32, '.exe');
+    URL64    = -join ($download, $file64, '.exe');
+  }
 }
 
 update


### PR DESCRIPTION
## Description
Fixes the updater to read the current website layout.

## Motivation and Context
fixes #2490
The website layout for downloads has changed.

## How Has this Been Tested?
Ran the updater and installed/uninstalled the package locally. Both x86 and x64 installs were tested.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
