### PR TITLE
(poweriso) Update regex for version and urls

### DIFF
--- a/automatic/poweriso/update.ps1
+++ b/automatic/poweriso/update.ps1
@@ -18,15 +18,20 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-  $re = 'PowerISO v([\d.]+)'
-  $version = ($download_page.Content -split "`n") -match $re | Select-Object -first 1
-  if ($version -match $re) { $version = $Matches[1] } else { throw "Can't find version" }
-  $majorVersion = $version -replace "^(\d+).*$", '$1'
+  $versionRegularExpression = 'V (?<version>[\d\.]+),'
+  $version = ($download_page.Content -split "`n") -match $versionRegularExpression | Select-Object -first 1
+  if ($version -match $versionRegularExpression) { $version = $Matches.version } else { throw "Can't find version" }
+
+  $32bitDownloadUrlRegularExpression = 'PowerISO[^-]*\.exe'
+  $64bitDownloadUrlRegularExpression = 'PowerISO.*-x64\.exe'
+
+  $url32     = $download_page.links | Where-Object href -match $32bitDownloadUrlRegularExpression | Select-Object -First 1 -expand href
+  $url64     = $download_page.links | Where-Object href -match $64bitDownloadUrlRegularExpression | Select-Object -First 1 -expand href
 
   @{
-    Version = $version
-    Url32   = "https://www.poweriso.com/PowerISO$majorVersion.exe"
-    Url64   = "https://www.poweriso.com/PowerISO$majorVersion-x64.exe"
+    Version = Get-ChocolateyNormalizedVersion $version
+    Url32   = $url32
+    Url64   = $url64
   }
 }
 


### PR DESCRIPTION
## Description

This commit updates the main regex for finding the latest version number to be "V (?<version>[\d\.]+)"
and then it extracts the version number.  Following that, rather than use some partially hard-coded URL's for the downloads, actually do other regex's to locate the URL's, and then pass them through to AU.

## Motivation and Context

The layout of the PowerIso download page has changed, so the previous regex for finding the information no longer works.

## How Has this Been Tested?

- Run `update_all.ps1 -name poweriso`

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).