### PR TITLE
(nmap) make AHK v2 compatible

### DIFF
--- a/automatic/nmap/nmap.nuspec
+++ b/automatic/nmap/nmap.nuspec
@@ -29,7 +29,7 @@
     <docsUrl>https://nmap.org/docs.html</docsUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/nmap</packageSourceUrl>
     <dependencies>
-      <dependency id="autohotkey" version="[1.1.33.10, 2.0.0)" />
+      <dependency id="autohotkey" version="2.0.0" />
       <dependency id="vcredist140" version="14.31.31103" />
     </dependencies>
   </metadata>

--- a/automatic/nmap/tools/install.ahk
+++ b/automatic/nmap/tools/install.ahk
@@ -1,63 +1,79 @@
-#SingleInstance, force
-SetTitleMatchMode, RegEx
+﻿#Requires AutoHotkey >=2.0
+#SingleInstance force
+SetTitleMatchMode("RegEx")
 
-WinWait, Nmap Setup
-Sleep, 100
-ControlSend,, {Enter}
-Sleep, 100
-ControlSend,, {Enter}
-Sleep, 100
-ControlSend,, !i
+WinWait("Nmap Setup")
+Sleep(100)
+ControlSend("{Enter}")
 
-loop {
-    IfWinExist, Npcap [0-9.]+ Setup, already installed
+Loop{
+    if WinExist("Npcap [0-9.]+ Setup", "already installed")
     {
-        Sleep, 100
-        ControlSend,, {Enter}
+        Sleep(100)
+        ControlSend("{Enter}")
     }
 
-    IfWinExist, Npcap [0-9.]+ Setup, License Agreement
+    if WinExist("Npcap [0-9.]+ Setup", "License Agreement")
     {
-        Sleep, 100
-        ControlSend,, {Enter}
-        Sleep, 100
-        ControlSend,, {Enter}
-        Sleep, 100
-        ControlSend,, {Enter}
+        Sleep(100)
+        ControlSend("{Enter}")
+        Sleep(200)
+        ControlSend("{Enter}")
+        Sleep(200)
+        ControlSend("{Enter}")
     }
 
-    IfWinExist, Npcap [0-9.]+ Setup, Installation Complete
+    if WinExist("Npcap [0-9.]+ Setup", "Installation Complete")
     {
-        Sleep, 100
-        ControlSend,, {Enter}
-        Sleep, 100
-        ControlSend,, {Enter}
+        Sleep(100)
+        ControlSend("{Enter}")
+        Sleep(100)
+        ControlSend("{Enter}")
+    }
+    
+    if WinExist("Nmap Setup", "License Agreement")
+    {
+        ControlSend("{Enter}")
+    }
+    
+    if WinExist("Nmap Setup", "Choose Install Location")
+    {
+        ControlSend("{Enter}")
     }
 
-    IfWinExist, Nmap Setup, Installation Complete
+    if WinExist("Nmap Setup", "Choose Components")
     {
-        Sleep, 100
-        ControlSend,, {Enter}
-        Sleep, 100
-        ControlSend,, {Enter}
-        Sleep, 100
-        ControlSend,, {Enter}
-        Sleep, 100
-        ControlSend,, {Enter}
+        ControlSend("{Enter}")
+    }
 
-        IfWinNotExist, Nmap Setup
+    if WinExist("Nmap Setup", "Installation Complete")
+    {
+        Sleep(100)
+        ControlSend("{Enter}")
+        Sleep(100)
+        ControlSend("{Enter}")
+        Sleep(100)
+        ControlSend("{Enter}")
+        Sleep(100)
+        if !WinExist("Nmap Setup")
+        {
+          break
+        }
+        ControlSend("{Enter}")
+
+        if !WinExist("Nmap Setup")
         {
           break
         }
     }
 
-    IfWinExist, Nmap Setup, Finished
+    if WinExist("Nmap Setup", "Finished")
     {
-        Sleep, 100
-        ControlSend,, {Enter}
-        Sleep, 100
+        Sleep(100)
+        ControlSend("{Enter}")
+        Sleep(100)
 
-        IfWinNotExist, Nmap Setup
+        if !WinExist("Nmap Setup")
         {
           break
         }
@@ -69,5 +85,5 @@ loop {
     ;     ControlSend,, {Enter}
     ; }
 
-    Sleep 1000
+    Sleep(1000)
 }


### PR DESCRIPTION
## Description

Updates the autohotkey script to be autohotkey v2 compatible, and changes the dependency to autohotkey v2.0.0+

## Motivation and Context

Fixes #2623 

Autohotkey v2 has syntax changes, this updates the script to work with those changes.

I also made some minor tweaks to the flow of the script, to ensure both fresh installs and upgrades/reinstalls work. I'm not sure if this is related to the v2 script upgrade, or Nmap installer changes in more recent versions.

## How Has this Been Tested?

Tested in the test environment.

Tested a fresh installation, tested a force reinstallation, and tested an upgrade from v7.95.0

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).
