### PR TITLE
Use Get-ChildItem instead of ls

### DIFF
--- a/extensions/chocolatey-core.extension/extensions/Get-AppInstallLocation.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-AppInstallLocation.ps1
@@ -60,7 +60,7 @@ function Get-AppInstallLocation {
     $dirs = $Env:ProgramFiles, "$Env:ProgramFiles\*\*"
     if (Get-ProcessorBits 64) { $dirs += ${ENV:ProgramFiles(x86)}, "${ENV:ProgramFiles(x86)}\*\*" }
     Write-Verbose "Trying Program Files with 2 levels depth: $dirs"
-    $location = (ls $dirs | ? {$_.PsIsContainer}) -match $AppNamePattern | select -First 1 | % {$_.FullName}
+    $location = (Get-ChildItem $dirs | ? {$_.PsIsContainer}) -match $AppNamePattern | select -First 1 | % {$_.FullName}
     if (is_dir $location) { return strip $location }
 
     Write-Verbose "Trying native commands on PATH"
@@ -69,7 +69,7 @@ function Get-AppInstallLocation {
 
     $appPaths =  "\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths"
     Write-Verbose "Trying Registry: $appPaths"
-    $location = (ls "HKCU:\$appPaths", "HKLM:\$appPaths") -match $AppNamePattern | select -First 1
+    $location = (Get-ChildItem "HKCU:\$appPaths", "HKLM:\$appPaths") -match $AppNamePattern | select -First 1
     if ($location) { $location = Split-Path $location }
     if (is_dir $location) { return strip $location }
 

--- a/extensions/chocolatey-core.extension/extensions/chocolatey-core.psm1
+++ b/extensions/chocolatey-core.extension/extensions/chocolatey-core.psm1
@@ -2,9 +2,9 @@
 # Include file names that start with capital letters, ignore others
 $ScriptRoot = Split-Path $MyInvocation.MyCommand.Definition
 
-$pre = ls Function:\*
-ls "$ScriptRoot\*.ps1" | ? { $_.Name -cmatch '^[A-Z]+' } | % { . $_  }
-$post = ls Function:\*
+$pre = Get-ChildItem Function:\*
+Get-ChildItem "$ScriptRoot\*.ps1" | ? { $_.Name -cmatch '^[A-Z]+' } | % { . $_  }
+$post = Get-ChildItem Function:\*
 $funcs = compare $pre $post | select -Expand InputObject | select -Expand Name
 $funcs | ? { $_ -cmatch '^[A-Z]+'} | % { Export-ModuleMember -Function $_ }
 

--- a/extensions/extensions.psm1
+++ b/extensions/extensions.psm1
@@ -1,7 +1,7 @@
 ﻿# This file is just to simplify importing of extensions for use in Chocolatey AU update scripts
 
-$modules = ls "$PSSCriptRoot/*.psm1" -Recurse -Exclude "extensions.psm1"
+$modules = Get-ChildItem "$PSScriptRoot/*.psm1" -Recurse -Exclude "extensions.psm1"
 
 foreach ($module in $modules) {
-  import-module $module.FullName
+  Import-Module $module.FullName
 }


### PR DESCRIPTION
## Description

- Fixes script compatibility when running from machines that have a native ls command

## Motivation and Context

I was trying to run one of the scripts in this repo on my mac (yeah, I know Chocolatey is for Windows!), and it tripped up on the `ls` as there is a native `ls` that was being invoked rather than an alias for `Get-ChildItem`

Using proper cmdlet names is just better anyway for scripts (and I think is suggested by the PowerShell Analyser)

## How Has this Been Tested?

Works locally

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My pull request is not coming from the master branch.
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the [Chocolatey Test Environment](https://github.com/chocolatey-community/chocolatey-test-environment/). _Note that we don't support the use of any other environment_.
- [ ] The changes only affect a single package (not including meta package).
