### PR TITLE
(maint) Updates Supported Versions of Chocolatey CLI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,7 @@ environment:
 
   #Chocolatey version we want to use when checking for updates (usually latest).
   choco_version: '2.4.3'
-  choco_version_pr: '2.2.2'
+  choco_version_pr: '2.3.0'
   nupkg_cache_path: C:\packages
 
 init:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -31,7 +31,6 @@ body:
         - 2.4.1
         - 2.4.0
         - 2.3.0
-        - 2.2.2
         - Other (note in the comments)
     validations:
       required: true


### PR DESCRIPTION
## Description

This change removes it from the issues templates, as well as updating the "PR version" used by AppVeyor to 2.3.0.

## Motivation and Context

Chocolatey CLI 2.2.2 is now more than a year old.

This repository supports the latest versions that are less than a year old, so we are removing 2.2.2 from the supported configuration.

## How Has this Been Tested?

No testing has been done.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~
- [x] Documentation only

## Checklist:

- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- ~[ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.~
- ~[ ] The changes only affect a single package (not including meta package).~

