### PR TITLE
(librecad) Fixes Update Filtering

### DIFF
--- a/automatic/librecad/update.ps1
+++ b/automatic/librecad/update.ps1
@@ -40,7 +40,7 @@ function global:au_GetLatest {
 
     $version = Get-Version $_.tag_name
 
-    $url = $_.assets | Where-Object browser_download_url -match '\.exe$' | Select-Object -ExpandProperty browser_download_url
+    $url = $_.assets.browser_download_url.Where{$_.EndsWith('.exe') -and $_ -notmatch "-win64\.exe$"}[0]
     $streamName = $version.ToString(2)
 
     if (!($streams.ContainsKey($streamName)) -and $url) {


### PR DESCRIPTION
## Description

This change ensures the x86 installer should not match the x64 exe.

We should consider adding the x64 installer to our package, but:
a) It doesn't need to be a part of this fix
b) It's not clear what the best way forward is - ship the x64 binary, and leave the x86 as a download, continue shipping the x86 and add the x64 as a download, ship both binaries? (25MB each, currently)

I can address that in this PR, or otherwise intend to open an issue to discuss the best move and then action it.

## Motivation and Context

LibreCAD has added a Win64 artifact to their build output. This was being found along with the x86 installer that we were looking for.

## How Has this Been Tested?

- `.\update_all.ps1 librecad`
- `Get-ChildItem .\automatic\ -Filter *.nupkg -Recurse | Sort-Object LastWriteTime | Select-Object -Last 1 | Set-Clipboard`
- `choco install librecad --confirm`
- `choco uninstall librecad --confirm`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~
- ~[ ] Migrated package (a package has been migrated from another repository)~

## Checklist:

- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- ~[ ] My change requires a change to documentation (this usually means the notes in the description of a package).~
- ~[ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).~
- ~[ ] I have updated the package description and it is less than 4000 characters.~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
