### PR TITLE
(djv) Fixes Update Script

### DIFF
--- a/automatic/djv/update.ps1
+++ b/automatic/djv/update.ps1
@@ -1,10 +1,8 @@
 ﻿Import-Module Chocolatey-AU
 
-# Temporary to allow pushing version 1.0.5
-$releases = 'https://darbyjohnston.github.io/DJV/download.html'
 $softwareName = 'djv-*'
 
-function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix -FileNameSkip 1 }
+function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix}
 
 function global:au_SearchReplace {
   @{
@@ -23,19 +21,13 @@ function global:au_SearchReplace {
     }
   }
 }
+
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-
-  $re = '64\.exe\/download$'
-  $url64 = $download_page.Links | ? href -match $re | select -first 1 -expand href | % { $_ -replace "^(ht|f)tp\:", '$1tps:' }
-
-  $verRe = '\/'
-  $version = $url64 -split "$verRe" | select -last 1 -skip 2
-
+  $LatestRelease = Get-GitHubRelease darbyjohnston DJV
 
   @{
-    URL64    = $url64
-    Version  = $version
+    URL64    = $LatestRelease.assets.Where{$_.name.EndsWith('.exe')}.browser_download_url
+    Version  = Get-Version $LatestRelease.tag_name
     FileType = 'exe'
   }
 }


### PR DESCRIPTION
## Description

This commit switches the version sourcing to GH Releases.

## Motivation and Context

The releases page used was not found, and seems to have moved to GitHub Releases.

## How Has this Been Tested?

- Tested update script
- Tested install and uninstall
    - uninstall is currently not silent, but that doesn't seem to have changed?

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
