### PR TITLE
(tixati.portable) fix updater and update package to v3.33

### DIFF
--- a/automatic/tixati.portable/tools/chocolateyInstall.ps1
+++ b/automatic/tixati.portable/tools/chocolateyInstall.ps1
@@ -3,21 +3,19 @@
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
-  packageName    = 'tixati.portable'
-  url            = 'https://download2.tixati.com/download/tixati-3.29-1.portable.zip'
-  checksum       = '656991111b61fe1f5a024b202e6bf3b02987419a8d7d47ae5cf5b88e78c7af09'
-  checksumType   = 'sha256'
-  unzipLocation  = $toolsPath
+  packageName   = 'tixati.portable'
+  url           = 'https://download.tixati.com/tixati-3.33-1.win32-standalone.zip'
+  checksum      = 'cd2bcf49113399a01a8b782d489cbacf2ea1eb437b9f48ed388b592fa3caf8b5'
+  url64         = 'https://download.tixati.com/tixati-3.33-1.win64-standalone.zip'
+  checksum64    = '8d2ccbd414e283ce867555dcceda0140087b3186b35b75303806189b56257d34'
+  checksumType  = 'sha256'
+  unzipLocation = $toolsPath
 }
 Install-ChocolateyZipPackage @packageArgs
 
-$is32bit = (Get-OSArchitectureWidth 32) -or ($Env:chocolateyForceX86 -eq 'true')
-$tixati_path = "$toolsPath\Tixati_portable"
-Remove-Item $tixati_path\tixati_Linux*
-if ($is32bit) {
-    Remove-Item $tixati_path\tixati_Windows64bit.exe
-    Move-Item $tixati_path\tixati_Windows32bit.exe $tixati_path\tixati.exe
-} else {
-    Remove-Item $tixati_path\tixati_Windows32bit.exe
-    Move-Item $tixati_path\tixati_Windows64bit.exe $tixati_path\tixati.exe
+$files = get-childitem $toolsPath -include *.exe -recurse
+foreach ($file in $files) {
+  if ($file.name -ne "tixati.exe") {
+    New-Item "$file.ignore" -type file -force | Out-Null
+  }
 }

--- a/automatic/tixati.portable/update.ps1
+++ b/automatic/tixati.portable/update.ps1
@@ -1,23 +1,36 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = 'https://www.tixati.com/download/portable.html'
+$releases = 'https://tixati.com/windows'
+$download = 'https://download.tixati.com/'
 
 function global:au_SearchReplace {
-   @{
-        ".\tools\chocolateyInstall.ps1" = @{
-            "(?i)(^\s*url\s*=\s*)('.*')"        = "`$1'$($Latest.URL32)'"
-            "(?i)(^\s*checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
-        }
+  @{
+    ".\tools\chocolateyInstall.ps1" = @{
+      "(?i)(^\s*url\s*=\s*)('.*')"        = "`$1'$($Latest.URL32)'"
+      "(?i)(^\s*checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
+      "(?i)(^\s*url64\s*=\s*)('.*')"      = "`$1'$($Latest.URL64)'"
+      "(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
     }
+  }
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-    $url32 = $download_page.links | Where-Object href -match '\.zip$' | ForEach-Object href
-    $url32 -match '(?<=tixati-).+?(?=\.portable)'
-    $version = $Matches[0] -replace '-.+'
+  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $url32 = $download_page.links | Where-Object href -match '\.win32-standalone$' | ForEach-Object href
+  $url64 = $download_page.links | Where-Object href -match '\.win64-standalone$' | ForEach-Object href
 
-    @{ URL32 = $url32;  Version = $version }
+  $url32 -match 'tixati-([0-9]+.[0-9]+)-[0-9]+.win32-standalone'
+  $version = $Matches[1]
+  $file32 = $Matches[0]
+
+  $url64 -match 'tixati-[0-9]+.[0-9]+-[0-9]+.win64-standalone'
+  $file64 = $Matches[0]
+
+  @{
+    Version = $version;
+    URL32   = -join ($download, $file32, '.zip');
+    URL64   = -join ($download, $file64, '.zip');
+  }
 }
 
-update -ChecksumFor 32
+update


### PR DESCRIPTION
## Description
Fixes both the updater and the install script to handle the download being split between x86/x64 versions.

## Motivation and Context
The website layout for downloads has changed and broke the updater.

## How Has this Been Tested?
The updater has been tested locally. Package install/uninstall has been tested locally and in the test environment.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
