### PR TITLE
(vlc*) Use HTTPS for VLC download URLs

### DIFF
--- a/automatic/vlc.install/update.ps1
+++ b/automatic/vlc.install/update.ps1
@@ -21,4 +21,4 @@ function global:au_SearchReplace {
 
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge }
 
-update -ChecksumFor none
+update -ChecksumFor none -NoCheckUrl

--- a/automatic/vlc.portable/update.ps1
+++ b/automatic/vlc.portable/update.ps1
@@ -29,4 +29,4 @@ function global:au_GetLatest {
     }
 }
 
-update -ChecksumFor none
+update -ChecksumFor none -NoCheckUrl

--- a/automatic/vlc.portable/update.ps1
+++ b/automatic/vlc.portable/update.ps1
@@ -25,7 +25,7 @@ function global:au_GetLatest {
     $version  = $url -split '-' | Select-Object -Last 1 -Skip 1
     @{
         Version      = $version
-        URL32        = 'http:' + $url
+        URL32        = 'https:' + $url
     }
 }
 

--- a/automatic/vlc/update.ps1
+++ b/automatic/vlc/update.ps1
@@ -17,8 +17,8 @@ function global:au_GetLatest {
     $version  = $url[0] -split '-' | Select-Object -Last 1 -Skip 1
     @{
         Version      = $version
-        URL32        = 'http:' + ( $url -match 'win32' | Select-Object -first 1 )
-        URL64        = 'http:' + ( $url -match 'win64' | Select-Object -first 1 )
+        URL32        = 'https:' + ( $url -match 'win32' | Select-Object -first 1 )
+        URL64        = 'https:' + ( $url -match 'win64' | Select-Object -first 1 )
     }
 }
 

--- a/automatic/vlc/update.ps1
+++ b/automatic/vlc/update.ps1
@@ -23,5 +23,5 @@ function global:au_GetLatest {
 }
 
 if ($MyInvocation.InvocationName -ne '.') {
-  update -ChecksumFor none
+  update -ChecksumFor none -NoCheckUrl
 }


### PR DESCRIPTION
## Description
- PowerShell update to construct VLC download URLs with HTTPS instead of HTTP.
- Change URL32 and URL64 in automatic/vlc/update.ps1 and URL32 in automatic/vlc.portable/update.ps1 to prefix generated links with 'https:'.

## Motivation and Context
- Ensure secure downloads and avoid mixed content or insecure redirects by using HTTPS for VLC download URLs.
- Aligns with modern transport security requirements and fixes potential security issues.

## How Has this Been Tested?

- Run `.\update_all.ps1 "vlc*" -ForcedPackages "vlc vlc.install vlc.portable"`
- Verify no errors are reported.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_. (_not needed as there are no changes to the package itself_)
- [ ] The changes only affect a single package (not including meta package).