### PR TITLE
(selenium-chromium-edge-driver) base url change

### DIFF
--- a/automatic/selenium-chromium-edge-driver/selenium-chromium-edge-driver.nuspec
+++ b/automatic/selenium-chromium-edge-driver/selenium-chromium-edge-driver.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/</projectUrl>
     <!-- Do not touch the icon URL, it will be updated automatically during the update check -->
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-packages@61b9a911f150dda68e67c519f839f149231650b2/icons/selenium-chromium-edge-driver.png</iconUrl>
-    <licenseUrl>https://msedgedriver.azureedge.net/EULA</licenseUrl>
+    <licenseUrl>https://msedgedriver.microsoft.com/EULA</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <!-- Do not touch the description, it is automatically updated from the Readme.md file. -->
     <description><![CDATA[WebDriver is an open source tool for automated testing of webapps across many browsers. It provides capabilities for navigating to web pages, user input, JavaScript execution, and more. MSEdgeDriver is a standalone server which implements WebDriver's wire protocol (https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol) for Chromium.

--- a/automatic/selenium-chromium-edge-driver/update.ps1
+++ b/automatic/selenium-chromium-edge-driver/update.ps1
@@ -33,8 +33,8 @@ function global:au_GetLatest {
   Invoke-WebRequest -URI $releases -OutFile $stableVersionFile -UseBasicParsing
   $packageVersion = Get-Content $stableVersionFile
 
-  $url32 = "https://msedgedriver.azureedge.net/$packageVersion/edgedriver_win32.zip"
-  $url64 = "https://msedgedriver.azureedge.net/$packageVersion/edgedriver_win64.zip"
+  $url32 = "https://msedgedriver.microsoft.com/$packageVersion/edgedriver_win32.zip"
+  $url64 = "https://msedgedriver.microsoft.com/$packageVersion/edgedriver_win64.zip"
 
   @{
     Version        = $packageVersion


### PR DESCRIPTION
## Description
Changed base URL in `selenium-chromium-edge-driver.nuspec` & `update.ps1`-file. 
From https://msedgedriver.azureedge.net/
to https://msedgedriver.microsoft.com/

## Motivation and Context
Trying to automate an automation setup in an vm, and this URL is blocking the installation of `selenium-chromium-edge-driver`.

## How Has this Been Tested?
Ran the command `choco install selenium-chromium-edge-driver`.
This is the result:
``` bash
Chocolatey v2.5.0
Installing the following packages:
selenium-chromium-edge-driver
By installing, you accept licenses for the packages.
Downloading package from source 'https://community.chocolatey.org/api/v2/'
Progress: Downloading selenium-chromium-edge-driver 138.0.3351.83... 100%

selenium-chromium-edge-driver v138.0.3351.83 [Approved]
selenium-chromium-edge-driver package files install completed. Performing other installation steps.
Attempt to get headers for https://msedgedriver.azureedge.net/138.0.3351.83/edgedriver_win64.zip failed.
  The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://msedgedriver.azureedge.net/138.0.3351.83/edgedriver_win64.zip'. Exception calling "GetResponse" with "0" argument(s): "The remote name could not be resolved: 'msedgedriver.azureedge.net'"
Downloading selenium-chromium-edge-driver 64 bit
  from 'https://msedgedriver.azureedge.net/138.0.3351.83/edgedriver_win64.zip'
ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://msedgedriver.azureedge.net/138.0.3351.83/edgedriver_win64.zip'. Exception calling "GetResponse" with "0" argument(s): "The remote name could not be resolved: 'msedgedriver.azureedge.net'" 
This package is likely not broken for licensed users - see https://docs.chocolatey.org/en-us/features/private-cdn.
The install of selenium-chromium-edge-driver was NOT successful.
Error while running 'C:\tools\chocolatey\lib\selenium-chromium-edge-driver\tools\chocolateyinstall.ps1'.
 See log for details.
 ```

## Screenshot (if appropriate, usually isn't needed):
<img width="930" height="682" alt="Screenshot 2025-07-31 at 14 30 12" src="https://github.com/user-attachments/assets/e2c75d0f-562b-466a-b756-c5738f264833" />

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
