### PR TITLE
(waterfox) fix AU version parsing

### DIFF
--- a/automatic/waterfox/update.ps1
+++ b/automatic/waterfox/update.ps1
@@ -90,7 +90,7 @@ function Get-Waterfox {
             throw "Couldn't find or divine the URL for Waterfox $TagVersion from the GitHub release ('$($LatestRelease.html_url)')"
           }
         }
-        Version = $TagVersion.Replace('G', (Get-Date).ToString('yyMM'))
+        Version = (Get-Date).ToString('yyMM') + $TagVersion
         SourceUrl = "https://github.com/WaterfoxCo/Waterfox"
         ProjectUrl = "https://www.waterfox.net/"
       }


### PR DESCRIPTION

## Description

Fixes the version parsing/mangling in the waterfox AU script. 

## Motivation and Context

Fixes #2648 
Waterfox stopped having the `G` prefix on versions, necessitating a change to the update script.

## How Has this Been Tested?

Tested update in powershell 5.1, package in test env. 

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
