### PR TITLE
(speccy) Update based on change to webpage

### DIFF
--- a/automatic/speccy/update.ps1
+++ b/automatic/speccy/update.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = 'https://www.ccleaner.com/speccy/download/standard'
+$releases = 'https://www.ccleaner.com/speccy/version-history'
 
 function global:au_SearchReplace {
   @{
@@ -13,14 +13,11 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $downloadPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
-
-  $re = '\.exe(\?[a-f\d]+)?$'
-  $url = $downloadPage.links | Where-Object href -match $re | Select-Object -First 1 -expand href
-
-  $downloadPage = Invoke-WebRequest -Uri 'https://www.ccleaner.com/speccy/version-history' -UseBasicParsing
-  $Matches = $null
   $downloadPage.Content -match "v((?:[\d]\.)[\d\.]+)\</span\>"
   $version = $Matches[1]
+  $versionParts = $version.Split(".")
+
+  $url = "https://download.ccleaner.com/spsetup$($versionParts[0])$($versionParts[1]).exe"
 
   @{
     URL32 = $url


### PR DESCRIPTION
## Description

The speccy download webpage has changed, and it no longer contains the explicit download URL.  Instead, let us construct the URL based on the known portion of the download URL
(https://download.ccleaner.com/spsetup???.exe)
and then put the major and minor portions of the version number where the ??? is.  This means very brittle, but I can't see another way of doing this :-(

## Motivation and Context

Updating of the speccy package isn't working.

## How Has this Been Tested?

- Ran `update_all.ps1 -name speccy`

## Screenshot (if appropriate, usually isn't needed):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).