### PR TITLE
(mkdocs-material) fix AU script

### DIFF
--- a/automatic/mkdocs-material/update.ps1
+++ b/automatic/mkdocs-material/update.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = 'https://pypi.python.org/pypi/mkdocs-material'
+$releases = 'https://pypi.org/rss/project/mkdocs-material/releases.xml'
 
 function global:au_SearchReplace {
   @{
@@ -14,11 +14,9 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -UseBasicParsing -Uri $releases
+    $download_page = Invoke-RestMethod -UseBasicParsing -Uri $releases -Method Get
 
-    $re = 'mkdocs\-material\/[\d\.]+\/$'
-    $url = $download_page.links | Where-Object href -match $re | Select-Object -first 1 -expand href
-    $version = $url -split '\/' | Select-Object -last 1 -skip 1
+    $version = $download_page | Select-Object -First 1 -ExpandProperty title
 
     $download_page = Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/squidfunk/mkdocs-material/raw/${version}/requirements.txt"
     if ($download_page.content -match "mkdocs>=(\d+\.[\d\.]+)") {


### PR DESCRIPTION
## Description

Fixes the mkdocs-material AU script version. 

## Motivation and Context

Package was outdated and failing update in appveyor.
Instead of trying to scrape the webpage for the latest version number, instead use the RSS feed on Pypi for this package.

## How Has this Been Tested?

Script tested in PowerShell v5.1
Package tested in test env.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

