### PR TITLE
(ruby.portable) Shim bat and cmd

### DIFF
--- a/automatic/ruby.portable/tools/chocolateyInstall.ps1
+++ b/automatic/ruby.portable/tools/chocolateyInstall.ps1
@@ -10,4 +10,12 @@ $packageArgs = @{
 
 Get-ChocolateyUnzip @packageArgs
 
+# Add shims for .bat and .cmd files, in the bin folder, that Chocolatey CLI will not shim
+$rubyDir = Join-Path -Path $toolsPath -ChildPath 'ruby\ruby*\bin\'
+'*.bat', '*.cmd' | ForEach-Object {
+  Get-ChildItem -Path (Join-Path -Path $rubyDir -ChildPath $_) | ForEach-Object {
+    Install-BinFile -Name $_.BaseName -Path $_.FullName
+  }
+}
+
 Get-ChildItem $toolsPath\*.7z | ForEach-Object { Remove-Item $_ -ea 0 }

--- a/automatic/ruby.portable/tools/chocolateyUninstall.ps1
+++ b/automatic/ruby.portable/tools/chocolateyUninstall.ps1
@@ -1,0 +1,10 @@
+﻿$ErrorActionPreference = 'Stop'
+$toolsPath = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
+
+# Remove shims added for .bat and .cmd files, in the Ruby bin folder
+$rubyDir = Join-Path -Path $toolsPath -ChildPath 'ruby\ruby*\bin\'
+'*.bat', '*.cmd' | ForEach-Object {
+  Get-ChildItem -Path (Join-Path -Path $rubyDir -ChildPath $_) | ForEach-Object {
+    Remove-BinFile -Name $_.BaseName -Path $_.FullName
+  }
+}


### PR DESCRIPTION
## Description
To fix #2256, the .bat and .cmd files in the Ruby bin folder are shimmed. 

## Motivation and Context
When the package is installed, commands in the Ruby bin folder are not added to the path or shimmed, so are not available on the command line everywhere. 

## How Has this Been Tested?
A new package was created with the code and run in the Chocolatey Test Environment. Shims are created on install and removed on uninstall. 

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
