### PR TITLE
fix(freecad): update release name regex

### DIFF
--- a/automatic/freecad/update_helper.ps1
+++ b/automatic/freecad/update_helper.ps1
@@ -32,9 +32,9 @@ param(
     }
     'portable' {
       $download_page = (Get-GitHubRelease -Owner "Freecad" -Name "Freecad" -Verbose).assets
-      $mobile = "portable"
+      $mobile = "Windows"
       $ext = "7z"
-      $re64 = "(FreeCAD\-)((\d+)?(\.))+?(\d)?(\-)(Windows)(\-)?(x\d{2})(\-|.)?(\d+)?(\.${ext})$"
+      $re64 = "(FreeCAD_)?((\d+)?(\.))+?(\d)?(\-conda)?(\-${mobile})(\-|.)?(x\d{2}_\d{2}\-)?(py\d{2,5})?(\.${ext})$"
 #      $url64 = ( $download_page.Links | ? href -match $re64 | Sort-Object -Property 'href' -Descending | Select-Object -First 1 -ExpandProperty 'href' )
       $url64 = ( $download_page | Where-Object Name -match $re64 | Select-Object -First 1 -ExpandProperty 'browser_download_url' )
       $vert = "$version"
@@ -44,9 +44,9 @@ param(
     }
     'stable' {
       $download_page =  (Get-GitHubRelease -Owner "Freecad" -Name "Freecad" -Verbose).assets
-      $mobile = "installer"
+      $mobile = "Windows"
       $ext = "exe"
-      $re64 = "(FreeCAD\-)((\d+)?(\.))+?(\d)?(\-)(WIN)(\-)?(x\d{2})\-(${mobile})(\-|.)?(\d+)?(\.${ext})$"
+      $re64 = $re64 = "(FreeCAD_)?((\d+)?(\.))+?(\d)?(\-conda)?(\-${mobile})(\-|.)?(x\d{2}_\d{2}\-)?(installer)?(\-|.)?(\d+)?(\.${ext})$"
 #      $url64 = ( $download_page.Links | ? href -match $re64 | Sort-Object -Property 'href' -Descending | Select-Object -First 1 -ExpandProperty 'href' )
       $url64 = ( $download_page | Where-Object Name -match $re64 | Select-Object -First 1 -ExpandProperty 'browser_download_url' )
       $vert = "$version"

--- a/automatic/freecad/update_helper.ps1
+++ b/automatic/freecad/update_helper.ps1
@@ -46,7 +46,7 @@ param(
       $download_page =  (Get-GitHubRelease -Owner "Freecad" -Name "Freecad" -Verbose).assets
       $mobile = "Windows"
       $ext = "exe"
-      $re64 = $re64 = "(FreeCAD_)?((\d+)?(\.))+?(\d)?(\-conda)?(\-${mobile})(\-|.)?(x\d{2}_\d{2}\-)?(installer)?(\-|.)?(\d+)?(\.${ext})$"
+      $re64 = "(FreeCAD_)?((\d+)?(\.))+?(\d)?(\-conda)?(\-${mobile})(\-|.)?(x\d{2}_\d{2}\-)?(installer)?(\-|.)?(\d+)?(\.${ext})$"
 #      $url64 = ( $download_page.Links | ? href -match $re64 | Sort-Object -Property 'href' -Descending | Select-Object -First 1 -ExpandProperty 'href' )
       $url64 = ( $download_page | Where-Object Name -match $re64 | Select-Object -First 1 -ExpandProperty 'browser_download_url' )
       $vert = "$version"


### PR DESCRIPTION
## Description
Update the regex to match the newer version of Freecad.


## Motivation and Context
Since Freecad 1.00, the release assets naming scheme changed.
This chocolatey package has been out of date ever since.

This PR is essentially PR #2578 with the changes implemented.

<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
1. Regex Tester
2. Chocolatey-test-environment.
  - The `update.ps1` script was first run locally to update the package version, 
  - then the local packages were used as a source for choco within the test environment.

Stable, portable and dev versions were successfully installed and uninstalled.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
