### PR TITLE
(simplewall) update portable archive type

### DIFF
--- a/automatic/simplewall.portable/tools/chocolateyInstall.ps1
+++ b/automatic/simplewall.portable/tools/chocolateyInstall.ps1
@@ -8,4 +8,4 @@ $packageArgs = @{
 
 Get-ChocolateyUnzip @packageArgs
 
-Remove-Item $toolsDir\*.zip -ea 0
+Remove-Item $toolsDir\*.7z -ea 0

--- a/automatic/simplewall.portable/update.ps1
+++ b/automatic/simplewall.portable/update.ps1
@@ -2,7 +2,7 @@
 
 function global:au_BeforeUpdate {
     $Latest.URL32 = $Latest.URL32_p
-    $Latest.FileType = 'zip'
+    $Latest.FileType = '7z'
     Copy-Item $PSScriptRoot\..\simplewall\README.md $PSScriptRoot\README.md
     Get-RemoteFiles -Purge -NoSuffix
 }

--- a/automatic/simplewall/update.ps1
+++ b/automatic/simplewall/update.ps1
@@ -6,7 +6,7 @@ function global:au_GetLatest {
     @{
         Version = $LatestRelease.tag_name.TrimStart("v.")  # Tags have a "v." prefix, not a typo
         URL32_i = $LatestRelease.assets | Where-Object {$_.name.EndsWith(".exe")} | Select-Object -ExpandProperty browser_download_url
-        URL32_p = $LatestRelease.assets | Where-Object {$_.name.EndsWith("bin.zip")} | Select-Object -ExpandProperty browser_download_url
+        URL32_p = $LatestRelease.assets | Where-Object {$_.name.EndsWith("bin.7z")} | Select-Object -ExpandProperty browser_download_url
     }
 }
 


### PR DESCRIPTION
## Description

Updates the archive type for portable simplewall. 

## Motivation and Context

Fixes #2660 

All three `simplewall*` packages use a shared update script from the metapackage, thus the change in archive type broke all three update scripts. 

## How Has this Been Tested?

Tested AU for all three  `simplewall*` packages in PowerShell v5.1
Tested `simplewall.portable` install and uninstall in test env.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

