### PR TITLE
(maint) Stop publishing releases for packages

### DIFF
--- a/update_all.ps1
+++ b/update_all.ps1
@@ -47,7 +47,7 @@ $Options = [ordered]@{
     Params = @{                                          #Report parameters:
       Github_UserRepo = $Env:github_user_repo         #  Markdown: shows user info in upper right corner
       NoAppVeyor      = $false                            #  Markdown: do not show AppVeyor build shield
-      UserMessage     = "[Ignored](#ignored) | [History](#update-history) | [Force Test](https://gist.github.com/$Env:gist_id_test) | [Releases](https://github.com/$Env:github_user_repo/tags)"       #  Markdown, Text: Custom user message to show
+      UserMessage     = "[Ignored](#ignored) | [History](#update-history) | [Force Test](https://gist.github.com/$Env:gist_id_test)"       #  Markdown, Text: Custom user message to show
       NoIcons         = $false                            #  Markdown: don't show icon
       IconSize        = 32                                #  Markdown: icon size
       Title           = ''                                #  Markdown, Text: TItle of the report, by default 'Update-AUPackages'
@@ -69,11 +69,6 @@ $Options = [ordered]@{
   Git                       = @{
     User     = ''                                       #Git username, leave empty if github api key is used
     Password = $Env:github_api_key                      #Password if username is not empty, otherwise api key
-  }
-
-  GitReleases               = @{
-    ApiToken    = $Env:github_api_key                   #Your github api key
-    ReleaseType = 'package'                             #Either 1 release per date, or 1 release per package
   }
 
   RunInfo                   = @{


### PR DESCRIPTION
## Description

This commit stops the execution of the code within AU to generate releases, and also to update the user message that is generated.

## Motivation and Context

As a team, we have decided that publishing of GitHub releases, and the associated tag that is generated is not helpful.

## How Has this Been Tested?

This can really only be tested by running AU when this PR is merged.

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).