### PR TITLE
Improve repo tests

### DIFF
--- a/automatic/python3-streams/python3-streams.nuspec
+++ b/automatic/python3-streams/python3-streams.nuspec
@@ -36,7 +36,7 @@ Example: `choco install python314 --params "/InstallDir:C:\your\install\path"`
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/python3-streams</packageSourceUrl>
     <projectSourceUrl>https://www.python.org/downloads/source</projectSourceUrl>
     <dependencies>
-      <dependency id="vcredist140" version="14.0.24215.20170201" />
+      <dependency id="vcredist2015" version="14.0.24215.20170201" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/python3-streams/python3-streams.nuspec
+++ b/automatic/python3-streams/python3-streams.nuspec
@@ -36,7 +36,7 @@ Example: `choco install python314 --params "/InstallDir:C:\your\install\path"`
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/python3-streams</packageSourceUrl>
     <projectSourceUrl>https://www.python.org/downloads/source</projectSourceUrl>
     <dependencies>
-      <dependency id="vcredist2015" version="14.0.24215.20170201" />
+      <dependency id="vcredist140" version="14.0.24215.20170201" />
     </dependencies>
   </metadata>
   <files>

--- a/scripts/Test-RepoPackage.ps1
+++ b/scripts/Test-RepoPackage.ps1
@@ -49,7 +49,7 @@
 #>
 param(
   [string]$packageName = $null,
-  [ValidateSet('all','update','install','uninstall','none')]
+  [ValidateSet('all', 'update', 'install', 'uninstall', 'none')]
   [string]$type = 'all',
   [switch]$CleanFiles,
   [switch]$TakeScreenshots,
@@ -60,663 +60,611 @@ param(
 )
 
 function CheckPackageSizes() {
-  $nupkgFiles = Get-ChildItem "$PSScriptRoot\.." -Filter "*.nupkg" -Recurse
+  $nupkgFiles = Get-ChildItem "$PSScriptRoot\.." -Filter '*.nupkg' -Recurse
 
-  $nupkgFiles | % {
-    $size = $_.Length
+  foreach ($file in $nupkgFiles) {
+    $size = $file.Length
     $maxSize = 200MB
-    $packageName = $_.Directory.Name
+    $pkgName = $file.Directory.Name
+
     if ($size -gt $maxSize) {
-      $friendlySize = $size / 1024 / 1024
-      WriteOutput -type Error "The package $packageName is too large. Maximum allowed size is $($maxSize / 1024 / 1024) MB. Actual size was $friendlySize MB!"
+      $friendlySize = [math]::Round($size / 1MB, 2)
+      WriteOutput -Type Error "The package $pkgName is too large. Maximum allowed size is 200 MB. Actual size was $friendlySize MB!"
       SetAppveyorExitCode -ExitCode 2
-    } else {
-      $index = 0
-      $suffix = @('Bytes';'KB';'MB')
-      $friendlySize = $size
-      while ($friendlySize -ge 1024 -and $index -lt ($suffix.Count - 1)) { $index++; $friendlySize /= 1024 }
-      $friendlySize = "{0:N2} {1}" -f $friendlySize,$suffix[$index]
-      WriteOutput "The size of the package $packageName was $friendlySize."
+    }
+    else {
+      $friendly = switch ($size) {
+        { $_ -lt 1KB } { '{0:N0} Bytes' -f $_ }
+        { $_ -lt 1MB } { '{0:N2} KB' -f ($_ / 1KB) }
+        Default { '{0:N2} MB' -f ($_ / 1MB) }
+      }
+      WriteOutput "The size of the package $pkgName was $friendly."
     }
   }
 }
 
-function CreateSnapshotArchive() {
+function CreateSnapshotArchive {
   param($packages, [string]$artifactsDirectory)
 
-  if (!(Get-Command 7z.exe -ea 0)) { WriteOutput -type Warning "7zip was not found in path, skipping creation of 7zip archive."; return }
-
-  if (!(Test-Path $artifactsDirectory)) { mkdir $artifactsDirectory }
-  $directories = $packages | ? {
-    Test-path "$env:ChocolateyInstall\.chocolatey\$($_.Name)*"
-  } | % {
-    $directory = Resolve-Path "$env:ChocolateyInstall\.chocolatey\$($_.Name)*" | select -last 1
-    "`"$directory`""
+  if (-not (Get-Command 7z.exe -ErrorAction SilentlyContinue)) {
+    WriteOutput -Type Warning '7zip was not found in PATH, skipping snapshot archive'
+    return
   }
 
-  $arguments = @(
-    'a'
-    '-mx9'
-    "`"$artifactsDirectory\install_snapshot.7z`""
-  ) + ($directories | select -Unique)
+  if (-not (Test-Path $artifactsDirectory)) {
+    New-Item $artifactsDirectory -ItemType Directory | Out-Null
+  }
 
-  . 7z $arguments
+  $dirs = $packages |
+  ForEach-Object {
+    $candidate = "$env:ChocolateyInstall\.chocolatey\$($_.Name)*"
+    if (Test-Path $candidate) {
+              (Resolve-Path $candidate | Select-Object -Last 1).ToString()
+    }
+  } |
+  Sort-Object -Unique
+
+  if ($dirs.Count -eq 0) { return }
+  & 7z a -mx9 "`"$artifactsDirectory\install_snapshot.7z`"" $dirs
 }
 
 function CreateLogArchive() {
   param([string]$artifactsDirectory)
 
-  $arguments = @(
-    'a'
-    '-mx9'
-    "`"$artifactsDirectory\choco_logs.7z`""
-    "`"$env:ChocolateyInstall\logs\*`""
-  )
-  . 7z $arguments
+  & 7z a -mx9 "`"$artifactsDirectory\choco_logs.7z`"" "`"$env:ChocolateyInstall\logs\*`""
 }
 
 function WriteOutput() {
-<#
+  <#
 .SYNOPSIS
   Simple helper function to simplify
   the different output methods we use.
 #>
+  [CmdletBinding()]
   param(
-    [Parameter(ValueFromPipeline = $true)]
-    [string]$text,
-    [ValidateSet('Error','Warning','ChocoError','ChocoWarning','ChocoInfo','Normal')]
-    [string]$type = 'Normal'
+    [Parameter(ValueFromPipeline)]
+    [string]$Text,
+    [ValidateSet('Error', 'Warning', 'ChocoError', 'ChocoWarning', 'ChocoInfo', 'Normal')]
+    [string]$Type = 'Normal'
   )
-   switch -Exact ($type) {
-    'Error' { Write-Error $text }
-    'Warning' { Write-Warning $text }
-    'ChocoError' { Write-Host $text -ForegroundColor Black -BackgroundColor Red }
-    'ChocoWarning' { Write-Host $text -ForegroundColor Black -BackgroundColor Yellow }
-    'ChocoInfo' { Write-Host $text -ForegroundColor White -BackgroundColor Black }
-    Default { Write-Host $text }
+  process {
+    switch ($Type) {
+      'Error' { Write-Error        $Text }
+      'Warning' { Write-Warning      $Text }
+      'ChocoError' { Write-Output  $Text }
+      'ChocoWarning' { Write-Output  $Text }
+      'ChocoInfo' { Write-Output  $Text }
+      Default { Write-Output  $Text }
+    }
   }
 }
 
 function WriteChocoOutput() {
-<#
+  <#
 .SYNOPSIS
   A simple helper function for processing the output of choco.
   Only meant to handle the colorization of text.
 #>
+  [CmdletBinding()]
   param(
-    [Parameter(ValueFromPipeline = $true)]
-    [string]$text
+    [Parameter(ValueFromPipeline)]
+    [string]$Text
   )
   begin {}
   process {
-    switch -Regex ($text) {
-      '(^|==\>.*\:)\s*ERROR|\s*Failures|^Uninstall may not be silent' { WriteOutput $text -type ChocoError }
-      '(^|==\>.*\:)\s*WARNING' { WriteOutput $text -type ChocoWarning }
-      Default { WriteOutput $text -type ChocoInfo }
+    switch -Regex ($Text) {
+      '(^|==\>.*\:)\s*ERROR|\s*Failures|^Uninstall may not be silent' { WriteOutput $Text -Type ChocoError }
+      '(^|==\>.*\:)\s*WARNING' { WriteOutput $Text -Type ChocoWarning }
+      Default { WriteOutput $Text -Type ChocoInfo }
     }
   }
-  end {}
 }
 
 function CleanFiles() {
-<#
+  <#
 .SYNOPSIS
   The function responsible for cleaning out temporary
   files before we run the tests.
 #>
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$screenShotDir
-  )
-  $pathsToClean = @(
-    "$env:ChocolateyInstall\logs\*"
-    "$env:TEMP\chocolatey\au\*"
+  param([string]$screenShotDir)
+
+  $paths = @(
+    "$env:ChocolateyInstall\logs\*",
+    "$env:TEMP\chocolatey\au\*",
     "$PSScriptRoot\..\Update-Force-Test*.md"
   )
-  if ($TakeScreenshots) { $pathsToClean += @("$screenShotDir\*") }
-  $pathsToClean += Get-ChildItem -Recurse "$PSScriptRoot\.." -Filter "*.nupkg" | select -Expand FullName
+  if ($TakeScreenshots) { $paths += "$screenShotDir\*" }
+  $paths += (Get-ChildItem -Recurse "$PSScriptRoot\.." -Filter '*.nupkg').FullName
 
-  $pathsToClean | % {
-    if (Test-Path $_) { rm $_ -Recurse }
-  }
+  foreach ($p in $paths) { if (Test-Path $p) { Remove-Item $p -Recurse -Force } }
 }
 
 function GetDependentPackage() {
-<#
+  <#
 .SYNOPSIS
   Function responsible for aquiring a meta package(s) dependency.
 #>
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$packageDirectory
-  )
-  $packageName = $PackageDirectory -split '[\/\\]' | select -last 1
-  $nuspecPath = Get-Item "$PackageDirectory\*.nuspec"
-  $content = Get-Content -Encoding UTF8 $nuspecPath
-  $Matches = $null
-  $content | ? { $_ -match "\<dependency.*id=`"(${packageName}.(install|portable|app|commandline))" } | select -First 1 | WriteOutput
-  $result = if ($Matches) { $Matches[1].ToLowerInvariant() } else { $null }
-  return $result
+  param([string]$packageDirectory)
+
+  $packageName = Split-Path $packageDirectory -Leaf
+  $nuspec = Get-Item "$packageDirectory\*.nuspec"
+  $regex = [regex]"<dependency.*id=`"(${packageName}\.(install|portable|app|commandline))"
+
+  $line = Get-Content -Encoding UTF8 $nuspec | Where-Object { $regex.IsMatch($_) } | Select-Object -First 1
+  if ($null -ne $line) {
+    return $regex.Match($line).Groups[1].Value.ToLowerInvariant()
+  }
+  return $null
 }
 
 function GetPackagePath() {
-<#
+  <#
 .SYNOPSIS
   Gets the full path to the specified package.
 #>
   param([string]$packageName)
-  if ($packageName -eq $null -or $packageName -eq '') {
-    return $null
+  if ([string]::IsNullOrWhiteSpace($packageName)) { return $null }
+
+  $src = Get-ChildItem "$PSScriptRoot\.." -Recurse -Filter "$packageName.nuspec" |
+  Select-Object -First 1 -ExpandProperty Directory
+  if (-not $src) { WriteOutput -Type Warning "No path was found for the package: $packageName" }
+  return $src
+}
+
+function Get-InternalDependency() {
+  <#
+        .SYNOPSIS
+            Return **all** repository-internal dependencies of a nuspec,
+            walking the graph recursively (breadth-first, unique).
+    #>
+  param(
+    [Parameter(Mandatory)]
+    [string]$NuspecPath,
+
+    [hashtable]$Seen = @{}
+  )
+
+  $xml = [xml](Get-Content $NuspecPath -Encoding UTF8)
+  $repoRoot = Resolve-Path "$PSScriptRoot\.."     # script lives in scripts/
+
+  foreach ($dep in $xml.package.metadata.dependencies.dependency) {
+    $id = $dep.id
+    if ($Seen.ContainsKey($id)) { continue }
+
+    $dir = Get-ChildItem $repoRoot -Directory -Filter $id -Recurse | Select-Object -First 1
+    if ($dir) {
+      $Seen[$id] = $true
+      Get-InternalDependency "$($dir.FullName)\$id.nuspec" -Seen $Seen | Out-Null
+    }
   }
-  $sourcePath = gci "$PSScriptRoot\.." -Recurse -Filter "$packageName.nuspec" | select -First 1 -Expand Directory
-  if (!$sourcePath) {
-    WriteOutput "No path was found for the package: $packageName" -type Warning
-  }
-  return $sourcePath
+  return $Seen.Keys
 }
 
 function GetPackageSelectQuery() {
-  param(
-    [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-    $InputObject
-  )
-  begin { $queries = @() }
+  param([Parameter(ValueFromPipeline)]$InputObject)
+  begin { $list = @() }
   process {
-    $queries += $InputObject | select `
-      @{Name = 'NuspecPath'; Expression = {Resolve-Path "$_\*.nuspec"}},
-      @{Name = 'Directory'; Expression = {Resolve-Path $_}},
-      @{Name = 'Name'; Expression = {[System.IO.Path]::GetFileName($_).ToLowerInvariant()}},
-      @{Name = 'IsAutomatic'; Expression = {$_ -match 'automatic[\/\\]'}},
-      @{Name = 'DependentPackage'; Expression = {GetDependentPackage -packageDirectory $_}}
+    $nuspecPath = Resolve-Path "$InputObject\*.nuspec"
+    $list += [pscustomobject]@{
+      NuspecPath           = $nuspecPath
+      Directory            = Resolve-Path $InputObject
+      Name                 = [IO.Path]::GetFileName($InputObject).ToLowerInvariant()
+      IsAutomatic          = $InputObject -match 'automatic[\/\\]'
+      DependentPackage     = GetDependentPackage -packageDirectory $_
+      InternalDependencies = Get-InternalDependency -NuspecPath $nuspecPath
+    }
   }
-  end {
-    $queries
-   }
+  end { $list }
 }
 
 function GetPackagesFromDiff() {
-<#
+  <#
   Gets the changed packages that have changed since the
   latest common ancestor of the current branch, and the specified $diffAgainst branch.
 
 .PARAMETER diffAgainst
   The branch we should run git diff against.
 #>
-  param(
-    [Parameter(Mandatory = $true)]
-    [ValidateNotNull()]
-    [string]$diffAgainst
-  )
-  $paths = git diff "${diffAgainst}..." --name-only | % {
-    if ($_.StartsWith('..')) {
-      $path = Split-Path -Parent $_
-    } else {
-      $root = Resolve-Path "$PSScriptRoot\.." -Relative
-      $path = Split-Path -Parent "$root\$_"
-    }
-    while ($path -and !(Test-Path "$path\*.nuspec")) {
-      $path = Split-Path -Parent $path
-    }
-    if ($path) { $path }
-  } | select -Unique
+  param([string]$diffAgainst)
 
-  return $paths | GetPackageSelectQuery
+  $paths = (git diff "${diffAgainst}..." --name-only | ForEach-Object {
+      $path = if ($_.StartsWith('..')) { Split-Path -Parent $_ } else {
+        $root = Resolve-Path "$PSScriptRoot\.." -Relative
+        Split-Path -Parent "$root\$_"
+      }
+      while ($path -and -not (Test-Path "$path\*.nuspec")) { $path = Split-Path -Parent $path }
+      if ($path) { $path }
+    }
+  ) | Sort-Object -Unique
+
+  $paths | GetPackageSelectQuery
 }
 
 function GetPackagesFromName() {
-  param(
-    [Parameter(Mandatory = $true)]
-    [ValidateNotNullOrEmpty()]
-    [string]$packageName
-  )
-  return Get-ChildItem "$PSScriptRoot\..\" -Recurse -Filter "$packageName.nuspec" | select -Unique -expand Directory | GetPackageSelectQuery
+  param([string]$packageName)
+
+  Get-ChildItem "$PSScriptRoot\.." -Recurse -Filter "$packageName.nuspec" |
+  Select-Object -Unique -ExpandProperty Directory |
+  GetPackageSelectQuery
 }
 
 function MoveLogFile() {
-<#
+  <#
 .SYNOPSIS
   Renames the chocolatey.log file to a file matching the specified packageName and commandType
   so it only contains the necessary log for the current package.
 #>
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$packageName,
-    [Parameter(Mandatory = $true)]
-    [string]$commandType
-  )
+  param([string]$packageName, [string]$commandType)
 
   if (Test-Path "$env:ChocolateyInstall\logs\chocolatey.log") {
-    mv "$env:ChocolateyInstall\logs\chocolatey.log" "$env:ChocolateyInstall\logs\${commandType}_${packageName}.log" | WriteOutput
+    Move-Item "$env:ChocolateyInstall\logs\chocolatey.log" `
+      "$env:ChocolateyInstall\logs\${commandType}_${packageName}.log"
   }
 }
 
 function RemoveDependentPackages() {
-  param(
-    [object]$packages
-  )
+  param($packages)
 
-  [array]$dependentPackages = $packages | ? { $_.DependentPackage -ne $null -and $_.DependentPackage -ne '' } | select -expand DependentPackage
-  if ($dependentPackages -ne $null -and $dependentPackages.Count -gt 0) {
-    $packages = $packages | ? { !$dependentPackages.Contains($_.Name) }
+  $dependent = $packages |
+  Where-Object { $_.DependentPackage } |
+  Select-Object -ExpandProperty DependentPackage
+  if ($null -ne $dependent -and $dependent.Count -gt 0) {
+    $packages = $packages | Where-Object { $dependent -notcontains $_.Name }
   }
   return $packages
 }
 
 function RunChocoPackProcess() {
-<#
+  <#
 .SYNOPSIS
   Function responsible for running choco pack when a nupkg file have not already been created.
 #>
-  param([string]$path)
-  if ($path -ne $null -and $path -ne '') { pushd $path }
-  if (!(Test-Path "*.nupkg")) {
-    . choco pack | WriteChocoOutput
-    if ($LastExitCode -ne 0) { popd; throw "Choco pack failed with code: $LastExitCode"; return }
+  param([string]$Path)
+
+  if (-not $Path) {
+    # nothing to push – just run choco
+    if (-not (Test-Path '*.nupkg')) {
+      choco pack | WriteChocoOutput
+      if ($LASTEXITCODE) { throw "Choco pack failed with code $LASTEXITCODE" }
+    }
+    return
   }
-  if ($path -ne $null -and $path -ne '') { popd}
+
+  Push-Location $Path
+  try {
+    if (-not (Test-Path '*.nupkg')) {
+      choco pack | WriteChocoOutput
+      if ($LASTEXITCODE) { throw "Choco pack failed with code $LASTEXITCODE" }
+    }
+  }
+  finally {
+    Pop-Location
+  }
 }
 
 function SetAppveyorExitCode() {
-<#
+  <#
 .SYNOPSIS
   Sets the exit code of the script when running on appveyor, so
   the build would fail when necessary.
 #>
-  param(
-    [int]$ExitCode
-  )
-  WriteOutput "Exit code was $ExitCode" -type Warning
+  param([int]$ExitCode)
 
-  if (!(Test-Path env:\APPVEYOR)) {
-    return
-  }
-  if ($ExitCode -ne 0) {
-    $host.SetShouldExit($ExitCode)
-  }
+  WriteOutput -Type Warning "Exit code was $ExitCode"
+  if (Test-Path env:\APPVEYOR -and $ExitCode) { $Host.SetShouldExit($ExitCode) }
 }
 
 function RunChocoProcess() {
-<#
+  <#
   Function responsible for running choco install/uninstall
   and handling choco failures.
 #>
   param(
-    [Parameter(Mandatory = $true)]
-    [string[]]$arguments,
-    [Parameter(Mandatory = $true)]
-    [int]$timeout,
-    [Parameter(Mandatory = $true)]
-    [bool]$takeScreenshot,
-    [Parameter(Mandatory = $true)]
-    [int]$timeoutBeforeScreenshot,
-    [Parameter(Mandatory = $true)]
-    [string]$screenShotDir
+    [string[]]$Arguments,
+    [int]     $Timeout,
+    [bool]    $TakeScreenshot,
+    [int]     $TimeoutBeforeScreenshot,
+    [string]  $ScreenShotDir
   )
 
-  $res = $true
-  $args = @($arguments) + @(
-    '--yes'
-    "--execution-timeout=$timeout"
-    "--ignorepackagecodes"
-  )
-  if ($arguments[0] -eq 'uninstall') {
-    $args += @(
-      '--all-versions'
-      '--autouninstaller'
-      '--fail-on-autouninstaller'
-      #'--force'
-    )
+  $result = $true
+  $chocoArgs = @($Arguments) + @('--yes', "--execution-timeout=$Timeout", '--ignorepackagecodes')
+
+  if ($Arguments[0] -eq 'uninstall') {
+    $chocoArgs += '--all-versions', '--autouninstaller', '--fail-on-autouninstaller'
   }
-  $packFailed = $false
-  $errorFilePath = "$screenShotDir\$($arguments[0])Error_$($arguments[1]).jpg"
-  if (!(Test-Path "$screenShotDir")) { mkdir "$screenShotDir" -Force | Out-Null }
 
-  $packageName = $arguments[1] -split ' ' | select -first 1
-  $pkgDir = Get-ChildItem -Path "$PSScriptRoot\.." -Filter "$packageName" -Recurse -Directory | select -first 1
-  $nupkgFile = Get-ChildItem -Path $pkgDir.FullName -Filter "*.nupkg" | select -first 1
-  $pkgNameVersion = Split-Path -Leaf $nupkgFile | % { ($_ -replace '((\.\d+)+(-[^-\.]+)?).nupkg', ':$1').Replace(':.', ':') -split ':' }
-  $packageName = $pkgNameVersion | select -first 1
-  $version     = $pkgNameVersion | select -last 1
-  if ($packageName -ne $arguments[1]) { $args[1] = $packageName }
+  if (-not (Test-Path $ScreenShotDir)) { New-Item $ScreenShotDir -ItemType Directory | Out-Null }
+
+  $pkgName = ($Arguments[1] -split ' ')[0]
+  $pkgDir = Get-ChildItem "$PSScriptRoot\.." -Filter $pkgName -Recurse -Directory | Select-Object -First 1
+  $nupkg = Get-ChildItem $pkgDir.FullName -Filter '*.nupkg' | Select-Object -First 1
+  $parts = (Split-Path -Leaf $nupkg) -replace '((\.\d+)+(-[^-\.]+)?).nupkg', ':$1' -replace ':\.', ':' -split ':'
+  $version = $parts[-1]
+
+  if ($pkgName -ne $Arguments[1]) { $chocoArgs[1] = $pkgName }
 
   try {
-    RunChocoPackProcess '' | WriteChocoOutput
-    if ($arguments[0] -eq 'install') {
-      if ($version) {
-        $args += @("--version=$($version)")
-        if ($version -match '\-') {
-          $args += @('--prerelease')
-        }
-      }
-    }
-    $failureOccurred = $false
-    $previousPercentage = -1;
-    $progressRegex = 'Progress\:.*\s+([\d]+)\%'
-    . choco $args | % {
-      $matches = $null
-      if ($failureOccurred) { WriteOutput "$_" -type ChocoError }
-       # We are only showing progress per 10th value
-      elseif([regex]::IsMatch($_, $progressRegex)) {
-        $progressMatch = [regex]::Match($_, $progressRegex).Groups[1].Value
-        if (($progressMatch % 10) -eq 0) {
-          if ($progressMatch -ne $previousPercentage) {
-            WriteChocoOutput $_
-          }
-          $previousPercentage = $progressMatch
-        }
-      }
-      else { WriteChocoOutput $_ }
+    RunChocoPackProcess ''
 
-      if ($_ -match "Failures") {
-        $failureOccurred = $true
-        $res = $false
-        # Allow everything to complete before we continue
-        sleep -Seconds 5
-        if ($takeScreenshot) {
-          Take-ScreenShot -file $errorFilePath -imagetype jpeg
-          # Wait for a second so the screenshot can be taken before we continue
-          sleep -Seconds 1
-        }
-        if ($arguments[0] -eq 'uninstall') {
-          Stop-Process -ProcessName "unins*" -ErrorAction Ignore
-        }
+    if ($Arguments[0] -eq 'install' -and $version) {
+      $chocoArgs += "--version=$version"
+      if ($version -match '-') { $chocoArgs += '--prerelease' }
+    }
 
-        Stop-Process -ProcessName "*$($arguments[1])*" -ErrorAction Ignore
+    $failure = $false
+    $prevPercent = -1
+    $progressRx = [regex]'Progress\:.*\s+(\d+)\%'
+
+    choco $chocoArgs | ForEach-Object {
+      if ($failure) { WriteOutput $_ -Type ChocoError; return }
+
+      if ($progressRx.IsMatch($_)) {
+        $pct = [int]$progressRx.Match($_).Groups[1].Value
+        if (($pct % 10) -eq 0 -and $pct -ne $prevPercent) {
+          WriteChocoOutput $_
+          $prevPercent = $pct
+        }
       }
-    }
-  } finally {
-    if ($LastExitCode -ne 0) {
-      SetAppveyorExitCode $LastExitCode
-      $res = $false
-    }
-    if ($takeScreenshot -and !$packFailed) {
-      if ($timeoutBeforeScreenshot -gt 0) { sleep -Seconds $timeoutBeforeScreenshot }
-      WriteOutput "Taking screenshot after $($arguments[0])"
-      # We take a screenshot when install/uninstall have finished to see if a program have started that isn't monitored by choco
-      $filePath = "$screenShotDir\$($arguments[0])_$($arguments[1]).jpg"
-      Take-ScreenShot -file $filePath -imagetype jpeg
+      else {
+        WriteChocoOutput $_
+      }
+
+      if ($_ -match 'Failures') {
+        $failure = $true
+        $result = $false
+        Start-Sleep 5
+        if ($TakeScreenshot) {
+          Take-ScreenShot -file "$ScreenShotDir\$($Arguments[0])Error_$pkgName.jpg" -imagetype jpeg
+          Start-Sleep 1
+        }
+        if ($Arguments[0] -eq 'uninstall') { Stop-Process -ProcessName 'unins*' -ErrorAction Ignore }
+        Stop-Process -ProcessName "*$pkgName*" -ErrorAction Ignore
+      }
     }
   }
-  return $res
+  finally {
+    if ($LASTEXITCODE) { SetAppveyorExitCode $LASTEXITCODE; $result = $false }
+
+    if ($TakeScreenshot) {
+      if ($TimeoutBeforeScreenshot -gt 0) { Start-Sleep -Seconds $TimeoutBeforeScreenshot }
+      WriteOutput "Taking screenshot after $($Arguments[0])"
+      Take-ScreenShot -file "$ScreenShotDir\$($Arguments[0])_$pkgName.jpg" -imagetype jpeg
+    }
+  }
+  return $result
 }
 
 function InstallPackage() {
-<#
+  <#
 .SYNOPSIS
   Function responsible for testing the installation of a single package.
 #>
   param(
-    [Parameter(Mandatory = $true)]
     $package,
-    [Parameter(Mandatory = $true)]
     [int]$chocoCommandTimeout,
-    [Parameter(Mandatory = $true)]
     [int]$screenshotTimeout,
-    [Parameter(Mandatory = $true)]
     [bool]$takeScreenshot,
-    [Parameter(Mandatory = $true)]
     [string]$screenShotDir
   )
 
-  $dependentSource = GetPackagePath -packageName $package.DependentPackage
-  if ($dependentSource) {
-    try {
-      RunChocoPackProcess -path $dependentSource | WriteChocoOutput
-    } catch {
-      WriteOutput "$_" -type Error
-      return $package.Name
-    }
-    $sources = "$($_.Directory);$dependentSource;chocolatey"
-  } else {
-    $sources = "$($_.Directory);chocolatey"
+  $depDirs = foreach ($depId in $package.InternalDependencies) {
+    $dir = GetPackagePath -packageName $depId
+    if ($dir) { RunChocoPackProcess -Path $dir; $dir }
   }
 
-  $arguments = @{
-    timeout = $chocoCommandTimeout
-    takeScreenshot = $takeScreenshot
-    timeoutBeforeScreenshot = $screenshotTimeout
-    arguments = 'install',$package.Name,"--source=`"$sources`""
-    screenShotDir = $screenShotDir
+  $sources = @($package.Directory) + $depDirs + 'chocolatey' | Sort-Object -Unique -Descending
+  $srcList = $sources -join ';'
+
+  $chocoArgs = @{
+    Timeout                 = $chocoCommandTimeout
+    TakeScreenshot          = $takeScreenshot
+    TimeoutBeforeScreenshot = $screenshotTimeout
+    Arguments               = @('install', $package.Name, "--source=`"$srcList`"")
+    ScreenShotDir           = $screenShotDir
   }
 
   try {
-  if (!(RunChocoProcess @arguments)) { return $package.Name }
-  } catch {
-    WriteOutput "$_" -type Error
+    if (-not (RunChocoProcess @chocoArgs)) { return $package.Name }
+  }
+  catch {
+    WriteOutput $_ -Type Error
     return $package.Name
   }
-
-  return ""
+  return ''
 }
 
 function TestAuUpdatePackages() {
-<#
+  <#
 .SYNOPSIS
   Function responsible for running au on the specified packages.
 #>
-  param(
-    $packages
-  )
-  [array]$packageNames = $packages | ? IsAutomatic | select -expand Name
-  $packageNames += $packages | ? { $_.DependentPackage -ne $null -and $_.DependentPackage -ne '' } | select -expand DependentPackage
-  if (!$packageNames) {
-    WriteOutput "No Automatic packages was found. Skipping Chocolatey AU update test."
-    return
-  }
+  param($packages)
+
+  $auto = $packages | Where-Object IsAutomatic | Select-Object -ExpandProperty Name
+  $meta = $packages | Where-Object { $_.DependentPackage } | Select-Object -ExpandProperty DependentPackage
+  $names = $auto + $meta
+
+  if (-not $names) { WriteOutput 'No automatic packages found – skipping AU test.'; return }
 
   try {
-    pushd "$PSScriptRoot\.."
-    .\test_all.ps1 -Name $packageNames -ThrowOnErrors
-  } catch {
-    SetAppveyorExitCode $LastExitCode
-    throw "An exception ocurred during Chocolatey AU update. Cancelling all other checks."
-  } finally {
+    Push-Location "$PSScriptRoot\.."
+    .\test_all.ps1 -Name $names -ThrowOnErrors
+  }
+  catch {
+    SetAppveyorExitCode $LASTEXITCODE
+    throw 'Exception during Chocolatey-AU update – aborting.'
+  }
+  finally {
     MoveLogFile -packageName 'chocolatey-au' -commandType 'update'
-    popd
+    Pop-Location
   }
 }
 
-function RunUpdateScripts {
-  param(
-    $packages
-  )
-  [array]$manualPackages = $packages | ? { !$_.IsAutomatic -and (Test-Path "$($_.Directory)\update.ps1") }
-  # Currently we do not support dependent packages
-  if (!$manualPackages) {
-    WriteOutput "No manual packages that contain an update script"
-    return
-  }
+function RunUpdateScripts() {
+  param($packages)
 
-  $manualPackages | % {
-    $name = $_.Name
-    WriteOutput "Running update.ps1 for $name"
-    try {
-      pushd $_.Directory
-      .\update.ps1
-    } catch {
-      SetAppveyorExitCode 1
-      throw "An exception ocurred during the manual update of $name. Cancelling all other checks."
-    } finally {
-      popd
-    }
+  $manual = $packages | Where-Object { -not $_.IsAutomatic -and (Test-Path "$($_.Directory)\update.ps1") }
+  if (-not $manual) { WriteOutput 'No manual packages with update.ps1 found'; return }
+
+  foreach ($p in $manual) {
+    WriteOutput "Running update.ps1 for $($p.Name)"
+    try { Push-Location $p.Directory; .\update.ps1 }
+    catch { SetAppveyorExitCode 1; throw "Manual update for $($p.Name) failed – aborting." }
+    finally { Pop-Location }
   }
 }
 
 function TestInstallAllPackages() {
-<#
+  <#
 .SYNOPSIS
   Function responsible for running the install tests on the specified packages.
 #>
   param(
-    [Parameter(Mandatory = $true)]
     $packages,
-    [Parameter(Mandatory = $true)]
     [int]$chocoCommandTimeout,
-    [Parameter(Mandatory = $true)]
     [int]$screenshotTimeout,
-    [Parameter(Mandatory = $true)]
     [bool]$takeScreenshot,
-    [Parameter(Mandatory = $true)]
     [string]$screenShotDir,
-    [Parameter(ValueFromRemainingArguments = $true)]
     [object[]]$ignoredValues
   )
 
-  $packages | % {
-    pushd $_.Directory
-    if ($runChocoWithAu) { Test-Package -Install | WriteChocoOutput }
-    else {
-      InstallPackage `
-        -package $_ `
-        -chocoCommandTimeout $chocoCommandTimeout `
-        -screenshotTimeout $screenshotTimeout `
-        -takeScreenshot $takeScreenshot `
-        -screenShotDir $screenShotDir
-      MoveLogFile -packageName $_.Name -commandType 'install'
+  $null = $ignoredValues   # mark as used
+
+  foreach ($p in $packages) {
+    Push-Location $p.Directory
+    try {
+      if ($runChocoWithAu) {
+        Test-Package -Install | WriteChocoOutput
+      }
+      else {
+        InstallPackage `
+          -package $p `
+          -chocoCommandTimeout $chocoCommandTimeout `
+          -screenshotTimeout $screenshotTimeout `
+          -takeScreenshot $takeScreenshot `
+          -screenShotDir $screenShotDir |
+        ForEach-Object { $_ }                      # emit result
+        MoveLogFile -packageName $p.Name -commandType 'install'
+      }
     }
-    popd
-  } | ? { $_ -ne $null -and $_ -ne '' }
+    finally { Pop-Location }
+  }
 }
 
 function UninstallPackage() {
-<#
+  <#
 .SYNOPSIS
   Function responsible for testing the uninstallation of a single package.
 #>
   param(
-    [Parameter(Mandatory = $true)]
     $package,
-    [Parameter(Mandatory = $true)]
     [int]$chocoCommandTimeout,
-    [Parameter(Mandatory = $true)]
     [int]$screenshotTimeout,
-    [Parameter(Mandatory = $true)]
     [bool]$takeScreenshot,
-    [Parameter(Mandatory = $true)]
     [string]$screenShotDir
   )
 
-  $dependentSource = GetPackagePath -packageName $package.DependentPackage
-  if ($dependentSource) {
-    try {
-      RunChocoPackProcess -path $dependentSource | WriteOutput
-    } catch {
-      WriteOutput "$_" -type Error
-      return $package.Name
-    }
-    $packageNames = @($package.Name ; $package.DependentPackage)
-  } else {
-    $packageNames = @($package.Name)
+  $names = @($package.InternalDependencies + $package.Name) | Select-Object -Unique
+  [array]::Reverse($names)
+
+  $chocoArgs = @{
+    Timeout                 = $chocoCommandTimeout
+    TakeScreenshot          = $takeScreenshot
+    TimeoutBeforeScreenshot = $screenshotTimeout
+    Arguments               = @('uninstall') + $names
+    ScreenShotDir           = $screenShotDir
   }
 
-  $arguments = @{
-    timeout = $chocoCommandTimeout
-    takeScreenshot = $takeScreenshot
-    timeoutBeforeScreenshot = $screenshotTimeout
-    arguments = @('uninstall';$packageNames)
-    screenShotDir = $screenShotDir
-  }
   try {
-    if (!(RunChocoProcess @arguments)) { return $package.Name }
-  } catch {
-    WriteOutput "$_" -type Error
+    if (-not (RunChocoProcess @chocoArgs)) { return $package.Name }
+  }
+  catch {
+    WriteOutput $_ -Type Error
     return $package.Name
   }
-
-  return ""
+  return ''
 }
 
 function TestUninstallAllPackages() {
-<#
+  <#
 .SYNOPSIS
   Function responsible for running the uninstall tests on the specified packages.
   But only if the package names isn't listed in the specified failedInstall object array.
 #>
   param(
-    [Parameter(Mandatory = $true)]
     $packages,
-    [Parameter(Mandatory = $true)]
     [int]$chocoCommandTimeout,
-    [Parameter(Mandatory = $true)]
     [int]$screenshotTimeout,
-    [Parameter(Mandatory = $true)]
     [bool]$takeScreenshot,
-    [Parameter(Mandatory = $true)]
     [string]$screenShotDir,
     [object[]]$failedInstalls,
-    [Parameter(ValueFromRemainingArguments = $true)]
     [object[]]$ignoredValues
   )
 
-  $packages | % {
-    $name = $_.Name
-    $packageFailed = $failedInstalls | ? { $_ -eq $name }
-    if ($packageFailed) {
-      WriteOutput "$name failed to install, skipping uninstall test..." -type Warning
-      return ""
-    } else {
-      pushd $_.Directory
-      if ($runChocoWithAu) { Test-Package -Uninstall | WriteChocoOutput }
+  $null = $ignoredValues   # mark as used
+
+  foreach ($p in $packages) {
+    if ($failedInstalls -contains $p.Name) {
+      WriteOutput "$($p.Name) failed to install, skipping uninstall…" -Type Warning
+      continue
+    }
+
+    Push-Location $p.Directory
+    try {
+      if ($runChocoWithAu) {
+        Test-Package -Uninstall | WriteChocoOutput
+      }
       else {
         UninstallPackage `
-          -package $_ `
+          -package $p `
           -chocoCommandTimeout $chocoCommandTimeout `
           -screenshotTimeout $screenshotTimeout `
           -takeScreenshot $takeScreenshot `
-          -screenShotDir $screenShotDir
-        MoveLogFile -packageName $name -commandType 'uninstall'
+          -screenShotDir $screenShotDir |
+        ForEach-Object { $_ }                      # emit result
+        MoveLogFile -packageName $p.Name -commandType 'uninstall'
       }
-      popd
     }
-  } | ? { $_ -ne $null -and $_ -ne '' }
+    finally { Pop-Location }
+  }
 }
 
-if ($packageName) {
-  $packages = GetPackagesFromName -packageName $packageName
-} else {
-  $packages = GetPackagesFromDiff -diffAgainst 'origin/master'
+$packages = if ($packageName) {
+  GetPackagesFromName -packageName $packageName
+}
+else {
+  GetPackagesFromDiff -diffAgainst 'origin/master'
 }
 
 $packages = RemoveDependentPackages -packages $packages
 
-if ($CleanFiles) {
-    CleanFiles -screenShotDir $artifactsDirectory
-}
+if ($CleanFiles) { CleanFiles -screenShotDir $artifactsDirectory }
 
-if (!$packages) {
-  WriteOutput "No changed packages was found. Exiting tests..." -type Warning
-  return;
-}
+if (-not $packages) { WriteOutput 'No changed packages detected – exiting.' -Type Warning; return }
 
 if ($TakeScreenshots) { . "$PSScriptRoot\Take-ScreenShot.ps1" }
-$arguments = @{
-  packages = $packages
+
+$commonArgs = @{
+  packages            = $packages
   chocoCommandTimeout = $chocoCommandTimeout
-  takeScreenshot = $TakeScreenshots
-  screenShotTimeout = $timeoutBeforeScreenshot
-  screenShotDir = $artifactsDirectory
+  takeScreenshot      = $TakeScreenshots
+  screenshotTimeout   = $timeoutBeforeScreenshot
+  screenShotDir       = $artifactsDirectory
 }
 
-if (@('all','update').Contains($type)) {
-  TestAuUpdatePackages -packages $packages
-  RunUpdateScripts -packages $packages
+if ('all', 'update' -contains $type) { TestAuUpdatePackages @commonArgs; RunUpdateScripts -packages $packages }
+if ('all', 'install' -contains $type) {
+  $failedInstalls = TestInstallAllPackages @commonArgs
+  if (-not $runChocoWithAu) { CreateSnapshotArchive -packages $packages -artifactsDirectory $artifactsDirectory }
 }
-if (@('all','install').Contains($type)) {
-  [array]$failedInstalls = TestInstallAllPackages @arguments
-  if (!$runChocoWithAu) { CreateSnapshotArchive -packages $packages -artifactsDirectory $artifactsDirectory }
-} else { $failedInstalls = @() }
-if (@('all','uninstall').Contains($type)) {
-  [array]$failedUninstalls = TestUninstallAllPackages @arguments -failedInstalls $failedInstalls
+else { $failedInstalls = @() }
+if ('all', 'uninstall' -contains $type) {
+  $failedUninstalls = TestUninstallAllPackages @commonArgs -failedInstalls $failedInstalls
 }
-if (@('all','install','uninstall').Contains($type) -and !$runChocoWithAu) { CreateLogArchive $artifactsDirectory }
+if (('all', 'install', 'uninstall') -contains $type -and -not $runChocoWithAu) { CreateLogArchive $artifactsDirectory }
 
-if ($failedInstalls.Count -gt 0) {
-  WriteOutput "The following packages failed to install:" -type ChocoWarning
-  WriteOutput "    $($failedInstalls -join ' ')" -type ChocoWarning
-}
-if ($failedUninstalls.Count -gt 0) {
-  WriteOutput "The following packages failed to uninstall:" -type ChocoWarning
-  WriteOutput "    $($failedUninstalls -join ' ')" -type ChocoWarning
-}
+if ($failedInstalls) { WriteOutput "Packages failed to install:`n    $($failedInstalls -join ' ')"   -Type ChocoWarning }
+if ($failedUninstalls) { WriteOutput "Packages failed to uninstall:`n    $($failedUninstalls -join ' ')" -Type ChocoWarning }
 
 CheckPackageSizes


### PR DESCRIPTION
## Description
Test-RepoPackage.ps1 refactor:

- Added Get-InternalDependency and automatic packing/ordering of in-repo dependencies.
- Tidier output and progress reporting (10 % steps, plain text for CI).
- Safer error-handling, early‐returns and proper Push/Pop-Location blocks.
- Better log/snapshot archiving and fast-fail exit-codes for AppVeyor.
- General code-style cleanup (cmdlet-binding, pipelines, naming).

## Motivation and Context

- CI missed transitive dependencies (e.g. python -> python3 -> python314); the rewrite makes the test harness faster, more reliable and easier to maintain.

fixes: #2678

## How Has this Been Tested?

- Ran `test_all.ps1` and observed the failure.
- Applied the fixes.
- Ran `test_all.ps1` and verified the failure is gone.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).