### PR TITLE
(peazip #2309) Fix URL and package contents

### DIFF
--- a/automatic/peazip.install/peazip.install.nuspec
+++ b/automatic/peazip.install/peazip.install.nuspec
@@ -16,7 +16,7 @@ The program supports over 150 archive formats including 7Z, ACE, ARC, ARJ, BZ2, 
 Features of PeaZip includes extract, create and convert multiple archives at once, create self-extracting archives, split/join, encrypted password manager, strong encryption with two factor authentication, secure deletion, find duplicate files, calculate hashes, manage graphic files (rotate, crop, resize, convert).
 ]]></description>
     <projectUrl>https://peazip.github.io/</projectUrl>
-    <projectSourceUrl>https://osdn.net/projects/peazip/releases/</projectSourceUrl>
+    <projectSourceUrl>https://github.com/peazip/PeaZip/</projectSourceUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/peazip.install</packageSourceUrl>
     <docsUrl>https://peazip.github.io/peazip-help-faq.html</docsUrl>
     <bugTrackerUrl>https://sourceforge.net/p/peazip/tickets/</bugTrackerUrl>

--- a/automatic/peazip/peazip.nuspec
+++ b/automatic/peazip/peazip.nuspec
@@ -20,7 +20,7 @@ Features of PeaZip includes extract, create and convert multiple archives at onc
 - **If the package is out of date please check [Version History](#versionhistory) for the latest submitted version. If you have a question, please ask it in [Chocolatey Community Package Discussions](https://github.com/chocolatey-community/chocolatey-packages/discussions) or raise an issue on the [Chocolatey Community Packages Repository](https://github.com/chocolatey-community/chocolatey-packages/issues) if you have problems with the package. Disqus comments will generally not be responded to.**
 ]]></description>
     <projectUrl>https://peazip.github.io/</projectUrl>
-    <projectSourceUrl>https://osdn.net/projects/peazip/releases/</projectSourceUrl>
+    <projectSourceUrl>https://github.com/peazip/PeaZip/</projectSourceUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-packages/tree/master/automatic/peazip</packageSourceUrl>
     <docsUrl>https://peazip.github.io/peazip-help-faq.html</docsUrl>
     <bugTrackerUrl>https://sourceforge.net/p/peazip/tickets/</bugTrackerUrl>
@@ -34,4 +34,5 @@ Features of PeaZip includes extract, create and convert multiple archives at onc
       <dependency id="peazip.install" version="[10.6.1]" />
     </dependencies>
   </metadata>
+  <files />
 </package>


### PR DESCRIPTION
## Description

This commit update the projectSourceUrl to go to the GitHub repository for this application. The previous URL is no longer working.  It also introduces an empty files element in the nuspec file to prevent the update.ps1 and readme.md from being packed into the nupkg.

## Motivation and Context

It was requested in the linked issue.

## How Has this Been Tested?

- Ran `update_all.ps1 -name peazip` and packed the resulting files


## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).