### PR TITLE
(thunderbird) fix AU and add esr stream

### DIFF
--- a/automatic/thunderbird/Readme.thunderbird.md
+++ b/automatic/thunderbird/Readme.thunderbird.md
@@ -1,0 +1,35 @@
+# <img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/thunderbird.png" width="48" height="48"/> [thunderbird](https://chocolatey.org/packages/thunderbird)
+
+Thunderbird is a free email application that's easy to set up and customize and it's loaded with great features!
+
+## Package Parameters
+
+- `/l:LOCALE` - Install given Firefox locale. See the [official page](https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt) for a complete list of available locales.
+- `/UseMozillaFallback` Makes a request to mozilla.org and reads the supported Language Culture code from the website.
+- `/NoStop` - Do not stop Thunderbird before running the install if it is running or attempt to restart it after install.
+
+Command-line options for installer configuration. See the [official page](https://firefox-source-docs.mozilla.org/browser/installer/windows/installer/FullConfig.html) for details and defaults.
+
+- `/InstallDir:PATH`
+- `/NoTaskbarShortcut` Do not create Taskbar Shortcut
+- `/NoDesktopShortcut` Do not create Desktop Shortcut
+- `/NoStartMenuShortcut` Do not create Start Menu Shortcut
+- `/NoMaintenanceService` Do not install Maintenance Service
+- `/RemoveDistributionDir` Remove Distribution directory on installation/update. (This is the default behavior of the Thunderbird Installer, but not for this Chocolatey Package)
+- `/NoAutoUpdate` Sets a policies.json file to not update Thunderbird and does not install the Maintenance Service
+
+### Examples
+
+`choco install thunderbird --params "/l=en-GB"`
+`choco install thunderbird --params "/NoTaskbarShortcut /NoDesktopShortcut /NoAutoUpdate"`    
+`choco install thunderbird --params "/UseMozillaFallback"`
+`choco install thunderbird --params "/NoStop"`
+
+## Notes
+- Looking for Thunderbird Extended Support Release? Install the [thunderbirdesr](/packages/thunderbirdesr) package.
+- If locale package parameter is not present, this package installs Thunderbird in the first language which matches this list:
+  1. If Thunderbird is already installed: the same language as the already installed Thunderbird.
+  1. The Windows system language where the Thunderbird package gets installed.
+  1. Language Culture code specified on Mozilla website (only when `/UseMozillaFallback` is specified).
+  1. If Thunderbird does not support the system language, it will fallback to `en-US`.
+- **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**

--- a/automatic/thunderbird/Readme.thunderbirdesr.md
+++ b/automatic/thunderbird/Readme.thunderbirdesr.md
@@ -1,0 +1,35 @@
+# <img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/thunderbird.png" width="48" height="48"/> [thunderbird](https://chocolatey.org/packages/thunderbird)
+
+Thunderbird is a free email application that's easy to set up and customize and it's loaded with great features!
+
+## Package Parameters
+
+- `/l:LOCALE` - Install given Firefox locale. See the [official page](https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt) for a complete list of available locales.
+- `/UseMozillaFallback` Makes a request to mozilla.org and reads the supported Language Culture code from the website.
+- `/NoStop` - Do not stop Thunderbird before running the install if it is running or attempt to restart it after install.
+
+Command-line options for installer configuration. See the [official page](https://firefox-source-docs.mozilla.org/browser/installer/windows/installer/FullConfig.html) for details and defaults.
+
+- `/InstallDir:PATH`
+- `/NoTaskbarShortcut` Do not create Taskbar Shortcut
+- `/NoDesktopShortcut` Do not create Desktop Shortcut
+- `/NoStartMenuShortcut` Do not create Start Menu Shortcut
+- `/NoMaintenanceService` Do not install Maintenance Service
+- `/RemoveDistributionDir` Remove Distribution directory on installation/update. (This is the default behavior of the Thunderbird Installer, but not for this Chocolatey Package)
+- `/NoAutoUpdate` Sets a policies.json file to not update Thunderbird and does not install the Maintenance Service
+
+### Examples
+
+`choco install thunderbirdesr --params "/l=en-GB"`
+`choco install thunderbirdesr --params "/NoTaskbarShortcut /NoDesktopShortcut /NoAutoUpdate"`    
+`choco install thunderbirdesr --params "/UseMozillaFallback"`
+`choco install thunderbirdesr --params "/NoStop"`
+
+## Notes
+- Looking for Thunderbird monthly release? Install the [thunderbird](/packages/thunderbird) package.
+- If locale package parameter is not present, this package installs Thunderbird in the first language which matches this list:
+  1. If Thunderbird is already installed: the same language as the already installed Thunderbird.
+  1. The Windows system language where the Thunderbird package gets installed.
+  1. Language Culture code specified on Mozilla website (only when `/UseMozillaFallback` is specified).
+  1. If Thunderbird does not support the system language, it will fallback to `en-US`.
+- **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**

--- a/automatic/thunderbird/update.ps1
+++ b/automatic/thunderbird/update.ps1
@@ -1,16 +1,53 @@
-﻿Import-Module Chocolatey-AU
+﻿[CmdletBinding()]
+param($IncludeStream, [switch] $Force)
+Import-Module Chocolatey-AU
 . "$PSScriptRoot\..\Firefox\update_helper.ps1"
 
-$releases = 'https://www.mozilla.org/en-US/thunderbird/all/'
+$releases = 'https://www.thunderbird.net/en-US/thunderbird/all/'
+$releasesESR = 'https://www.thunderbird.net/en-US/thunderbird/all/?release=esr'
 $product  = 'thunderbird'
+
+function GetThunderBirdESRVersionAndUrlFormats() {
+  param(
+    [string]$baseUrl,
+    [string]$Product,
+    [bool]$Supports64Bit = $true
+  )
+
+  $latestUrl32 = $baseUrl + "?product=" + $product + "-latest&os=win&lang=en-US"
+  $redirectedUrl = Get-RedirectedUrl $latestUrl32
+ 
+  $url = $latestUrl32 -replace 'en-US', '${locale}' -replace '&amp;', '&'
+  $version = $redirectedUrl -split '\/' | Select-Object -Last 1 -Skip 3
+  if ($version.EndsWith('esr')) {
+    $version = $version.TrimEnd('esr')
+    $url = $url -replace 'esr-latest', "${version}esr"
+  }
+
+  $result = @{
+    Version     = $version
+    Win32Format = $url -replace 'latest', $version
+  }
+
+  if ($Supports64Bit) {
+    $result += @{
+      Win64Format = $url -replace 'os=win', 'os=win64' -replace 'win32', 'win64' -replace 'latest', $version
+    }
+  }
+  return $result
+}
+
+function global:au_BeforeUpdate {
+  Copy-Item "$PSScriptRoot\Readme.$($Latest.PackageName).md" "$PSScriptRoot\README.md" -Force
+}
 
 function global:au_AfterUpdate {
   $version = $Latest.RemoteVersion
   CreateChecksumsFile -ToolsDirectory "$PSScriptRoot\tools" `
-    -ExecutableName "Thunderbird Setup $($version)esr.exe" `
+    -ExecutableName $Latest.ExeName `
     -Version $version `
     -Product $product `
-    -ExtendedRelease
+    -ExtendedRelease:$($Latest.PackageName -eq 'thunderbirdesr')
 }
 
 function global:au_SearchReplace {
@@ -21,16 +58,39 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
+  $streams = @{}
+  
   $data  = GetVersionAndUrlFormats -UpdateUrl $releases -Product $product
+  $version = $data.Version
 
-  @{
+  $streams.Add("latest", @{
     LocaleURL = "$releases"
     Version = $data.Version
     RemoteVersion = $data.Version
     Win32Format = $data.Win32Format
     Win64Format = $data.Win64Format
     SoftwareName = 'Mozilla Thunderbird'
-  }
+    ReleaseNotes  = "https://www.thunderbird.net/en-US/thunderbird/${version}/releasenotes/"
+    PackageName   = 'thunderbird'
+    ExeName       = "Thunderbird Setup $($version).exe"
+    })
+
+  $data = GetThunderBirdESRVersionAndUrlFormats -baseUrl "https://download.mozilla.org/" -Product "${product}-esr"
+  $version = $data.Version
+
+  $streams.Add('esr', @{
+    LocaleURL = "$releasesESR"
+    Version = $data.Version
+    RemoteVersion = $data.Version
+    Win32Format = $data.Win32Format
+    Win64Format = $data.Win64Format
+    SoftwareName = 'Mozilla Thunderbird'
+    ReleaseNotes  = "https://www.thunderbird.net/en-US/thunderbird/${version}esr/releaseNotes/"
+    ExeName       = "Thunderbird Setup $($version)esr.exe"
+    PackageName   = 'thunderbirdesr'
+    })
+
+  return @{ Streams = $streams }
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
## Description

This fixes the thunderbird automatic updater, and adds a stream for the new ESR channel.

## Motivation and Context

As per the blog post: https://blog.thunderbird.net/2025/02/thunderbird-desktop-release-channel-default-download/
Thunderbird has added both a regular monthly release and a ESR channel, like Firefox.

This updates the regular release AU script to work again, and adds a new `thunderbirdesr` package. This would be a new package ID, however, it would be stream of an existing package, so not completely new. It was modeled after the `FirefoxESR` package script, however, a slightly different method had to be used as the download pages are different.

PR is draft, pending outcome of discussion: https://github.com/orgs/chocolatey-community/discussions/2661

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [ x My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).


