### PR TITLE
(1password8) Fix Download Link Generation

### DIFF
--- a/automatic/1password8/update.ps1
+++ b/automatic/1password8/update.ps1
@@ -1,5 +1,4 @@
 ﻿Import-Module Chocolatey-AU
-. "$PSScriptRoot\..\1password\update_helper.ps1"
 
 function global:au_SearchReplace {
   @{
@@ -18,8 +17,11 @@ function Find-1Password8Stream {
 
   if ($releasesPage -match 'Updated to (?<version>8\.[\d\.]+) on') {
     $version = Get-Version $Matches['version']
-    $url = $releasesPage.Links | Where-Object href -match 'Setup.*\.exe$' | Where-Object href -NotMatch 'BETA' | Select-Object -First 1 -ExpandProperty href
-    $url = $url -replace 'LATEST', $version -replace '\.exe$','.msi' # The MSI is documented on: https://support.1password.com/deploy-1password/
+
+    # We are using a semi-hardcoded link here, as we are not ready to move to the MSIX installer.
+    # The direct MSI downloads, though not advertised on the download page, are still valid -
+    # See: https://support.1password.com/deploy-1password/
+    $url = "https://downloads.1password.com/win/1PasswordSetup-$($version).msi"
 
     @{
       URL32          = $url


### PR DESCRIPTION
## Description

This PR modifies the update script to have a more brittle (but also working) method for grabbing the MSI link, due to the change in the provided link from 1password.

## Motivation and Context

The update script was failing to find the setup, as 1Password has moved to providing only msix links on the default download page.

MSI links still exist based on the version, so we will rely on that not changing for now.

## How Has this Been Tested?

- Updated the package (and the 1password package)
- Tested installation / uninstallation of the package

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).
    The changes technically fix both 1password8 and 1password for the same reason.
