### PR TITLE
(curl) Removes x86 Installer from Package

### DIFF
--- a/automatic/curl/legal/VERIFICATION.txt
+++ b/automatic/curl/legal/VERIFICATION.txt
@@ -6,7 +6,6 @@ Package can be verified like this:
 
 1. Go to https://curl.se/windows/, and look for the official binaries provided.
 
-   x32: https://curl.se/windows/dl-8.15.0_1/curl-8.15.0_1-win32-mingw.zip
    x64: https://curl.se/windows/dl-8.15.0_1/curl-8.15.0_1-win64-mingw.zip
 
    to download the zip files. You may wish to rename one of the files.
@@ -15,7 +14,6 @@ Package can be verified like this:
    - Use powershell function 'Get-FileHash'
    - Use Chocolatey utility 'checksum.exe'
 
-   checksum32: 8C3C291CB7B4BEDFE31562833CEF1BFD29F19EAD4BACD5070A080CBABF9D05B8
    checksum64: FE569416CF023A401F5369A7E7C14AA5673F9A847B1E570AE53F309D8BAE0D1C
 
 File 'LICENSE.txt' obtained from:

--- a/automatic/curl/update.ps1
+++ b/automatic/curl/update.ps1
@@ -6,9 +6,7 @@ function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt"      = @{
       "(?i)(Go to)\s*[^,]*" = "`${1} $releases"
-      "(?i)(\s+x32:).*"     = "`${1} $($Latest.URL32)"
       "(?i)(\s+x64:).*"     = "`${1} $($Latest.URL64)"
-      "(?i)(checksum32:).*" = "`${1} $($Latest.Checksum32)"
       "(?i)(checksum64:).*" = "`${1} $($Latest.Checksum64)"
     }
 
@@ -17,7 +15,6 @@ function global:au_SearchReplace {
     }
 
     ".\tools\chocolateyInstall.ps1" = @{
-      "(?i)(^\s*FileFullPath\s*=\s*`"`[$]toolsPath\\).*`""   = "`${1}$($Latest.FileName32)`""
       "(?i)(^\s*FileFullPath64\s*=\s*`"`[$]toolsPath\\).*`"" = "`${1}$($Latest.FileName64)`""
     }
   }
@@ -40,7 +37,6 @@ function global:au_GetLatest {
 
   @{
     Version      = $version
-    URL32        = $url -match 'win32' | Select-Object -first 1
     URL64        = $url | Where-Object { $_ -notmatch 'win32' -and $_ -match $version } | Select-Object -first 1
     ReleaseNotes = $releaseNotes
   }


### PR DESCRIPTION
## Description

This commit removes the x86 installer from the package, as when browsing the download page, it seems that curl.se is no longer publishing files for the x86 arch.

The source code is still available for compilation, if required.

## Motivation and Context

Curl has been failing the package update, due to the removal of the x86 installer from the downloads page.

## How Has this Been Tested?

- Ran `.\update_all.ps1 -Name curl`, observed failure
- Updated package files
- Ran `.\update_all.ps1 -Name curl`, got update for 8.16.0

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
