### PR TITLE
(bleachbit.install) Fix direct download URL extraction

### DIFF
--- a/automatic/bleachbit.install/update.ps1
+++ b/automatic/bleachbit.install/update.ps1
@@ -6,7 +6,7 @@ function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
   $filename = ($download_page.links | Where-Object href -Match '.exe$' |
     Where-Object href -NotMatch 'fosshub' |
-    Select-Object -First 1 -expand href) -Replace '.*file=', ''
+    Select-Object -First 1 -expand href) -Replace '^.*/', ''
 
   if (!$filename) {
     # Most likely we only got a fosshub url in this case,


### PR DESCRIPTION
## Description

Replace the `file=` query extraction with filename extraction from the URL path in `bleachbit.install/update.ps1`.

## Motivation and Context

The download page now provides a URL such as: `https://download.bleachbit.org/get/BleachBit-6.0.4-setup.exe`

The existing replacement expects `file=`, so it leaves the entire URL unchanged. The script then prepends the download host again, producing an invalid URL and causing both `bleachbit.install` and its `bleachbit` meta-package updater to fail with HTTP 404.

Extracting the filename lets the existing code construct the direct installer URL. Using the provided URL unchanged would return an HTML download page rather than the installer.

## How Has this Been Tested?

- Ran both package updaters using Chocolatey-AU 1.0.0 under Windows PowerShell against temporary package copies.
- Confirmed successful URL validation, installer download, SHA-256 calculation, file updates, and package creation for version 6.0.4.
- Confirmed the meta-package dependency updated to `[6.0.4]`.
- After simplifying the extraction, checked `au_GetLatest` against the live download page and confirmed the expected version and direct installer URL, which returned HTTP 200.

Install/uninstall testing was not performed because only `update.ps1` changed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:

- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [x] The changes only affect a single package (not including meta package).
