### PR TITLE
(7zip.install) Shim 7zG.exe as well

### DIFF
--- a/automatic/7zip.install/tools/chocolateyInstall.ps1
+++ b/automatic/7zip.install/tools/chocolateyInstall.ps1
@@ -21,3 +21,4 @@ if (!$installLocation)  { Write-Warning "Can't find 7zip install location"; retu
 Write-Host "7zip installed to '$installLocation'"
 
 Install-BinFile '7z' $installLocation\7z.exe
+Install-BinFile '7zG' $installLocation\7zG.exe

--- a/automatic/7zip.install/tools/chocolateyUninstall.ps1
+++ b/automatic/7zip.install/tools/chocolateyUninstall.ps1
@@ -17,6 +17,7 @@ if ($key.Count -eq 1) {
 
     Uninstall-ChocolateyPackage @packageArgs
     Uninstall-BinFile -Name "7z.exe" -Path $packageArgs["file"]
+    Uninstall-BinFile -Name "7zG.exe" -Path $packageArgs["file"]
   }
 } elseif ($key.Count -eq 0) {
   Write-Warning "$packageName has already been uninstalled by other means."


### PR DESCRIPTION
## Description
Shim the 7zG.exe command line tool in addition to the existing 7z.exe shim

## Motivation and Context
7zG should be in PATH if 7z.exe is in there too, as both might be used interchangably (7zG spawns a GUI window to show progress, which is an user feedback enhancement if unpacking/testing a long archive).
My personal use case for this is would be to make an explorer right click entry to unzip zip files using a different codepage than the current systemwide one, which wouldn't spawn a terminal window.

## How Has this Been Tested?
Works as excepted. To test I went in the install script, replaced the file in the packageArgs to the path of a 7z2500-x64.exe I downloaded from 7-zip's site. Tested using 7zG from the command line worked, and that the shim gets removed on uninstall.
Change is low risk, so I didn't went to test further, everything I tried works correctly, and no existing functionality seems broken.

I do not have the necessary disk space to test on the vagrant box, should be quick to check at least.

## Screenshot (if appropriate, usually isn't needed):
Feel free to ask for one

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [-] My change requires a change to documentation (this usually means the notes in the description of a package).
- [-] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [-] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [SKIP] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).

