### PR TITLE
(curl) Remove mention of 32bit file

### DIFF
--- a/automatic/curl/tools/chocolateyInstall.ps1
+++ b/automatic/curl/tools/chocolateyInstall.ps1
@@ -4,7 +4,6 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
     PackageName    = $env:chocolateyPackageName
-    FileFullPath   = "$toolsPath\curl-8.15.0_1-win32-mingw.zip"
     FileFullPath64 = "$toolsPath\curl-8.16.0_2-win64-mingw.zip"
     Destination    = $toolsPath
 }


### PR DESCRIPTION
## Description

Additional change following this [PR](https://github.com/chocolatey-community/chocolatey-packages/pull/2713).

## Motivation and Context

This should have been included in the previous commit, where the 32bit installer was removed, as it is no longer provided by the project.

## How Has this Been Tested?

- Ran .\update_all.ps1 -Name curl, observed failure
- Updated package files
- Ran .\update_all.ps1 -Name curl, got update for 8.16.0

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).